### PR TITLE
Simplify road mesh generation

### DIFF
--- a/maliput_utilities/include/maliput-utilities/generate_obj.h
+++ b/maliput_utilities/include/maliput-utilities/generate_obj.h
@@ -29,10 +29,10 @@ struct ObjFeatures {
   bool draw_branch_points{true};
   /// Draw highlighting of elevation_bounds of each lane?
   bool draw_elevation_bounds{true};
-  /// Reduce the amount of vertices from the road. This could reduce
-  /// the accuracy of curved roads. Change to false if you desire
-  /// the full road generated.
-  bool off_grid_mesh_generation{true};
+  /// Reduce the amount of vertices from the road by creating
+  /// quads big enough which don't violate some tolerance. This could affect
+  /// the accuracy of curved roads.
+  bool off_grid_mesh_generation{false};
   /// Tolerance for mesh simplification, or the distance from a vertex to an
   /// edge line or to a face plane at which said vertex is considered redundant
   /// (i.e. it is not necessary to further define those geometrical entities),

--- a/maliput_utilities/src/maliput-utilities/generate_obj.cc
+++ b/maliput_utilities/src/maliput-utilities/generate_obj.cc
@@ -84,13 +84,17 @@ std::string FormatMaterial(const Material& mat)
                       mat.shinines, 1.0 - mat.transparency);
 }
 
-// Let `step_s` be a step in arc-length s-coordinate, `s0` an s-coordinate in
-// `lane` and grid_unit` the minimum step in s-coordinate to take. It increases
-// `step_s`,  from the minimum of `grid_unit` and the arc-length distance to the
-// lane end, until the distance of the Inertial frame positions in the center of
-// `lane`, left most and right most of the driveable surface to the respective
-// points at `s0 + step_s` is bigger than `grid_unit` or we reach the end of
-// the `lane`. 
+// Compute the maximum step in s-coordinates that can approximate the distance 
+// between its ends in world's inertial frame coordinates up to the given
+// `grid_unit` (taken as an absolute tolerance).
+//
+// Let `step_s` be a step in s-coordinates, `s0` a valid s-coordinate in
+// `lane` and `grid_unit` the minimum step in s-coordinates to take.
+// Starting at the minimum of `grid_unit` and the distance in s-coordinates i.e.
+// arc-length, to the `lane`'s end along the center line, increase `step_s`
+// until the distance between its ends in world's coordinates along the center,
+// left most and right most lines of the `lane`'s driveable
+// surface is bigger than `grid_unit` or the end of the `lane` is reached. 
 double ComputeSampleStep(
       const maliput::api::Lane* lane, double s0, double grid_unit) {
   DRAKE_DEMAND(lane != nullptr);
@@ -261,8 +265,8 @@ void GeneratePreciseRoadMesh(GeoMesh* mesh, const api::Lane* lane,
   }
 }
 
-// Traverses @p lane, generating a cover of the surface with with quads
-// (4-vertex faces) which are added to @p mesh.  The quads are squares in
+// Traverses @p lane, generating a cover of the surface with quads
+// (4-vertex faces) which are added to @p mesh.  The quads are quadrilaterals in
 // the (s,r) space of the lane.
 //
 // @param mesh  the GeoMesh which will receive the quads


### PR DESCRIPTION
We are having some performance issues with the renderer for meshes with more than ~80.000 vertices so I modified the mesh generation algorithm to simplify it even more and make triangles along the way since our renderer works with triangles only. The most basic stuff that any renderer needs to support are triangles, so I think that triangulating the faces is the less we can do. The simplify method that it's provided by maliput wasn't doing this at all.
So,a method called "ComputeSampleStepForCenterLine" was implemented thanks to @agalbachicar. Playing a little bit with that method, I saw that using a small value for the grid_unit variable improves the quality of the roads (with a value of 0.01 I got nice results and the load time isn't that bad). Opening some road files from malidrive, I discovered that some lanes are transparent, but it seems that there's something missing in road generator? I saw the same issue in Blender without this changes.
The first image is the one we load using our viewer, the second one is blender. You can see that the lane that we can't see in our viewer, isn't visible either if we toggle the material view from Blender.
![maliput_town03](https://user-images.githubusercontent.com/22626234/61640514-da962400-ac73-11e9-9e16-be51b11b0a5c.png)
![blender_town03](https://user-images.githubusercontent.com/22626234/61640526-dd911480-ac73-11e9-8d6f-9e2e93b86533.png)

