### PR TITLE
Adding IntersectionBook::GetIntersections() API

### DIFF
--- a/maliput/maliput/include/maliput/api/intersection_book.h
+++ b/maliput/maliput/include/maliput/api/intersection_book.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "maliput/api/intersection.h"
 #include "drake/common/drake_copyable.h"
 
@@ -14,6 +16,11 @@ class IntersectionBook {
 
   virtual ~IntersectionBook() = default;
 
+  /// Gets a list of all Intersections within this book.
+  std::vector<Intersection*> GetIntersections() {
+    return DoGetIntersections();
+  }
+
   /// Gets the specified Intersection. Returns nullptr if @p id is unrecognized.
   /// Otherwise, the returned pointer is guaranteed to remain valid throughout
   /// the lifetime of this IntersectionBook's instance.
@@ -25,6 +32,8 @@ class IntersectionBook {
   IntersectionBook() = default;
 
  private:
+  virtual std::vector<Intersection*> DoGetIntersections() = 0;
+
   virtual Intersection* DoGetIntersection(const Intersection::Id& id) = 0;
 };
 

--- a/maliput/maliput/include/maliput/base/intersection_book.h
+++ b/maliput/maliput/include/maliput/base/intersection_book.h
@@ -24,6 +24,8 @@ class IntersectionBook : public api::IntersectionBook {
   void AddIntersection(std::unique_ptr<api::Intersection> intersection);
 
  private:
+  std::vector<api::Intersection*> DoGetIntersections() override;
+
   api::Intersection* DoGetIntersection(const api::Intersection::Id& id)
       override;
 

--- a/maliput/maliput/src/base/intersection_book.cc
+++ b/maliput/maliput/src/base/intersection_book.cc
@@ -28,6 +28,16 @@ class IntersectionBook::Impl {
     }
   }
 
+  std::vector<Intersection*> DoGetIntersections() const {
+    std::vector<Intersection*> intersections;
+    auto it = book_.begin();
+    while(it != book_.end()) {
+      intersections.push_back(it->second.get());
+      it++;
+    }
+    return intersections;
+  }
+
   Intersection* DoGetIntersection(const Intersection::Id& id) const {
     auto it = book_.find(id);
     if (it == book_.end()) {
@@ -47,6 +57,10 @@ IntersectionBook::~IntersectionBook() = default;
 void IntersectionBook::AddIntersection(
     std::unique_ptr<api::Intersection> intersection) {
   impl_->AddIntersection(std::move(intersection));
+}
+
+std::vector<Intersection*> IntersectionBook::DoGetIntersections() {
+  return impl_->DoGetIntersections();
 }
 
 Intersection* IntersectionBook::DoGetIntersection(const Intersection::Id& id) {

--- a/maliput/maliput/src/test_utilities/mock.cc
+++ b/maliput/maliput/src/test_utilities/mock.cc
@@ -174,6 +174,11 @@ class MockIntersectionBook final : public IntersectionBook {
                       rules::PhaseRing::Id("MockRing")) {}
 
  private:
+  std::vector<api::Intersection*> DoGetIntersections() {
+    std::vector<api::Intersection*> result(1, &intersection_);
+    return result;
+  }
+
   api::Intersection* DoGetIntersection(const api::Intersection::Id& id) {
     if (id == intersection_.id()) {
       return &intersection_;

--- a/maliput/maliput_integration_tests/test/intersection_book_loader_test.cc
+++ b/maliput/maliput_integration_tests/test/intersection_book_loader_test.cc
@@ -65,6 +65,7 @@ TEST_F(TestLoading2x2IntersectionIntersectionBook, LoadFromFile) {
   std::unique_ptr<api::IntersectionBook> book = LoadIntersectionBookFromFile(
       filepath_, *rulebook_, *ring_book_, &phase_provider);
   EXPECT_NE(book, nullptr);
+  EXPECT_EQ(int(book->GetIntersections().size()), 1);
   EXPECT_EQ(book->GetIntersection(Intersection::Id("unknown")), nullptr);
   Intersection* intersection =
       book->GetIntersection(Intersection::Id("2x2Intersection"));


### PR DESCRIPTION
Adding IntersectionBook::GetIntersections() API to be able to obtain all existing intersections. Need this for opendrive2inomap converter to be able to populate traffic data into inomap.