### PR TITLE
Adds constructor to UniqueBulbId

### DIFF
--- a/maliput/maliput/include/maliput/api/rules/traffic_lights.h
+++ b/maliput/maliput/include/maliput/api/rules/traffic_lights.h
@@ -302,6 +302,16 @@ class TrafficLight final {
 /// of the bulb's ID, the ID of the bulb group that contains the bulb, and the
 /// the ID of the traffic light that contains the bulb group.
 struct UniqueBulbId {
+
+  /// Constructs a UniqueBulbId.
+  UniqueBulbId(const TrafficLight::Id& traffic_light_id_in,
+               const BulbGroup::Id& bulb_group_id_in,
+               const Bulb::Id& bulb_id_in)
+      : traffic_light_id(traffic_light_id_in),
+        bulb_group_id(bulb_group_id_in),
+        bulb_id(bulb_id_in) {
+  }
+
   /// Returns the string representation of the %TypeSpecificIdentifier.
   const std::string to_string() const {
     return traffic_light_id.string() + "-" + bulb_group_id.string() + "-" +

--- a/maliput/maliput/test/api/traffic_lights_test.cc
+++ b/maliput/maliput/test/api/traffic_lights_test.cc
@@ -329,7 +329,7 @@ GTEST_TEST(UniqueBulbIdTest, Usage) {
   const BulbGroup::Id bulb_group_id(bulb_group_name);
   const Bulb::Id bulb_id(bulb_name);
 
-  const UniqueBulbId dut{traffic_light_id, bulb_group_id, bulb_id};
+  const UniqueBulbId dut(traffic_light_id, bulb_group_id, bulb_id);
 
   // A mismatch of just one internal ID results in the UniqueBulbId no longer
   // matching.


### PR DESCRIPTION
This is needed by boost python bindings.