### PR TITLE
Adds a default constructor to UniqueBulbId

### DIFF
--- a/maliput/maliput/include/maliput/api/rules/traffic_lights.h
+++ b/maliput/maliput/include/maliput/api/rules/traffic_lights.h
@@ -302,6 +302,12 @@ class TrafficLight final {
 /// of the bulb's ID, the ID of the bulb group that contains the bulb, and the
 /// the ID of the traffic light that contains the bulb group.
 struct UniqueBulbId {
+  /// A default constructor. This was originally intended for use by
+  /// boost::python bindings in downstream projects.
+  UniqueBulbId()
+      : traffic_light_id(TrafficLight::Id("default")),
+        bulb_group_id(BulbGroup::Id("default")),
+        bulb_id(Bulb::Id("default")) {};
 
   /// Constructs a UniqueBulbId.
   UniqueBulbId(const TrafficLight::Id& traffic_light_id_in,

--- a/maliput/maliput/test/api/traffic_lights_test.cc
+++ b/maliput/maliput/test/api/traffic_lights_test.cc
@@ -320,6 +320,13 @@ TEST_F(TrafficLightTest, Assignment) {
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, traffic_light_));
 }
 
+GTEST_TEST(UniqueBulbIdTest, DefaultConstructor) {
+  const UniqueBulbId dut;
+  EXPECT_EQ(dut.traffic_light_id, TrafficLight::Id("default"));
+  EXPECT_EQ(dut.bulb_group_id, BulbGroup::Id("default"));
+  EXPECT_EQ(dut.bulb_id, Bulb::Id("default"));
+}
+
 GTEST_TEST(UniqueBulbIdTest, Usage) {
   const std::string traffic_light_name{"MyTrafficLight"};
   const std::string bulb_group_name{"MyBulbGroup"};


### PR DESCRIPTION
This is required by boost::python bindings.