### PR TITLE
Migrates DRAKE_THROW to MALIPUT_THROW

### DIFF
--- a/dragway/src/dragway/road_geometry.cc
+++ b/dragway/src/dragway/road_geometry.cc
@@ -8,6 +8,7 @@
 #include "drake/math/saturate.h"
 
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_throw.h"
 #include "maliput/geometry_base/brute_force_find_road_positions_strategy.h"
 
 #include "dragway/branch_point.h"
@@ -121,7 +122,7 @@ int RoadGeometry::GetLaneIndex(const api::GeoPosition& geo_pos) const {
     }
   }
   if (!lane_found) {
-    throw std::runtime_error("dragway::RoadGeometry::GetLaneIndex: Failed to "
+    MALIPUT_THROW_MESSAGE("dragway::RoadGeometry::GetLaneIndex: Failed to "
         "find lane for geo_pos (" + std::to_string(geo_pos.x()) + ", " +
         std::to_string(geo_pos.y()) + ").");
   }

--- a/dragway/test/dragway_test.cc
+++ b/dragway/test/dragway_test.cc
@@ -4,9 +4,11 @@
 
 #include <gtest/gtest.h>
 
+#include "maliput/common/assertion_error.h"
 #include "maliput/test_utilities/check_id_indexing.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 #include "maliput/test_utilities/maliput_types_compare.h"
+
 #include "dragway/branch_point.h"
 #include "dragway/junction.h"
 #include "dragway/lane.h"
@@ -811,7 +813,8 @@ TEST_F(MaliputDragwayLaneTest, ThrowIfGeoPosHasMismatchedDerivatives) {
   api::LanePositionT<drake::AutoDiffXd> lane_position(s, r, h);
 
   EXPECT_THROW(
-      lane_->ToGeoPositionT<drake::AutoDiffXd>(lane_position), std::runtime_error);
+      lane_->ToGeoPositionT<drake::AutoDiffXd>(lane_position),
+      maliput::common::assertion_error);
 }
 
 TEST_F(MaliputDragwayLaneTest, ThrowIfLanePosHasMismatchedDerivatives) {
@@ -826,7 +829,7 @@ TEST_F(MaliputDragwayLaneTest, ThrowIfLanePosHasMismatchedDerivatives) {
 
   EXPECT_THROW(
       lane_->ToLanePositionT<drake::AutoDiffXd>(geo_position, nullptr, nullptr),
-      std::runtime_error);
+      maliput::common::assertion_error);
 }
 
 TEST_F(MaliputDragwayLaneTest, ToLanePositionSymbolic1) {

--- a/maliput/include/maliput/api/lane.h
+++ b/maliput/include/maliput/api/lane.h
@@ -3,12 +3,14 @@
 #include <memory>
 #include <string>
 
-#include "maliput/api/lane_data.h"
-#include "maliput/api/type_specific_identifier.h"
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/symbolic.h"
+
+#include "maliput/api/lane_data.h"
+#include "maliput/api/type_specific_identifier.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace api {
@@ -288,7 +290,7 @@ class Lane {
   // drake::AutoDiffXd overload of DoToGeoPosition().
   virtual GeoPositionT<drake::AutoDiffXd> DoToGeoPositionAutoDiff(
       const LanePositionT<drake::AutoDiffXd>&) const {
-    throw std::runtime_error(
+    MALIPUT_THROW_MESSAGE(
         "DoToGeoPosition has been instantiated with drake::AutoDiffXd arguments, "
         "but a Lane backend has not overridden its drake::AutoDiffXd specialization.");
   }
@@ -298,7 +300,7 @@ class Lane {
       const GeoPositionT<drake::AutoDiffXd>&,
       GeoPositionT<drake::AutoDiffXd>*,
       drake::AutoDiffXd*) const {
-    throw std::runtime_error(
+    MALIPUT_THROW_MESSAGE(
         "DoToLanePosition has been instantiated with drake::AutoDiffXd arguments, "
         "but a Lane backend has not overridden its drake::AutoDiffXd specialization.");
   }
@@ -306,7 +308,7 @@ class Lane {
   // drake::symbolic::Expression overload of DoToGeoPosition().
   virtual GeoPositionT<drake::symbolic::Expression> DoToGeoPositionSymbolic(
       const LanePositionT<drake::symbolic::Expression>&) const {
-    throw std::runtime_error(
+    MALIPUT_THROW_MESSAGE(
         "DoToGeoPosition has been instantiated with drake::symbolic::Expression "
         "arguments, but a Lane backend has not overridden its "
         "drake::symbolic::Expression specialization.");
@@ -316,7 +318,7 @@ class Lane {
   virtual LanePositionT<drake::symbolic::Expression> DoToLanePositionSymbolic(
       const GeoPositionT<drake::symbolic::Expression>&,
       GeoPositionT<drake::symbolic::Expression>*, drake::symbolic::Expression*) const {
-    throw std::runtime_error(
+    MALIPUT_THROW_MESSAGE(
         "DoToLanePosition has been instantiated with drake::symbolic::Expression "
         "arguments, but a Lane backend has not overridden its "
         "drake::symbolic::Expression specialization.");

--- a/maliput/include/maliput/api/lane_data.h
+++ b/maliput/include/maliput/api/lane_data.h
@@ -6,12 +6,13 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"
 #include "drake/math/quaternion.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
+
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace api {
@@ -374,11 +375,11 @@ class RBounds {
   RBounds() = default;
 
   /// Fully parameterized constructor.
-  /// @throws std::runtime_error When @p min is greater than 0.
-  /// @throws std::runtime_error When @p max is smaller than 0.
+  /// @throws maliput::common::assertion_error When @p min is greater than 0.
+  /// @throws maliput::common::assertion_error When @p max is smaller than 0.
   RBounds(double min, double max) : min_(min), max_(max) {
-    DRAKE_THROW_UNLESS(min <= 0.);
-    DRAKE_THROW_UNLESS(max >= 0.);
+    MALIPUT_THROW_UNLESS(min <= 0.);
+    MALIPUT_THROW_UNLESS(max >= 0.);
   }
 
   /// @name Getters and Setters
@@ -386,17 +387,17 @@ class RBounds {
   /// Gets minimum bound.
   double min() const { return min_; }
   /// Sets minimum bound.
-  /// @throws std::runtime_error When @p min is greater than 0.
+  /// @throws maliput::common::assertion_error When @p min is greater than 0.
   void set_min(double min) {
-    DRAKE_THROW_UNLESS(min <= 0.);
+    MALIPUT_THROW_UNLESS(min <= 0.);
     min_ = min;
   }
   /// Gets maximum bound.
   double max() const { return max_; }
   /// Sets maximum bound.
-  /// @throws std::runtime_error When @p max is smaller than 0.
+  /// @throws maliput::common::assertion_error When @p max is smaller than 0.
   void set_max(double max) {
-    DRAKE_THROW_UNLESS(max >= 0.);
+    MALIPUT_THROW_UNLESS(max >= 0.);
     max_ = max;
   }
   //@}
@@ -419,11 +420,11 @@ class HBounds {
   HBounds() = default;
 
   /// Fully parameterized constructor.
-  /// @throws std::runtime_error When @p min is greater than 0.
-  /// @throws std::runtime_error When @p max is smaller than 0.
+  /// @throws maliput::common::assertion_error When @p min is greater than 0.
+  /// @throws maliput::common::assertion_error When @p max is smaller than 0.
   HBounds(double min, double max) : min_(min), max_(max) {
-    DRAKE_THROW_UNLESS(min <= 0.);
-    DRAKE_THROW_UNLESS(max >= 0.);
+    MALIPUT_THROW_UNLESS(min <= 0.);
+    MALIPUT_THROW_UNLESS(max >= 0.);
   }
 
   /// @name Getters and Setters
@@ -431,17 +432,17 @@ class HBounds {
   /// Gets minimum bound.
   double min() const { return min_; }
   /// Sets minimum bound.
-  /// @throws std::runtime_error When @p min is greater than 0.
+  /// @throws maliput::common::assertion_error When @p min is greater than 0.
   void set_min(double min) {
-    DRAKE_THROW_UNLESS(min <= 0.);
+    MALIPUT_THROW_UNLESS(min <= 0.);
     min_ = min;
   }
   /// Gets maximum bound.
   double max() const { return max_; }
   /// Sets maximum bound.
-  /// @throws std::runtime_error When @p max is smaller than 0.
+  /// @throws maliput::common::assertion_error When @p max is smaller than 0.
   void set_max(double max) {
-    DRAKE_THROW_UNLESS(max >= 0.);
+    MALIPUT_THROW_UNLESS(max >= 0.);
     max_ = max;
   }
   //@}

--- a/maliput/include/maliput/api/road_geometry.h
+++ b/maliput/include/maliput/api/road_geometry.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 
 #include "maliput/api/branch_point.h"
 #include "maliput/api/junction.h"
@@ -13,6 +12,7 @@
 #include "maliput/api/lane_data.h"
 #include "maliput/api/segment.h"
 #include "maliput/api/type_specific_identifier.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace api {
@@ -133,14 +133,14 @@ class RoadGeometry {
   ///         When @p radius is infinity, the query should return the closest
   ///         point for each lane.
   ///
-  /// @throws std::runtime_error When @p radius is negative.
+  /// @throws maliput::common::assertion_error When @p radius is negative.
   ///
   /// Note that derivative implementations may choose to violate the above
   /// semantics for performance reasons. See docstrings of derivative
   /// implementations for details.
   std::vector<RoadPositionResult> FindRoadPositions(
       const GeoPosition& geo_position, double radius) const {
-    DRAKE_THROW_UNLESS(radius >= 0.);
+    MALIPUT_THROW_UNLESS(radius >= 0.);
     return DoFindRoadPositions(geo_position, radius);
   }
 

--- a/maliput/include/maliput/api/rules/direction_usage_rule.h
+++ b/maliput/include/maliput/api/rules/direction_usage_rule.h
@@ -3,9 +3,12 @@
 #include <unordered_map>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
+
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/type_specific_identifier.h"
-#include "drake/common/drake_copyable.h"
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace api {
@@ -99,15 +102,16 @@ class DirectionUsageRule final {
   /// @param id the unique ID of this rule (in the RoadRulebook)
   /// @param zone LaneSRange to which this rule applies
   /// @param states a vector of valid states for the rule
-  /// @throws std::exception if size of states is not exactly 1.
+  /// @throws maliput::common::assertion_error if size of states is not exactly
+  ///         1.
   DirectionUsageRule(const Id& id, const LaneSRange& zone,
                      std::vector<State> states)
       : id_(id), zone_(zone) {
-    DRAKE_THROW_UNLESS(states.size() == 1);
+    MALIPUT_THROW_UNLESS(states.size() == 1);
     for (const State& state : states) {
       // Construct index of states by ID, ensuring uniqueness of ID's.
       auto result = states_.emplace(state.id(), state);
-      DRAKE_THROW_UNLESS(result.second);
+      MALIPUT_THROW_UNLESS(result.second);
     }
   }
 
@@ -128,9 +132,9 @@ class DirectionUsageRule final {
   ///
   /// This is a convenience function for returning a static rule's single state.
   ///
-  /// @throws std::exception if `is_static()` is false.
+  /// @throws maliput::common::assertion_error if `is_static()` is false.
   const State& static_state() const {
-    DRAKE_THROW_UNLESS(is_static());
+    MALIPUT_THROW_UNLESS(is_static());
     return states_.begin()->second;
   }
 

--- a/maliput/include/maliput/api/rules/right_of_way_rule.h
+++ b/maliput/include/maliput/api/rules/right_of_way_rule.h
@@ -5,7 +5,10 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
+
+#include "maliput/api/rules/regions.h"
+#include "maliput/api/type_specific_identifier.h"
+#include "maliput/common/maliput_throw.h"
 
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/rules/traffic_lights.h"
@@ -132,9 +135,10 @@ class RightOfWayRule final {
   /// @param related_bulb_groups The related bulb groups. All IDs present within
   ///        the supplied map are assumed to be valid.
   ///
-  /// @throws std::exception if `states` is empty or if `states` contains
-  /// duplicate State::Id's.
-  /// @throws common::assertion_error if any duplicate BulbGroup::Id is found.
+  /// @throws maliput::common::assertion_error if `states` is empty or if
+  ///         `states` contains duplicate State::Id's.
+  /// @throws maliput::common::assertion_error if any duplicate BulbGroup::Id is
+  ///         found.
   RightOfWayRule(
       const Id& id,
       const LaneSRoute& zone,
@@ -147,7 +151,7 @@ class RightOfWayRule final {
     for (const State& state : states) {
       // Construct index of states by ID, ensuring uniqueness of ID's.
       auto result = states_.emplace(state.id(), state);
-      DRAKE_THROW_UNLESS(result.second);
+      MALIPUT_THROW_UNLESS(result.second);
     }
     for (const auto& traffic_light_bulb_group : related_bulb_groups) {
       for (const BulbGroup::Id& bulb_group_id :
@@ -182,9 +186,9 @@ class RightOfWayRule final {
   ///
   /// This is a convenience function for returning a static rule's single state.
   ///
-  /// @throws std::exception if `is_static()` is false.
+  /// @throws maliput::common::assertion_error if `is_static()` is false.
   const State& static_state() const {
-    DRAKE_THROW_UNLESS(is_static());
+    MALIPUT_THROW_UNLESS(is_static());
     return states_.begin()->second;
   }
 

--- a/maliput/include/maliput/api/rules/road_rulebook.h
+++ b/maliput/include/maliput/api/rules/road_rulebook.h
@@ -2,12 +2,14 @@
 
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
+
 #include "maliput/api/rules/direction_usage_rule.h"
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/speed_limit_rule.h"
-#include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace api {
@@ -44,10 +46,10 @@ class RoadRulebook {
   /// `tolerance` does not permit matching across BranchPoints (past the
   /// s-bounds of a Lane).
   ///
-  /// @throws std::runtime_error if `tolerance` is negative.
+  /// @throws maliput::common::assertion_error if `tolerance` is negative.
   QueryResults FindRules(
       const std::vector<LaneSRange>& ranges, double tolerance) const {
-    DRAKE_THROW_UNLESS(tolerance >= 0.);
+    MALIPUT_THROW_UNLESS(tolerance >= 0.);
     return DoFindRules(ranges, tolerance);
   }
 

--- a/maliput/include/maliput/api/rules/speed_limit_rule.h
+++ b/maliput/include/maliput/api/rules/speed_limit_rule.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "drake/common/drake_copyable.h"
+
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/type_specific_identifier.h"
-#include "drake/common/drake_copyable.h"
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace api {
@@ -40,13 +43,13 @@ class SpeedLimitRule {
   /// @param max maximum speed
   ///
   /// `min` and `max` must be non-negative, and `min` must be less than
-  /// or equal to `max`, otherwise a std::runtime_error is thrown.
+  /// or equal to `max`, otherwise a maliput::common::assertion_error is thrown.
   SpeedLimitRule(const Id& id, const LaneSRange& zone, Severity severity,
                  double min, double max)
       : id_(id), zone_(zone), severity_(severity), min_(min), max_(max) {
-    DRAKE_THROW_UNLESS(min >= 0.);
-    DRAKE_THROW_UNLESS(max >= 0.);
-    DRAKE_THROW_UNLESS(min <= max);
+    MALIPUT_THROW_UNLESS(min >= 0.);
+    MALIPUT_THROW_UNLESS(max >= 0.);
+    MALIPUT_THROW_UNLESS(min <= max);
   }
 
   /// Returns the persistent identifier.

--- a/maliput/include/maliput/api/type_specific_identifier.h
+++ b/maliput/include/maliput/api/type_specific_identifier.h
@@ -5,8 +5,10 @@
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/hash.h"
+
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace api {
@@ -44,10 +46,10 @@ class TypeSpecificIdentifier {
 
   /// Constructs a %TypeSpecificIdentifier from the given `string`.
   ///
-  /// @throws std::runtime_error if `string` is empty.
+  /// @throws maliput::common::assertion_error if `string` is empty.
   explicit TypeSpecificIdentifier(std::string string)
       : string_(std::move(string)) {
-    DRAKE_THROW_UNLESS(!string_.empty());
+    MALIPUT_THROW_UNLESS(!string_.empty());
   }
 
   /// Returns the string representation of the %TypeSpecificIdentifier.

--- a/maliput/include/maliput/base/manual_rule_state_provider.h
+++ b/maliput/include/maliput/base/manual_rule_state_provider.h
@@ -2,9 +2,10 @@
 
 #include <unordered_map>
 
+#include "drake/common/drake_copyable.h"
+
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/rule_state_provider.h"
-#include "drake/common/drake_copyable.h"
 
 namespace maliput {
 
@@ -22,7 +23,8 @@ class ManualRuleStateProvider final : public api::rules::RuleStateProvider {
   ///
   /// @throws std::logic_error if a RightOfWayRule with an ID of @p id
   /// already exists in this provider.
-  /// @throws std::runtime_error if the dynamic state failed to be added.
+  /// @throws maliput::common::assertion_error if the dynamic state failed to be
+  /// added.
   void AddState(
       const api::rules::RightOfWayRule::Id& id,
       const api::rules::RightOfWayRule::State::Id& initial_state);

--- a/maliput/include/maliput/base/manual_rulebook.h
+++ b/maliput/include/maliput/base/manual_rulebook.h
@@ -28,35 +28,35 @@ class ManualRulebook : public api::rules::RoadRulebook {
 
   /// Adds a new RightOfWayRule.
   ///
-  /// @throws std::runtime_error if a rule with the same ID already exists
-  /// in the ManualRulebook.
+  /// @throws maliput::common::assertion_error if a rule with the same ID
+  /// already exists in the ManualRulebook.
   void AddRule(const api::rules::RightOfWayRule& rule);
 
   /// Removes the RightOfWayRule labeled by `id`.
   ///
-  /// @throws std::runtime_error if no such rule exists.
+  /// @throws maliput::common::assertion_error if no such rule exists.
   void RemoveRule(const api::rules::RightOfWayRule::Id& id);
 
   /// Adds a new SpeedLimitRule.
   ///
-  /// @throws std::runtime_error if a rule with the same ID already exists
-  /// in the ManualRulebook.
+  /// @throws maliput::common::assertion_error if a rule with the same ID
+  /// already exists in the ManualRulebook.
   void AddRule(const api::rules::SpeedLimitRule& rule);
 
   /// Removes the SpeedLimitRule labeled by `id`.
   ///
-  /// @throws std::runtime_error if no such rule exists.
+  /// @throws maliput::common::assertion_error if no such rule exists.
   void RemoveRule(const api::rules::SpeedLimitRule::Id& id);
 
   /// Adds a new DirectionUsageRule.
   ///
-  /// @throws std::runtime_error if a rule with the same ID already exists
-  /// in the ManualRulebook.
+  /// @throws maliput::common::assertion_error if a rule with the same ID
+  /// already exists in the ManualRulebook.
   void AddRule(const api::rules::DirectionUsageRule& rule);
 
   /// Removes the DirectionUsageRule labeled by `id`.
   ///
-  /// @throws std::runtime_error if no such rule exists.
+  /// @throws maliput::common::assertion_error if no such rule exists.
   void RemoveRule(const api::rules::DirectionUsageRule::Id& id);
 
  private:

--- a/maliput/include/maliput/base/simple_rulebook.h
+++ b/maliput/include/maliput/base/simple_rulebook.h
@@ -3,12 +3,13 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
+
 #include "maliput/api/rules/direction_usage_rule.h"
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/road_rulebook.h"
 #include "maliput/api/rules/speed_limit_rule.h"
-#include "drake/common/drake_copyable.h"
 
 namespace maliput {
 
@@ -28,35 +29,35 @@ class SimpleRulebook : public api::rules::RoadRulebook {
 
   /// Adds a new RightOfWayRule.
   ///
-  /// @throws std::runtime_error if a rule with the same ID already exists
-  /// in the SimpleRulebook.
+  /// @throws maliput::common::assertion_error if a rule with the same ID
+  /// already exists in the SimpleRulebook.
   void AddRule(const api::rules::RightOfWayRule& rule);
 
   /// Removes the RightOfWayRule labeled by `id`.
   ///
-  /// @throws std::runtime_error if no such rule exists.
+  /// @throws maliput::common::assertion_error if no such rule exists.
   void RemoveRule(const api::rules::RightOfWayRule::Id& id);
 
   /// Adds a new SpeedLimitRule.
   ///
-  /// @throws std::runtime_error if a rule with the same ID already exists
-  /// in the SimpleRulebook.
+  /// @throws maliput::common::assertion_error if a rule with the same ID
+  /// already exists in the SimpleRulebook.
   void AddRule(const api::rules::SpeedLimitRule& rule);
 
   /// Removes the SpeedLimitRule labeled by `id`.
   ///
-  /// @throws std::runtime_error if no such rule exists.
+  /// @throws maliput::common::assertion_error if no such rule exists.
   void RemoveRule(const api::rules::SpeedLimitRule::Id& id);
 
   /// Adds a new DirectionUsageRule.
   ///
-  /// @throws std::runtime_error if a rule with the same ID already exists
-  /// in the SimpleRulebook.
+  /// @throws maliput::common::assertion_error if a rule with the same ID
+  /// already exists in the SimpleRulebook.
   void AddRule(const api::rules::DirectionUsageRule& rule);
 
   /// Removes the DirectionUsageRule labeled by `id`.
   ///
-  /// @throws std::runtime_error if no such rule exists.
+  /// @throws maliput::common::assertion_error if no such rule exists.
   void RemoveRule(const api::rules::DirectionUsageRule::Id& id);
 
  private:

--- a/maliput/include/maliput/common/maliput_throw.h
+++ b/maliput/include/maliput/common/maliput_throw.h
@@ -61,3 +61,10 @@ void Throw(const char* condition, const char* func, const char* file, int line);
           #condition, __func__, __FILE__, __LINE__);                          \
     }                                                                         \
   } while (0)
+
+/// Throws an exception with a message showing at least the condition text,
+/// function name, file, and line.
+#define MALIPUT_THROW_MESSAGE(msg)                                            \
+  do {                                                                        \
+    ::maliput::common::internal::Throw(#msg, __func__, __FILE__, __LINE__);   \
+  } while (0)

--- a/maliput/include/maliput/geometry_base/brute_force_find_road_positions_strategy.h
+++ b/maliput/include/maliput/geometry_base/brute_force_find_road_positions_strategy.h
@@ -23,9 +23,9 @@ namespace geometry_base {
 ///        must not be negative.
 /// @return A vector of RoadPositionResults representing the possible
 ///         RoadPositions.
-/// @throws std::runtime_error If rg is nullptr, or any entity within it is
-///         nullptr.
-/// @throws std::runtime_error If radius is negative.
+/// @throws maliput::common::assertion_error If rg is nullptr, or any entity
+///         within it is nullptr.
+/// @throws maliput::common::assertion_error If radius is negative.
 std::vector<maliput::api::RoadPositionResult>
 BruteForceFindRoadPositionsStrategy(
     const maliput::api::RoadGeometry* rg,

--- a/maliput/include/maliput/geometry_base/lane_end_set.h
+++ b/maliput/include/maliput/geometry_base/lane_end_set.h
@@ -2,9 +2,11 @@
 
 #include <vector>
 
-#include "maliput/api/lane_data.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
+
+#include "maliput/api/lane_data.h"
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace geometry_base {
@@ -20,10 +22,10 @@ class LaneEndSet : public api::LaneEndSet {
 
   /// Adds an api::LaneEnd to the set.
   ///
-  /// @throws std::exception if `end.lane` is nullptr.
+  /// @throws maliput::common::assertion_error if `end.lane` is nullptr.
   void Add(const api::LaneEnd& end) {
     // TODO(maddog@tri.global)  This assertion belongs in LaneEnd itself.
-    DRAKE_THROW_UNLESS(end.lane != nullptr);
+    MALIPUT_THROW_UNLESS(end.lane != nullptr);
     ends_.push_back(end);
   }
 

--- a/maliput/include/maliput/geometry_base/road_geometry.h
+++ b/maliput/include/maliput/geometry_base/road_geometry.h
@@ -5,14 +5,16 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_copyable.h"
+
 #include "maliput/api/basic_id_index.h"
 #include "maliput/api/branch_point.h"
 #include "maliput/api/junction.h"
 #include "maliput/api/road_geometry.h"
 #include "maliput/geometry_base/branch_point.h"
 #include "maliput/geometry_base/junction.h"
-#include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace geometry_base {
@@ -46,7 +48,7 @@ class RoadGeometry : public api::RoadGeometry {
   /// @param linear_tolerance the linear tolerance
   /// @param angular_tolerance the angular tolerance
   ///
-  /// @throws std::exception if either `linear_tolerance` or
+  /// @throws maliput::common::assertion_error if either `linear_tolerance` or
   ///         `angular_tolerance` or `scale_length` is non-positive.
   RoadGeometry(const api::RoadGeometryId& id,
                double linear_tolerance, double angular_tolerance,
@@ -55,9 +57,9 @@ class RoadGeometry : public api::RoadGeometry {
         linear_tolerance_(linear_tolerance),
         angular_tolerance_(angular_tolerance),
         scale_length_(scale_length) {
-    DRAKE_THROW_UNLESS(linear_tolerance_ > 0.);
-    DRAKE_THROW_UNLESS(angular_tolerance_ > 0.);
-    DRAKE_THROW_UNLESS(scale_length_ > 0.);
+    MALIPUT_THROW_UNLESS(linear_tolerance_ > 0.);
+    MALIPUT_THROW_UNLESS(angular_tolerance_ > 0.);
+    MALIPUT_THROW_UNLESS(scale_length_ > 0.);
   }
 
   /// Adds @p junction to this RoadGeometry.

--- a/maliput/src/api/basic_id_index.cc
+++ b/maliput/src/api/basic_id_index.cc
@@ -1,27 +1,27 @@
 #include "maliput/api/basic_id_index.h"
 
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace api {
 
 void BasicIdIndex::AddLane(const Lane* lane) {
-  DRAKE_THROW_UNLESS(lane_map_.emplace(lane->id(), lane).second);
+  MALIPUT_THROW_UNLESS(lane_map_.emplace(lane->id(), lane).second);
 }
 
 
 void BasicIdIndex::AddSegment(const Segment* segment) {
-  DRAKE_THROW_UNLESS(segment_map_.emplace(segment->id(), segment).second);
+  MALIPUT_THROW_UNLESS(segment_map_.emplace(segment->id(), segment).second);
 }
 
 
 void BasicIdIndex::AddJunction(const Junction* junction) {
-  DRAKE_THROW_UNLESS(junction_map_.emplace(junction->id(), junction).second);
+  MALIPUT_THROW_UNLESS(junction_map_.emplace(junction->id(), junction).second);
 }
 
 
 void BasicIdIndex::AddBranchPoint(const BranchPoint* branch_point) {
-  DRAKE_THROW_UNLESS(
+  MALIPUT_THROW_UNLESS(
       branch_point_map_.emplace(branch_point->id(), branch_point).second);
 }
 

--- a/maliput/src/api/lane.cc
+++ b/maliput/src/api/lane.cc
@@ -15,8 +15,8 @@ GeoPositionT<drake::AutoDiffXd> Lane::ToGeoPositionT<drake::AutoDiffXd>(
     const LanePositionT<drake::AutoDiffXd>& lane_pos) const {
   // Fail fast if lane_pos contains derivatives of inconsistent sizes.
   const Eigen::VectorXd deriv = lane_pos.s().derivatives();
-  DRAKE_THROW_UNLESS(deriv.size() == lane_pos.r().derivatives().size());
-  DRAKE_THROW_UNLESS(deriv.size() == lane_pos.h().derivatives().size());
+  MALIPUT_THROW_UNLESS(deriv.size() == lane_pos.r().derivatives().size());
+  MALIPUT_THROW_UNLESS(deriv.size() == lane_pos.h().derivatives().size());
 
   return DoToGeoPositionAutoDiff(lane_pos);
 }
@@ -42,8 +42,8 @@ LanePositionT<drake::AutoDiffXd> Lane::ToLanePositionT<drake::AutoDiffXd>(
     drake::AutoDiffXd* distance) const {
   // Fail fast if geo_pos contains derivatives of inconsistent sizes.
   const Eigen::VectorXd deriv = geo_pos.x().derivatives();
-  DRAKE_THROW_UNLESS(deriv.size() == geo_pos.y().derivatives().size());
-  DRAKE_THROW_UNLESS(deriv.size() == geo_pos.z().derivatives().size());
+  MALIPUT_THROW_UNLESS(deriv.size() == geo_pos.y().derivatives().size());
+  MALIPUT_THROW_UNLESS(deriv.size() == geo_pos.z().derivatives().size());
 
   LanePositionT<drake::AutoDiffXd> result =
       DoToLanePositionAutoDiff(geo_pos, nearest_point, distance);

--- a/maliput/src/api/road_network.cc
+++ b/maliput/src/api/road_network.cc
@@ -4,8 +4,7 @@
 
 #include "maliput/api/lane.h"
 #include "maliput/api/rules/regions.h"
-
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace api {
@@ -25,13 +24,13 @@ RoadNetwork::RoadNetwork(
       phase_ring_book_(std::move(phase_ring_book)),
       rule_state_provider_(std::move(rule_state_provider)),
       phase_provider_(std::move(phase_provider)) {
-  DRAKE_THROW_UNLESS(road_geometry_.get() != nullptr);
-  DRAKE_THROW_UNLESS(rulebook_.get() != nullptr);
-  DRAKE_THROW_UNLESS(traffic_light_book_.get() != nullptr);
-  DRAKE_THROW_UNLESS(intersection_book_.get() != nullptr);
-  DRAKE_THROW_UNLESS(phase_ring_book_.get() != nullptr);
-  DRAKE_THROW_UNLESS(rule_state_provider_.get() != nullptr);
-  DRAKE_THROW_UNLESS(phase_provider_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(road_geometry_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(rulebook_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(traffic_light_book_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(intersection_book_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(phase_ring_book_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(rule_state_provider_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(phase_provider_.get() != nullptr);
 }
 
 }  // namespace api

--- a/maliput/src/api/road_network_validator.cc
+++ b/maliput/src/api/road_network_validator.cc
@@ -20,7 +20,7 @@ void ValidateRoadNetwork(const RoadNetwork& road_network,
       const LaneId lane_id = lane_map.first;
       const auto results = road_network.rulebook()->FindRules(
           {{lane_id, {0.0, lane_map.second->length()}}}, 0);
-      DRAKE_THROW_UNLESS(results.direction_usage.size() > 0);
+      MALIPUT_THROW_UNLESS(results.direction_usage.size() > 0);
     }
   }
 }

--- a/maliput/src/api/rules/phase_ring.cc
+++ b/maliput/src/api/rules/phase_ring.cc
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace api {
@@ -15,22 +15,22 @@ namespace {
 /// This is because every phase must specify the complete state of all the rules
 /// and bulb states mentioned by the ring.
 void VerifyAllPhasesHaveSameCoverage(const std::vector<Phase>& phases) {
-  DRAKE_THROW_UNLESS(phases.size() >= 1);
+  MALIPUT_THROW_UNLESS(phases.size() >= 1);
   const auto& r = phases.at(0);  // The reference phase.
   for (const auto& phase : phases) {
-    DRAKE_THROW_UNLESS(phase.rule_states().size() == r.rule_states().size());
+    MALIPUT_THROW_UNLESS(phase.rule_states().size() == r.rule_states().size());
     for (const auto& s : phase.rule_states()) {
-      DRAKE_THROW_UNLESS(r.rule_states().count(s.first) == 1);
+      MALIPUT_THROW_UNLESS(r.rule_states().count(s.first) == 1);
     }
     // Require both set of bulb states to be defined or undefined together.
-    DRAKE_THROW_UNLESS(
+    MALIPUT_THROW_UNLESS(
         (r.bulb_states() == drake::nullopt && phase.bulb_states() == drake::nullopt) ||
         (r.bulb_states() != drake::nullopt && phase.bulb_states() != drake::nullopt));
     if (r.bulb_states() != drake::nullopt) {
-      DRAKE_THROW_UNLESS(phase.bulb_states()->size() ==
+      MALIPUT_THROW_UNLESS(phase.bulb_states()->size() ==
                          r.bulb_states()->size());
       for (const auto& s : *phase.bulb_states()) {
-        DRAKE_THROW_UNLESS(r.bulb_states()->count(s.first) == 1);
+        MALIPUT_THROW_UNLESS(r.bulb_states()->count(s.first) == 1);
       }
     }
   }
@@ -42,9 +42,9 @@ void VerifyNextPhases(
     const std::vector<Phase>& phases,
     const std::unordered_map<Phase::Id,
                              std::vector<PhaseRing::NextPhase>>& next_phases) {
-  DRAKE_THROW_UNLESS(phases.size() == next_phases.size());
+  MALIPUT_THROW_UNLESS(phases.size() == next_phases.size());
   for (const auto& phase : phases) {
-    DRAKE_THROW_UNLESS(next_phases.find(phase.id()) != next_phases.end());
+    MALIPUT_THROW_UNLESS(next_phases.find(phase.id()) != next_phases.end());
   }
 }
 
@@ -55,11 +55,11 @@ PhaseRing::PhaseRing(const Id& id, const std::vector<Phase>& phases,
                                                        std::vector<NextPhase>>>&
                          next_phases)
     : id_(id) {
-  DRAKE_THROW_UNLESS(phases.size() >= 1);
+  MALIPUT_THROW_UNLESS(phases.size() >= 1);
   for (const Phase& phase : phases) {
     // Construct index of phases by ID, ensuring uniqueness of ID's.
     auto result = phases_.emplace(phase.id(), phase);
-    DRAKE_THROW_UNLESS(result.second);
+    MALIPUT_THROW_UNLESS(result.second);
   }
   if (next_phases != drake::nullopt) {
     next_phases_ = *next_phases;

--- a/maliput/src/api/rules/traffic_lights.cc
+++ b/maliput/src/api/rules/traffic_lights.cc
@@ -3,9 +3,9 @@
 #include <algorithm>
 #include <utility>
 
-#include "drake/common/drake_throw.h"
-
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace api {
@@ -46,10 +46,10 @@ Bulb::Bulb(const Bulb::Id& id, const GeoPosition& position_bulb_group,
       type_(type),
       arrow_orientation_rad_(arrow_orientation_rad),
       bounding_box_(std::move(bounding_box)) {
-  DRAKE_THROW_UNLESS(type_ != BulbType::kArrow ||
+  MALIPUT_THROW_UNLESS(type_ != BulbType::kArrow ||
                      arrow_orientation_rad_ != drake::nullopt);
   if (type_ != BulbType::kArrow) {
-    DRAKE_THROW_UNLESS(arrow_orientation_rad_ == drake::nullopt);
+    MALIPUT_THROW_UNLESS(arrow_orientation_rad_ == drake::nullopt);
   }
   if (states == drake::nullopt || states->size() == 0) {
     states_ = {BulbState::kOff, BulbState::kOn};
@@ -80,7 +80,7 @@ BulbGroup::BulbGroup(const BulbGroup::Id& id,
       position_traffic_light_(position_traffic_light),
       orientation_traffic_light_(orientation_traffic_light),
       bulbs_(bulbs) {
-  DRAKE_THROW_UNLESS(bulbs_.size() > 0);
+  MALIPUT_THROW_UNLESS(bulbs_.size() > 0);
 }
 
 drake::optional<Bulb> BulbGroup::GetBulb(const Bulb::Id& id) const {

--- a/maliput/src/base/intersection.cc
+++ b/maliput/src/base/intersection.cc
@@ -1,6 +1,6 @@
 #include "maliput/base/intersection.h"
 
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 
@@ -9,7 +9,7 @@ Intersection::Intersection(const Id& id,
                            const api::rules::PhaseRing& ring,
                            ManualPhaseProvider* phase_provider)
     : api::Intersection(id, region, ring), phase_provider_(phase_provider) {
-  DRAKE_THROW_UNLESS(phase_provider_ != nullptr);
+  MALIPUT_THROW_UNLESS(phase_provider_ != nullptr);
 }
 
 drake::optional<api::rules::PhaseProvider::Result> Intersection::Phase() const {

--- a/maliput/src/base/intersection_book.cc
+++ b/maliput/src/base/intersection_book.cc
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 
@@ -19,7 +19,7 @@ class IntersectionBook::Impl {
   ~Impl() = default;
 
   void AddIntersection(std::unique_ptr<Intersection> intersection) {
-    DRAKE_THROW_UNLESS(intersection != nullptr);
+    MALIPUT_THROW_UNLESS(intersection != nullptr);
     auto result = book_.emplace(intersection->id(), std::move(intersection));
     if (!result.second) {
       throw std::logic_error(

--- a/maliput/src/base/intersection_book_loader.cc
+++ b/maliput/src/base/intersection_book_loader.cc
@@ -4,14 +4,15 @@
 
 #include "yaml-cpp/yaml.h"
 
+#include "drake/common/drake_optional.h"
+
 #include "maliput/api/rules/phase.h"
 #include "maliput/api/rules/phase_ring.h"
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/base/intersection.h"
 #include "maliput/base/intersection_book.h"
-#include "drake/common/drake_optional.h"
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 using maliput::api::rules::LaneSRange;
 using maliput::api::rules::LaneSRoute;
@@ -41,17 +42,17 @@ std::vector<LaneSRange> GetRegion(const RoadRulebook& road_rulebook,
 std::unique_ptr<api::Intersection> BuildIntersection(
     const YAML::Node& intersection_node, const RoadRulebook& road_rulebook,
     const PhaseRingBook& phase_ring_book, ManualPhaseProvider* phase_provider) {
-  DRAKE_THROW_UNLESS(intersection_node.IsMap());
-  DRAKE_THROW_UNLESS(intersection_node["ID"].IsDefined());
-  DRAKE_THROW_UNLESS(intersection_node["PhaseRing"].IsDefined());
-  DRAKE_THROW_UNLESS(intersection_node["InitialPhase"].IsDefined());
+  MALIPUT_THROW_UNLESS(intersection_node.IsMap());
+  MALIPUT_THROW_UNLESS(intersection_node["ID"].IsDefined());
+  MALIPUT_THROW_UNLESS(intersection_node["PhaseRing"].IsDefined());
+  MALIPUT_THROW_UNLESS(intersection_node["InitialPhase"].IsDefined());
   const Intersection::Id id(intersection_node["ID"].as<std::string>());
   const PhaseRing::Id ring_id(intersection_node["PhaseRing"].as<std::string>());
   const Phase::Id phase_id(intersection_node["InitialPhase"].as<std::string>());
   drake::optional<PhaseRing> ring = phase_ring_book.GetPhaseRing(ring_id);
-  DRAKE_THROW_UNLESS(ring.has_value());
-  DRAKE_THROW_UNLESS(ring->phases().size() > 0);
-  DRAKE_THROW_UNLESS(ring->phases().find(phase_id) != ring->phases().end());
+  MALIPUT_THROW_UNLESS(ring.has_value());
+  MALIPUT_THROW_UNLESS(ring->phases().size() > 0);
+  MALIPUT_THROW_UNLESS(ring->phases().find(phase_id) != ring->phases().end());
   drake::optional<api::rules::Phase::Id> next_phase_id = drake::nullopt;
   drake::optional<double> duration_until = drake::nullopt;
   std::vector<PhaseRing::NextPhase> next_phases =
@@ -81,13 +82,13 @@ std::unique_ptr<api::Intersection> BuildIntersection(
 std::unique_ptr<api::IntersectionBook> BuildFrom(
     const YAML::Node& root_node, const RoadRulebook& road_rulebook,
     const PhaseRingBook& phase_ring_book, ManualPhaseProvider* phase_provider) {
-  DRAKE_THROW_UNLESS(root_node.IsMap());
+  MALIPUT_THROW_UNLESS(root_node.IsMap());
   const YAML::Node& intersections_node = root_node["Intersections"];
   auto result = std::make_unique<IntersectionBook>();
   if (!intersections_node.IsDefined()) {
     return result;
   }
-  DRAKE_THROW_UNLESS(intersections_node.IsSequence());
+  MALIPUT_THROW_UNLESS(intersections_node.IsSequence());
   for (const YAML::Node& intersection_node : intersections_node) {
     result->AddIntersection(BuildIntersection(intersection_node, road_rulebook,
                                               phase_ring_book, phase_provider));

--- a/maliput/src/base/manual_phase_provider.cc
+++ b/maliput/src/base/manual_phase_provider.cc
@@ -4,7 +4,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 
@@ -44,7 +44,7 @@ class ManualPhaseProvider::Impl {
       throw std::logic_error(
           "Duration-until specified when next phase is unspecified.");
     }
-    DRAKE_THROW_UNLESS(phases_.find(id) != phases_.end());
+    MALIPUT_THROW_UNLESS(phases_.find(id) != phases_.end());
     phases_.at(id) =
         PhaseProvider::Result{phase, ComputeNext(next_phase, duration_until)};
   }

--- a/maliput/src/base/manual_phase_ring_book.cc
+++ b/maliput/src/base/manual_phase_ring_book.cc
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 
@@ -43,10 +43,10 @@ class ManualPhaseRingBook::Impl {
       throw std::logic_error("Attempted to remove unknown PhaseRing with ID " +
                              ring_id.string());
     }
-    DRAKE_THROW_UNLESS(ring_book_.erase(ring_id) == 1);
+    MALIPUT_THROW_UNLESS(ring_book_.erase(ring_id) == 1);
     const Phase& phase = ring->phases().begin()->second;
     for (const auto& element : phase.rule_states()) {
-      DRAKE_THROW_UNLESS(rule_book_.erase(element.first) == 1);
+      MALIPUT_THROW_UNLESS(rule_book_.erase(element.first) == 1);
     }
   }
 

--- a/maliput/src/base/manual_rulebook.cc
+++ b/maliput/src/base/manual_rulebook.cc
@@ -222,7 +222,7 @@ class ManualRulebook::Impl {
     // Add to map.
     auto map_result = map->emplace(rule.id(), rule);
     // Throw if the id was already present.
-    DRAKE_THROW_UNLESS(map_result.second);
+    MALIPUT_THROW_UNLESS(map_result.second);
     // Add to index.
     index_->AddRule(rule);
   }
@@ -234,12 +234,12 @@ class ManualRulebook::Impl {
 
   template <class T>
   void RemoveAnyRule(const typename T::Id& id, IdIndex<T>* map) {
-    DRAKE_THROW_UNLESS(map->count(id) == 1);
+    MALIPUT_THROW_UNLESS(map->count(id) == 1);
     // Remove from index.
     index_->RemoveRule(map->at(id));
     // Remove from map.
     auto map_result = map->erase(id);
-    DRAKE_THROW_UNLESS(map_result > 0);
+    MALIPUT_THROW_UNLESS(map_result > 0);
   }
 
   std::unique_ptr<RangeIndex> index_;

--- a/maliput/src/base/phase_ring_book_loader.cc
+++ b/maliput/src/base/phase_ring_book_loader.cc
@@ -13,8 +13,7 @@
 #include "maliput/api/rules/traffic_lights.h"
 #include "maliput/base/manual_phase_ring_book.h"
 #include "maliput/common/maliput_abort.h"
-
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace YAML {
 
@@ -69,7 +68,7 @@ using api::rules::UniqueBulbId;
 // in @p rules_node.
 std::unordered_map<RightOfWayRule::Id, RightOfWayRule> GetRules(
     const RoadRulebook* rulebook, const YAML::Node& rules_node) {
-  DRAKE_THROW_UNLESS(rules_node.IsSequence());
+  MALIPUT_THROW_UNLESS(rules_node.IsSequence());
   std::unordered_map<RightOfWayRule::Id, RightOfWayRule> result;
   for (const YAML::Node& rule_node : rules_node) {
     const RightOfWayRule::Id rule_id(rule_node.as<std::string>());
@@ -122,7 +121,7 @@ void ConfirmBulbsExist(const BulbGroup& bulb_group,
                        const YAML::Node& bulbs_node) {
   for (const auto& bulb_group_pair : bulbs_node) {
     const Bulb::Id bulb_id(bulb_group_pair.first.as<std::string>());
-    DRAKE_THROW_UNLESS(bulb_group.GetBulb(bulb_id) != drake::nullopt);
+    MALIPUT_THROW_UNLESS(bulb_group.GetBulb(bulb_id) != drake::nullopt);
   }
 }
 
@@ -132,26 +131,26 @@ drake::optional<BulbStates> LoadBulbStates(const TrafficLightBook* traffic_light
   const YAML::Node& traffic_light_states_node =
       phase_node["TrafficLightStates"];
   if (traffic_light_states_node.IsDefined()) {
-    DRAKE_THROW_UNLESS(traffic_light_states_node.IsMap());
+    MALIPUT_THROW_UNLESS(traffic_light_states_node.IsMap());
     result = BulbStates();
     for (const auto& traffic_light_pair : traffic_light_states_node) {
       const TrafficLight::Id traffic_light_id(
           traffic_light_pair.first.as<std::string>());
       const drake::optional<TrafficLight> traffic_light =
           traffic_light_book->GetTrafficLight(traffic_light_id);
-      DRAKE_THROW_UNLESS(traffic_light.has_value());
+      MALIPUT_THROW_UNLESS(traffic_light.has_value());
       const YAML::Node& bulb_group_node = traffic_light_pair.second;
-      DRAKE_THROW_UNLESS(bulb_group_node.IsDefined());
-      DRAKE_THROW_UNLESS(bulb_group_node.IsMap());
+      MALIPUT_THROW_UNLESS(bulb_group_node.IsDefined());
+      MALIPUT_THROW_UNLESS(bulb_group_node.IsMap());
       for (const auto& bulb_group_pair : bulb_group_node) {
         const BulbGroup::Id bulb_group_id(
             bulb_group_pair.first.as<std::string>());
         const drake::optional<BulbGroup> bulb_group =
             traffic_light->GetBulbGroup(bulb_group_id);
-        DRAKE_THROW_UNLESS(bulb_group.has_value());
+        MALIPUT_THROW_UNLESS(bulb_group.has_value());
         const YAML::Node& bulbs_node = bulb_group_pair.second;
-        DRAKE_THROW_UNLESS(bulbs_node.IsDefined());
-        DRAKE_THROW_UNLESS(bulbs_node.IsMap());
+        MALIPUT_THROW_UNLESS(bulbs_node.IsDefined());
+        MALIPUT_THROW_UNLESS(bulbs_node.IsMap());
         ConfirmBulbsExist(*bulb_group, bulbs_node);
         for (const auto& bulb : bulb_group->bulbs()) {
           BulbState bulb_state = bulb.GetDefaultState();
@@ -174,7 +173,7 @@ void VerifyPhaseExists(const std::vector<Phase>& phases,
   const auto it =
       std::find_if(phases.begin(), phases.end(),
                    [&](const Phase& p) -> bool { return p.id() == phase_id; });
-  DRAKE_THROW_UNLESS(it != phases.end());
+  MALIPUT_THROW_UNLESS(it != phases.end());
 }
 
 drake::optional<const std::unordered_map<Phase::Id, std::vector<PhaseRing::NextPhase>>>
@@ -185,16 +184,16 @@ BuildNextPhases(const std::vector<Phase>& phases,
     return drake::nullopt;
   }
   std::unordered_map<Phase::Id, std::vector<PhaseRing::NextPhase>> result;
-  DRAKE_THROW_UNLESS(phase_ring_node.IsMap());
+  MALIPUT_THROW_UNLESS(phase_ring_node.IsMap());
   for (const auto& graph_node_it : graph_node) {
     const Phase::Id phase_id(graph_node_it.first.as<std::string>());
     VerifyPhaseExists(phases, phase_id);
     const YAML::Node& next_phases_node = graph_node_it.second;
-    DRAKE_THROW_UNLESS(next_phases_node.IsSequence());
+    MALIPUT_THROW_UNLESS(next_phases_node.IsSequence());
     std::vector<PhaseRing::NextPhase> next_phases;
     for (const YAML::Node& next_phase_node : next_phases_node) {
-      DRAKE_THROW_UNLESS(next_phase_node.IsMap());
-      DRAKE_THROW_UNLESS(next_phase_node["ID"].IsDefined());
+      MALIPUT_THROW_UNLESS(next_phase_node.IsMap());
+      MALIPUT_THROW_UNLESS(next_phase_node["ID"].IsDefined());
       const Phase::Id next_phase_id(next_phase_node["ID"].as<std::string>());
       VerifyPhaseExists(phases, next_phase_id);
       drake::optional<double> duration_until = drake::nullopt;
@@ -213,32 +212,32 @@ BuildNextPhases(const std::vector<Phase>& phases,
 PhaseRing BuildPhaseRing(const RoadRulebook* rulebook,
                          const TrafficLightBook* traffic_light_book,
                          const YAML::Node& phase_ring_node) {
-  DRAKE_THROW_UNLESS(phase_ring_node.IsMap());
-  DRAKE_THROW_UNLESS(phase_ring_node["ID"].IsDefined());
+  MALIPUT_THROW_UNLESS(phase_ring_node.IsMap());
+  MALIPUT_THROW_UNLESS(phase_ring_node["ID"].IsDefined());
   const PhaseRing::Id ring_id(phase_ring_node["ID"].as<std::string>());
   const std::unordered_map<RightOfWayRule::Id, RightOfWayRule> rules =
       GetRules(rulebook, phase_ring_node["Rules"]);
 
   const YAML::Node& phases_node = phase_ring_node["Phases"];
-  DRAKE_THROW_UNLESS(phases_node.IsDefined());
-  DRAKE_THROW_UNLESS(phases_node.IsSequence());
+  MALIPUT_THROW_UNLESS(phases_node.IsDefined());
+  MALIPUT_THROW_UNLESS(phases_node.IsSequence());
   std::vector<Phase> phases;
   for (const YAML::Node& phase_node : phases_node) {
-    DRAKE_THROW_UNLESS(phase_node.IsMap());
-    DRAKE_THROW_UNLESS(phase_node["ID"].IsDefined());
+    MALIPUT_THROW_UNLESS(phase_node.IsMap());
+    MALIPUT_THROW_UNLESS(phase_node["ID"].IsDefined());
     const Phase::Id phase_id(phase_node["ID"].as<std::string>());
     // First get a RuleStates object populated with default states of all rules.
     // Then, override the defaults with the states specified in the YAML
     // document.
     RuleStates rule_states = CreateDefaultRuleStates(rules);
     const YAML::Node& rule_states_node = phase_node["RightOfWayRuleStates"];
-    DRAKE_THROW_UNLESS(rule_states_node.IsDefined());
-    DRAKE_THROW_UNLESS(rule_states_node.IsMap());
+    MALIPUT_THROW_UNLESS(rule_states_node.IsDefined());
+    MALIPUT_THROW_UNLESS(rule_states_node.IsMap());
     for (const auto& rule_state_it : rule_states_node) {
       RightOfWayRule::Id rule_id(rule_state_it.first.as<std::string>());
       RightOfWayRule::State::Id state_id(
           rule_state_it.second.as<std::string>());
-      DRAKE_THROW_UNLESS(rule_states.find(rule_id) != rule_states.end());
+      MALIPUT_THROW_UNLESS(rule_states.find(rule_id) != rule_states.end());
       rule_states.at(rule_id) = state_id;
     }
     drake::optional<BulbStates> bulb_states =
@@ -253,10 +252,10 @@ PhaseRing BuildPhaseRing(const RoadRulebook* rulebook,
 std::unique_ptr<api::rules::PhaseRingBook> BuildFrom(
     const RoadRulebook* rulebook, const TrafficLightBook* traffic_light_book,
     const YAML::Node& root_node) {
-  DRAKE_THROW_UNLESS(root_node.IsMap());
+  MALIPUT_THROW_UNLESS(root_node.IsMap());
   const YAML::Node& phase_rings_node = root_node["PhaseRings"];
-  DRAKE_THROW_UNLESS(phase_rings_node.IsDefined());
-  DRAKE_THROW_UNLESS(phase_rings_node.IsSequence());
+  MALIPUT_THROW_UNLESS(phase_rings_node.IsDefined());
+  MALIPUT_THROW_UNLESS(phase_rings_node.IsSequence());
   auto result = std::make_unique<ManualPhaseRingBook>();
   for (const YAML::Node& phase_ring_node : phase_rings_node) {
     result->AddPhaseRing(

--- a/maliput/src/base/road_rulebook_loader.cc
+++ b/maliput/src/base/road_rulebook_loader.cc
@@ -6,7 +6,6 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "drake/common/drake_throw.h"
 #include "drake/common/text_logging.h"
 
 #include "maliput/api/lane.h"
@@ -85,7 +84,7 @@ struct convert<DirectionUsageRule::State::Severity> {
       node = "Preferred";
       return node;
     } else {
-      DRAKE_THROW_UNLESS(rhs == DirectionUsageRule::State::Severity::kStrict);
+      MALIPUT_THROW_UNLESS(rhs == DirectionUsageRule::State::Severity::kStrict);
       node = "Strict";
       return node;
     }
@@ -164,8 +163,8 @@ namespace {
 SRange ObtainSRange(const Lane* lane, const YAML::Node& lane_node) {
   if (lane_node["SRange"]) {
     const SRange srange = lane_node["SRange"].as<SRange>();
-    DRAKE_THROW_UNLESS(srange.s0() >= 0);
-    DRAKE_THROW_UNLESS(srange.s1() <= lane->length());
+    MALIPUT_THROW_UNLESS(srange.s0() >= 0);
+    MALIPUT_THROW_UNLESS(srange.s1() <= lane->length());
     return srange;
   } else {
     return SRange(0, lane->length());
@@ -174,18 +173,18 @@ SRange ObtainSRange(const Lane* lane, const YAML::Node& lane_node) {
 
 LaneSRange BuildLaneSRange(const api::RoadGeometry* road_geometry,
                            const YAML::Node& lane_node) {
-  DRAKE_THROW_UNLESS(lane_node.IsMap());
-  DRAKE_THROW_UNLESS(lane_node["Lane"].IsDefined());
+  MALIPUT_THROW_UNLESS(lane_node.IsMap());
+  MALIPUT_THROW_UNLESS(lane_node["Lane"].IsDefined());
   const LaneId lane_id(lane_node["Lane"].as<std::string>());
   const Lane* lane = road_geometry->ById().GetLane(lane_id);
-  DRAKE_THROW_UNLESS(lane != nullptr);
+  MALIPUT_THROW_UNLESS(lane != nullptr);
   const SRange s_range = ObtainSRange(lane, lane_node);
   return LaneSRange(lane_id, s_range);
 }
 
 LaneSRoute BuildLaneSRoute(const api::RoadGeometry* road_geometry,
                            const YAML::Node& zone_node) {
-  DRAKE_THROW_UNLESS(zone_node.IsSequence());
+  MALIPUT_THROW_UNLESS(zone_node.IsSequence());
   std::vector<LaneSRange> ranges;
   for (const YAML::Node& lane_node : zone_node) {
     ranges.emplace_back(BuildLaneSRange(road_geometry, lane_node));
@@ -198,7 +197,7 @@ namespace {
 
 std::vector<RightOfWayRule::State> BuildRightOfWayStates(
     const YAML::Node& states_node) {
-  DRAKE_THROW_UNLESS(states_node.IsMap());
+  MALIPUT_THROW_UNLESS(states_node.IsMap());
   std::vector<RightOfWayRule::State> states;
   if (states_node["Go"]) {
     states.push_back(RightOfWayRule::State(
@@ -279,17 +278,17 @@ RightOfWayRule::RelatedBulbGroups BuildRelatedBulbGroups(
 
 RightOfWayRule BuildRightOfWayRule(const api::RoadGeometry* road_geometry,
                                    const YAML::Node& rule_node) {
-  DRAKE_THROW_UNLESS(rule_node.IsMap());
-  DRAKE_THROW_UNLESS(rule_node["ID"].IsDefined());
+  MALIPUT_THROW_UNLESS(rule_node.IsMap());
+  MALIPUT_THROW_UNLESS(rule_node["ID"].IsDefined());
   const RightOfWayRule::Id rule_id(rule_node["ID"].as<std::string>());
 
   const YAML::Node& states_node = rule_node["States"];
-  DRAKE_THROW_UNLESS(states_node.IsDefined());
+  MALIPUT_THROW_UNLESS(states_node.IsDefined());
   const std::vector<RightOfWayRule::State> states =
       BuildRightOfWayStates(states_node);
 
   const YAML::Node& zone_node = rule_node["Zone"];
-  DRAKE_THROW_UNLESS(zone_node.IsDefined());
+  MALIPUT_THROW_UNLESS(zone_node.IsDefined());
   const LaneSRoute zone = BuildLaneSRoute(road_geometry, zone_node);
 
   return RightOfWayRule(rule_id, zone, BuildRightOfWayZoneType(rule_node),
@@ -301,12 +300,12 @@ RightOfWayRule BuildRightOfWayRule(const api::RoadGeometry* road_geometry,
 namespace {
 std::vector<DirectionUsageRule::State> BuildDirectionUsageStates(
     const YAML::Node& states_node) {
-  DRAKE_THROW_UNLESS(states_node.IsSequence());
+  MALIPUT_THROW_UNLESS(states_node.IsSequence());
   std::vector<DirectionUsageRule::State> states;
   for (const YAML::Node& state_node : states_node) {
-    DRAKE_THROW_UNLESS(state_node["ID"].IsDefined());
-    DRAKE_THROW_UNLESS(state_node["Severity"].IsDefined());
-    DRAKE_THROW_UNLESS(state_node["Type"].IsDefined());
+    MALIPUT_THROW_UNLESS(state_node["ID"].IsDefined());
+    MALIPUT_THROW_UNLESS(state_node["Severity"].IsDefined());
+    MALIPUT_THROW_UNLESS(state_node["Type"].IsDefined());
     states.push_back(DirectionUsageRule::State(
         DirectionUsageRule::State::Id(state_node["ID"].as<std::string>()),
         state_node["Type"].as<DirectionUsageRule::State::Type>(),
@@ -317,17 +316,17 @@ std::vector<DirectionUsageRule::State> BuildDirectionUsageStates(
 
 DirectionUsageRule BuildDirectionUsageRule(
     const api::RoadGeometry* road_geometry, const YAML::Node& rule_node) {
-  DRAKE_THROW_UNLESS(rule_node.IsMap());
-  DRAKE_THROW_UNLESS(rule_node["ID"].IsDefined());
+  MALIPUT_THROW_UNLESS(rule_node.IsMap());
+  MALIPUT_THROW_UNLESS(rule_node["ID"].IsDefined());
   const DirectionUsageRule::Id rule_id(rule_node["ID"].as<std::string>());
 
   const YAML::Node& states_node = rule_node["States"];
-  DRAKE_THROW_UNLESS(states_node.IsDefined());
+  MALIPUT_THROW_UNLESS(states_node.IsDefined());
   const std::vector<DirectionUsageRule::State> states =
       BuildDirectionUsageStates(states_node);
 
   const YAML::Node& zone_node = rule_node["Zone"];
-  DRAKE_THROW_UNLESS(zone_node.IsDefined());
+  MALIPUT_THROW_UNLESS(zone_node.IsDefined());
   const LaneSRange zone = BuildLaneSRange(road_geometry, zone_node);
 
   return DirectionUsageRule(rule_id, zone, states);
@@ -336,13 +335,13 @@ DirectionUsageRule BuildDirectionUsageRule(
 
 std::unique_ptr<api::rules::RoadRulebook> BuildFrom(
     const api::RoadGeometry* road_geometry, const YAML::Node& root_node) {
-  DRAKE_THROW_UNLESS(root_node.IsMap());
+  MALIPUT_THROW_UNLESS(root_node.IsMap());
   const YAML::Node& rulebook_node = root_node["RoadRulebook"];
-  DRAKE_THROW_UNLESS(rulebook_node.IsDefined());
-  DRAKE_THROW_UNLESS(rulebook_node.IsMap());
+  MALIPUT_THROW_UNLESS(rulebook_node.IsDefined());
+  MALIPUT_THROW_UNLESS(rulebook_node.IsMap());
   const YAML::Node& right_of_way_rules_node = rulebook_node["RightOfWayRules"];
-  DRAKE_THROW_UNLESS(right_of_way_rules_node.IsDefined());
-  DRAKE_THROW_UNLESS(right_of_way_rules_node.IsSequence());
+  MALIPUT_THROW_UNLESS(right_of_way_rules_node.IsDefined());
+  MALIPUT_THROW_UNLESS(right_of_way_rules_node.IsSequence());
   std::unique_ptr<ManualRulebook> rulebook = std::make_unique<ManualRulebook>();
   for (const YAML::Node& right_of_way_rule_node : right_of_way_rules_node) {
     rulebook->AddRule(
@@ -350,8 +349,8 @@ std::unique_ptr<api::rules::RoadRulebook> BuildFrom(
   }
   const YAML::Node& direction_usage_rules_node =
       rulebook_node["DirectionUsageRules"];
-  DRAKE_THROW_UNLESS(direction_usage_rules_node.IsDefined());
-  DRAKE_THROW_UNLESS(direction_usage_rules_node.IsSequence());
+  MALIPUT_THROW_UNLESS(direction_usage_rules_node.IsDefined());
+  MALIPUT_THROW_UNLESS(direction_usage_rules_node.IsSequence());
   for (const YAML::Node& direction_usage_rule_node :
        direction_usage_rules_node) {
     rulebook->AddRule(

--- a/maliput/src/base/traffic_light_book_loader.cc
+++ b/maliput/src/base/traffic_light_book_loader.cc
@@ -6,13 +6,15 @@
 
 #include "yaml-cpp/yaml.h"
 
+#include "drake/common/eigen_types.h"
+#include "drake/math/quaternion.h"
+
 #include "maliput/api/lane_data.h"
 #include "maliput/api/rules/traffic_light_book.h"
 #include "maliput/api/rules/traffic_lights.h"
 #include "maliput/base/traffic_light_book.h"
-#include "drake/common/drake_throw.h"
-#include "drake/common/eigen_types.h"
-#include "drake/math/quaternion.h"
+#include "maliput/common/maliput_throw.h"
+
 
 using drake::Quaternion;
 using maliput::api::GeoPosition;
@@ -219,15 +221,15 @@ namespace maliput {
 namespace {
 
 Bulb BuildBulb(const YAML::Node& bulb_node) {
-  DRAKE_THROW_UNLESS(bulb_node.IsDefined());
-  DRAKE_THROW_UNLESS(bulb_node.IsMap());
-  DRAKE_THROW_UNLESS(bulb_node["ID"].IsDefined());
+  MALIPUT_THROW_UNLESS(bulb_node.IsDefined());
+  MALIPUT_THROW_UNLESS(bulb_node.IsMap());
+  MALIPUT_THROW_UNLESS(bulb_node["ID"].IsDefined());
   const Bulb::Id id(bulb_node["ID"].as<std::string>());
   const YAML::Node& pose_node = bulb_node["Pose"];
-  DRAKE_THROW_UNLESS(pose_node.IsDefined());
-  DRAKE_THROW_UNLESS(pose_node.IsMap());
-  DRAKE_THROW_UNLESS(pose_node["position_bulb_group"].IsDefined());
-  DRAKE_THROW_UNLESS(pose_node["orientation_bulb_group"].IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node.IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node.IsMap());
+  MALIPUT_THROW_UNLESS(pose_node["position_bulb_group"].IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node["orientation_bulb_group"].IsDefined());
   const GeoPosition position_bulb_group =
       pose_node["position_bulb_group"].as<GeoPosition>();
   const Rotation orientation_bulb_group =
@@ -236,22 +238,22 @@ Bulb BuildBulb(const YAML::Node& bulb_node) {
   const YAML::Node& bounding_box_node = bulb_node["BoundingBox"];
   Bulb::BoundingBox bounding_box;
   if (bounding_box_node.IsDefined()) {
-    DRAKE_THROW_UNLESS(bounding_box_node.IsMap());
+    MALIPUT_THROW_UNLESS(bounding_box_node.IsMap());
     bounding_box = bounding_box_node.as<Bulb::BoundingBox>();
   }
 
   const YAML::Node& color_node = bulb_node["Color"];
-  DRAKE_THROW_UNLESS(color_node.IsDefined());
+  MALIPUT_THROW_UNLESS(color_node.IsDefined());
   const BulbColor color = color_node.as<BulbColor>();
 
   const YAML::Node& type_node = bulb_node["Type"];
-  DRAKE_THROW_UNLESS(type_node.IsDefined());
+  MALIPUT_THROW_UNLESS(type_node.IsDefined());
   const BulbType type = type_node.as<BulbType>();
 
   drake::optional<double> arrow_orientation_rad = drake::nullopt;
   if (type == BulbType::kArrow) {
     const YAML::Node& arrow_orientation_node = bulb_node["ArrowOrientation"];
-    DRAKE_THROW_UNLESS(arrow_orientation_node.IsDefined());
+    MALIPUT_THROW_UNLESS(arrow_orientation_node.IsDefined());
     arrow_orientation_rad = arrow_orientation_node.as<double>();
   }
 
@@ -266,22 +268,22 @@ Bulb BuildBulb(const YAML::Node& bulb_node) {
 }
 
 BulbGroup BuildBulbGroup(const YAML::Node& bulb_group_node) {
-  DRAKE_THROW_UNLESS(bulb_group_node.IsDefined());
-  DRAKE_THROW_UNLESS(bulb_group_node.IsMap());
-  DRAKE_THROW_UNLESS(bulb_group_node["ID"].IsDefined());
+  MALIPUT_THROW_UNLESS(bulb_group_node.IsDefined());
+  MALIPUT_THROW_UNLESS(bulb_group_node.IsMap());
+  MALIPUT_THROW_UNLESS(bulb_group_node["ID"].IsDefined());
   const BulbGroup::Id id(bulb_group_node["ID"].as<std::string>());
   const YAML::Node& pose_node = bulb_group_node["Pose"];
-  DRAKE_THROW_UNLESS(pose_node.IsDefined());
-  DRAKE_THROW_UNLESS(pose_node.IsMap());
-  DRAKE_THROW_UNLESS(pose_node["position_traffic_light"].IsDefined());
-  DRAKE_THROW_UNLESS(pose_node["orientation_traffic_light"].IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node.IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node.IsMap());
+  MALIPUT_THROW_UNLESS(pose_node["position_traffic_light"].IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node["orientation_traffic_light"].IsDefined());
   const GeoPosition position_traffic_light =
       pose_node["position_traffic_light"].as<GeoPosition>();
   const Rotation orientation_traffic_light =
       pose_node["orientation_traffic_light"].as<Rotation>();
   const YAML::Node& bulbs_node = bulb_group_node["Bulbs"];
-  DRAKE_THROW_UNLESS(bulbs_node.IsDefined());
-  DRAKE_THROW_UNLESS(bulbs_node.IsSequence());
+  MALIPUT_THROW_UNLESS(bulbs_node.IsDefined());
+  MALIPUT_THROW_UNLESS(bulbs_node.IsSequence());
   std::vector<Bulb> bulbs;
   for (const YAML::Node& bulb_node : bulbs_node) {
     bulbs.push_back(BuildBulb(bulb_node));
@@ -291,21 +293,21 @@ BulbGroup BuildBulbGroup(const YAML::Node& bulb_group_node) {
 }
 
 TrafficLight BuildTrafficLight(const YAML::Node& traffic_light_node) {
-  DRAKE_THROW_UNLESS(traffic_light_node.IsMap());
+  MALIPUT_THROW_UNLESS(traffic_light_node.IsMap());
   const TrafficLight::Id id(traffic_light_node["ID"].as<std::string>());
   const YAML::Node& pose_node = traffic_light_node["Pose"];
-  DRAKE_THROW_UNLESS(pose_node.IsDefined());
-  DRAKE_THROW_UNLESS(pose_node.IsMap());
-  DRAKE_THROW_UNLESS(pose_node["position_road_network"].IsDefined());
-  DRAKE_THROW_UNLESS(pose_node["orientation_road_network"].IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node.IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node.IsMap());
+  MALIPUT_THROW_UNLESS(pose_node["position_road_network"].IsDefined());
+  MALIPUT_THROW_UNLESS(pose_node["orientation_road_network"].IsDefined());
   const GeoPosition position_road_network =
       pose_node["position_road_network"].as<GeoPosition>();
   const Rotation orientation_road_network =
       pose_node["orientation_road_network"].as<Rotation>();
 
   const YAML::Node& bulb_groups_node = traffic_light_node["BulbGroups"];
-  DRAKE_THROW_UNLESS(bulb_groups_node.IsDefined());
-  DRAKE_THROW_UNLESS(bulb_groups_node.IsSequence());
+  MALIPUT_THROW_UNLESS(bulb_groups_node.IsDefined());
+  MALIPUT_THROW_UNLESS(bulb_groups_node.IsSequence());
   std::vector<BulbGroup> bulb_groups;
   for (const YAML::Node& bulb_group_node : bulb_groups_node) {
     bulb_groups.push_back(BuildBulbGroup(bulb_group_node));
@@ -316,10 +318,10 @@ TrafficLight BuildTrafficLight(const YAML::Node& traffic_light_node) {
 
 std::unique_ptr<api::rules::TrafficLightBook> BuildFrom(
     const YAML::Node& root_node) {
-  DRAKE_THROW_UNLESS(root_node.IsMap());
+  MALIPUT_THROW_UNLESS(root_node.IsMap());
   const YAML::Node& traffic_lights_node = root_node["TrafficLights"];
-  DRAKE_THROW_UNLESS(traffic_lights_node.IsDefined());
-  DRAKE_THROW_UNLESS(traffic_lights_node.IsSequence());
+  MALIPUT_THROW_UNLESS(traffic_lights_node.IsDefined());
+  MALIPUT_THROW_UNLESS(traffic_lights_node.IsSequence());
   auto result = std::make_unique<TrafficLightBook>();
   for (const YAML::Node& traffic_light_node : traffic_lights_node) {
     result->AddTrafficLight(BuildTrafficLight(traffic_light_node));

--- a/maliput/src/geometry_base/branch_point.cc
+++ b/maliput/src/geometry_base/branch_point.cc
@@ -1,7 +1,7 @@
 #include "maliput/geometry_base/branch_point.h"
 
 #include "maliput/geometry_base/lane.h"
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace geometry_base {
@@ -12,9 +12,9 @@ void BranchPoint::AttachToRoadGeometry(
     Passkey<RoadGeometry>,
     const api::RoadGeometry* road_geometry) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(road_geometry != nullptr);
+  MALIPUT_THROW_UNLESS(road_geometry != nullptr);
   // Preconditions
-  DRAKE_THROW_UNLESS(road_geometry_ == nullptr);
+  MALIPUT_THROW_UNLESS(road_geometry_ == nullptr);
   road_geometry_ = road_geometry;
 }
 
@@ -23,12 +23,12 @@ void BranchPoint::AddBranch(Lane* lane, api::LaneEnd::Which end,
                             LaneEndSet* side) {
   // Parameter checks
   // TODO(maddog@tri.global)  This invariant should be part of api::LaneEnd.
-  DRAKE_THROW_UNLESS(lane != nullptr);
-  DRAKE_THROW_UNLESS((side == &a_side_) || (side == &b_side_));
+  MALIPUT_THROW_UNLESS(lane != nullptr);
+  MALIPUT_THROW_UNLESS((side == &a_side_) || (side == &b_side_));
   // Preconditions
   const api::LaneEnd lane_end{lane, end};
-  DRAKE_THROW_UNLESS(confluent_branches_.count(lane_end) == 0);
-  DRAKE_THROW_UNLESS(ongoing_branches_.count(lane_end) == 0);
+  MALIPUT_THROW_UNLESS(confluent_branches_.count(lane_end) == 0);
+  MALIPUT_THROW_UNLESS(ongoing_branches_.count(lane_end) == 0);
   LaneEndSet* const other_side = (side == &a_side_) ? &b_side_ : &a_side_;
   side->Add(lane_end);
   confluent_branches_[lane_end] = side;
@@ -52,11 +52,11 @@ void BranchPoint::SetDefault(const api::LaneEnd& lane_end,
   const auto& le_ongoing = ongoing_branches_.find(lane_end);
   const auto& db_confluent = confluent_branches_.find(default_branch);
   // Verify that lane_end belongs to this BranchPoint.
-  DRAKE_THROW_UNLESS(le_ongoing != ongoing_branches_.end());
+  MALIPUT_THROW_UNLESS(le_ongoing != ongoing_branches_.end());
   // Verify that default_branch belongs to this BranchPoint.
-  DRAKE_THROW_UNLESS(db_confluent != confluent_branches_.end());
+  MALIPUT_THROW_UNLESS(db_confluent != confluent_branches_.end());
   // Verify that default_branch is an ongoing lane for lane_end.
-  DRAKE_THROW_UNLESS(db_confluent->second == le_ongoing->second);
+  MALIPUT_THROW_UNLESS(db_confluent->second == le_ongoing->second);
 
   defaults_[lane_end] = default_branch;
 }

--- a/maliput/src/geometry_base/brute_force_find_road_positions_strategy.cc
+++ b/maliput/src/geometry_base/brute_force_find_road_positions_strategy.cc
@@ -2,11 +2,10 @@
 
 #include <limits>
 
-#include "drake/common/drake_throw.h"
-
 #include "maliput/api/junction.h"
 #include "maliput/api/lane.h"
 #include "maliput/api/segment.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace geometry_base {
@@ -16,20 +15,20 @@ BruteForceFindRoadPositionsStrategy(
     const maliput::api::RoadGeometry* rg,
     const maliput::api::GeoPosition& geo_position,
     double radius) {
-  DRAKE_THROW_UNLESS(rg != nullptr);
-  DRAKE_THROW_UNLESS(radius >= 0.);
+  MALIPUT_THROW_UNLESS(rg != nullptr);
+  MALIPUT_THROW_UNLESS(radius >= 0.);
 
   std::vector<maliput::api::RoadPositionResult> road_position_results;
 
   for (int i = 0; i < rg->num_junctions(); ++i) {
     const maliput::api::Junction* junction = rg->junction(i);
-    DRAKE_THROW_UNLESS(junction != nullptr);
+    MALIPUT_THROW_UNLESS(junction != nullptr);
     for (int j = 0; j < junction->num_segments(); ++j) {
       const maliput::api::Segment* segment = junction->segment(j);
-      DRAKE_THROW_UNLESS(segment != nullptr);
+      MALIPUT_THROW_UNLESS(segment != nullptr);
       for (int k = 0; k < segment->num_lanes(); ++k) {
         const api::Lane* lane = segment->lane(k);
-        DRAKE_THROW_UNLESS(lane != nullptr);
+        MALIPUT_THROW_UNLESS(lane != nullptr);
         double distance{};
         maliput::api::GeoPosition nearest_position;
         const maliput::api::LanePosition lane_position =

--- a/maliput/src/geometry_base/junction.cc
+++ b/maliput/src/geometry_base/junction.cc
@@ -1,6 +1,6 @@
 #include "maliput/geometry_base/junction.h"
 
-#include "drake/common/drake_throw.h"
+#include "maliput/common/maliput_throw.h"
 
 namespace maliput {
 namespace geometry_base {
@@ -11,13 +11,13 @@ void Junction::AttachToRoadGeometry(
     const std::function<void(const api::Segment*)>& segment_indexing_callback,
     const std::function<void(const api::Lane*)>& lane_indexing_callback) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(road_geometry != nullptr);
-  DRAKE_THROW_UNLESS(!!segment_indexing_callback);
-  DRAKE_THROW_UNLESS(!!lane_indexing_callback);
+  MALIPUT_THROW_UNLESS(road_geometry != nullptr);
+  MALIPUT_THROW_UNLESS(!!segment_indexing_callback);
+  MALIPUT_THROW_UNLESS(!!lane_indexing_callback);
   // Preconditions
-  DRAKE_THROW_UNLESS(road_geometry_ == nullptr);
-  DRAKE_THROW_UNLESS(!segment_indexing_callback_);
-  DRAKE_THROW_UNLESS(!lane_indexing_callback_);
+  MALIPUT_THROW_UNLESS(road_geometry_ == nullptr);
+  MALIPUT_THROW_UNLESS(!segment_indexing_callback_);
+  MALIPUT_THROW_UNLESS(!lane_indexing_callback_);
 
   road_geometry_ = road_geometry;
   // Store the indexing callbacks for future use.
@@ -34,7 +34,7 @@ void Junction::AttachToRoadGeometry(
 
 void Junction::AddSegmentPrivate(std::unique_ptr<Segment> segment) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(segment.get() != nullptr);
+  MALIPUT_THROW_UNLESS(segment.get() != nullptr);
   segments_.emplace_back(std::move(segment));
   Segment* const raw_segment = segments_.back().get();
 

--- a/maliput/src/geometry_base/lane.cc
+++ b/maliput/src/geometry_base/lane.cc
@@ -1,10 +1,8 @@
 #include "maliput/geometry_base/lane.h"
 
-#include "drake/common/drake_throw.h"
-
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_throw.h"
 #include "maliput/geometry_base/branch_point.h"
-
 
 namespace maliput {
 namespace geometry_base {
@@ -12,11 +10,11 @@ namespace geometry_base {
 void Lane::AttachToSegment(Passkey<Segment>,
                            const api::Segment* segment, int index) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(segment != nullptr);
-  DRAKE_THROW_UNLESS(index >= 0);
+  MALIPUT_THROW_UNLESS(segment != nullptr);
+  MALIPUT_THROW_UNLESS(index >= 0);
   // Preconditions
-  DRAKE_THROW_UNLESS(segment_ == nullptr);
-  DRAKE_THROW_UNLESS(index_ == -1);
+  MALIPUT_THROW_UNLESS(segment_ == nullptr);
+  MALIPUT_THROW_UNLESS(index_ == -1);
 
   segment_ = segment;
   index_ = index;
@@ -25,9 +23,9 @@ void Lane::AttachToSegment(Passkey<Segment>,
 void Lane::SetStartBranchPoint(Passkey<BranchPoint>,
                                BranchPoint* branch_point) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(branch_point != nullptr);
+  MALIPUT_THROW_UNLESS(branch_point != nullptr);
   // Preconditions
-  DRAKE_THROW_UNLESS(start_branch_point_ == nullptr);
+  MALIPUT_THROW_UNLESS(start_branch_point_ == nullptr);
 
   start_branch_point_ = branch_point;
 }
@@ -35,9 +33,9 @@ void Lane::SetStartBranchPoint(Passkey<BranchPoint>,
 void Lane::SetFinishBranchPoint(Passkey<BranchPoint>,
                                 BranchPoint* branch_point) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(branch_point != nullptr);
+  MALIPUT_THROW_UNLESS(branch_point != nullptr);
   // Preconditions
-  DRAKE_THROW_UNLESS(finish_branch_point_ == nullptr);
+  MALIPUT_THROW_UNLESS(finish_branch_point_ == nullptr);
 
   finish_branch_point_ = branch_point;
 }

--- a/maliput/src/geometry_base/road_geometry.cc
+++ b/maliput/src/geometry_base/road_geometry.cc
@@ -12,7 +12,7 @@ namespace geometry_base {
 
 void RoadGeometry::AddJunctionPrivate(std::unique_ptr<Junction> junction) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(junction.get() != nullptr);
+  MALIPUT_THROW_UNLESS(junction.get() != nullptr);
   junctions_.emplace_back(std::move(junction));
   Junction* const raw_junction = junctions_.back().get();
   raw_junction->AttachToRoadGeometry(
@@ -27,7 +27,7 @@ void RoadGeometry::AddJunctionPrivate(std::unique_ptr<Junction> junction) {
 void RoadGeometry::AddBranchPointPrivate(
     std::unique_ptr<BranchPoint> branch_point) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(branch_point.get() != nullptr);
+  MALIPUT_THROW_UNLESS(branch_point.get() != nullptr);
   branch_points_.emplace_back(std::move(branch_point));
   BranchPoint* const raw_branch_point = branch_points_.back().get();
   raw_branch_point->AttachToRoadGeometry({}, this);

--- a/maliput/src/geometry_base/segment.cc
+++ b/maliput/src/geometry_base/segment.cc
@@ -13,9 +13,9 @@ const api::Junction* Segment::do_junction() const {
 void Segment::AttachToJunction(Passkey<Junction>,
                                const api::Junction* junction) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(junction != nullptr);
+  MALIPUT_THROW_UNLESS(junction != nullptr);
   // Preconditions
-  DRAKE_THROW_UNLESS(junction_ == nullptr);
+  MALIPUT_THROW_UNLESS(junction_ == nullptr);
 
   junction_ = junction;
 }
@@ -25,9 +25,9 @@ void Segment::SetLaneIndexingCallback(
     Passkey<Junction>,
     const std::function<void(const api::Lane*)>& callback) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(!!callback);
+  MALIPUT_THROW_UNLESS(!!callback);
   // Preconditions
-  DRAKE_THROW_UNLESS(!lane_indexing_callback_);
+  MALIPUT_THROW_UNLESS(!lane_indexing_callback_);
 
   lane_indexing_callback_ = callback;
   // Index any Lanes that had already been added to this Segment.
@@ -39,7 +39,7 @@ void Segment::SetLaneIndexingCallback(
 
 void Segment::AddLanePrivate(std::unique_ptr<Lane> lane) {
   // Parameter checks
-  DRAKE_THROW_UNLESS(lane.get() != nullptr);
+  MALIPUT_THROW_UNLESS(lane.get() != nullptr);
   lanes_.emplace_back(std::move(lane));
   Lane* const raw_lane = lanes_.back().get();
 

--- a/maliput/src/test_utilities/mock_geometry.cc
+++ b/maliput/src/test_utilities/mock_geometry.cc
@@ -1,8 +1,7 @@
 #include "maliput/test_utilities/mock_geometry.h"
 
-#include "drake/common/drake_throw.h"
-
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_throw.h"
 
 
 namespace maliput {
@@ -13,55 +12,55 @@ namespace test {
 api::RoadPosition MockRoadGeometry::DoToRoadPosition(
     const api::GeoPosition&, const api::RoadPosition*,
     api::GeoPosition*, double*) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 std::vector<api::RoadPositionResult>
 MockRoadGeometry::DoFindRoadPositions(const api::GeoPosition&, double) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 double MockLane::do_length() const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 api::RBounds MockLane::do_lane_bounds(double) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 api::RBounds MockLane::do_driveable_bounds(double) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 api::HBounds MockLane::do_elevation_bounds(double, double) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 api::GeoPosition MockLane::DoToGeoPosition(const api::LanePosition&) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 api::Rotation MockLane::DoGetOrientation(const api::LanePosition&) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 api::LanePosition MockLane::DoEvalMotionDerivatives(
     const api::LanePosition&, const api::IsoLaneVelocity&) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 
 api::LanePosition MockLane::DoToLanePosition(
     const api::GeoPosition&, api::GeoPosition*, double*) const {
-  DRAKE_THROW_UNLESS(false);
+  MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }
 

--- a/maliput/test/api/lane_data_test.cc
+++ b/maliput/test/api/lane_data_test.cc
@@ -4,6 +4,8 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/symbolic.h"
+
+#include "maliput/common/assertion_error.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 
 namespace maliput {
@@ -332,8 +334,8 @@ GTEST_TEST(RBoundsTest, ParameterizedConstructor) {
   EXPECT_EQ(dut.min(), kMin);
   EXPECT_EQ(dut.max(), kMax);
   // Checks constraints on the constructor.
-  EXPECT_THROW(RBounds(kMax, kMax), std::runtime_error);
-  EXPECT_THROW(RBounds(kMin, kMin), std::runtime_error);
+  EXPECT_THROW(RBounds(kMax, kMax), maliput::common::assertion_error);
+  EXPECT_THROW(RBounds(kMin, kMin), maliput::common::assertion_error);
 }
 
 GTEST_TEST(RBoundsTest, Setters) {
@@ -346,8 +348,8 @@ GTEST_TEST(RBoundsTest, Setters) {
   dut.set_max(2. * kMax);
   EXPECT_EQ(dut.max(), 2. * kMax);
   // Checks constraints on the setters.
-  EXPECT_THROW(dut.set_min(kMax), std::runtime_error);
-  EXPECT_THROW(dut.set_max(kMin), std::runtime_error);
+  EXPECT_THROW(dut.set_min(kMax), maliput::common::assertion_error);
+  EXPECT_THROW(dut.set_max(kMin), maliput::common::assertion_error);
 }
 
 GTEST_TEST(HBoundsTest, DefaultConstructor) {
@@ -365,8 +367,8 @@ GTEST_TEST(HBoundsTest, ParameterizedConstructor) {
   EXPECT_EQ(dut.min(), kMin);
   EXPECT_EQ(dut.max(), kMax);
   // Checks constraints on the constructor.
-  EXPECT_THROW(HBounds(kMax, kMax), std::runtime_error);
-  EXPECT_THROW(HBounds(kMin, kMin), std::runtime_error);
+  EXPECT_THROW(HBounds(kMax, kMax), maliput::common::assertion_error);
+  EXPECT_THROW(HBounds(kMin, kMin), maliput::common::assertion_error);
 }
 
 GTEST_TEST(HBoundsTest, Setters) {
@@ -379,8 +381,8 @@ GTEST_TEST(HBoundsTest, Setters) {
   dut.set_max(2. * kMax);
   EXPECT_EQ(dut.max(), 2. * kMax);
   // Checks constraints on the setters.
-  EXPECT_THROW(dut.set_min(kMax), std::runtime_error);
-  EXPECT_THROW(dut.set_max(kMin), std::runtime_error);
+  EXPECT_THROW(dut.set_min(kMax), maliput::common::assertion_error);
+  EXPECT_THROW(dut.set_max(kMin), maliput::common::assertion_error);
 }
 
 }  // namespace

--- a/maliput/test/api/rules_road_rulebook_test.cc
+++ b/maliput/test/api/rules_road_rulebook_test.cc
@@ -9,7 +9,7 @@
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/speed_limit_rule.h"
-#include "drake/common/drake_throw.h"
+#include "maliput/common/assertion_error.h"
 
 namespace maliput {
 namespace api {
@@ -95,7 +95,7 @@ GTEST_TEST(RoadRulebookTest, ExerciseInterface) {
 
   const double kNegativeTolerance = -1.;
   EXPECT_THROW(dut.FindRules({}, kNegativeTolerance),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_EQ(dut.GetRule(dut.kRightOfWay.id()).id(), dut.kRightOfWay.id());
   EXPECT_THROW(dut.GetRule(RightOfWayRule::Id("xxx")), std::out_of_range);

--- a/maliput/test/api/rules_speed_limit_test.cc
+++ b/maliput/test/api/rules_speed_limit_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "maliput/api/rules/regions.h"
+#include "maliput/common/assertion_error.h"
 #include "maliput/test_utilities/rules_speed_limit_compare.h"
 #include "maliput/test_utilities/rules_test_utilities.h"
 
@@ -32,16 +33,16 @@ GTEST_TEST(SpeedLimitRuleTest, Construction) {
   EXPECT_THROW(SpeedLimitRule(SpeedLimitRule::Id("some_id"), kZone,
                               SpeedLimitRule::Severity::kStrict,
                               90., 77.),
-               std::runtime_error);
+               maliput::common::assertion_error);
   // Negative limits are not allowed.
   EXPECT_THROW(SpeedLimitRule(SpeedLimitRule::Id("some_id"), kZone,
                               SpeedLimitRule::Severity::kStrict,
                               -8., 77.),
-               std::runtime_error);
+               maliput::common::assertion_error);
   EXPECT_THROW(SpeedLimitRule(SpeedLimitRule::Id("some_id"), kZone,
                               SpeedLimitRule::Severity::kStrict,
                               -8., -6.),
-               std::runtime_error);
+               maliput::common::assertion_error);
 }
 
 

--- a/maliput/test/api/type_specific_identifier_test.cc
+++ b/maliput/test/api/type_specific_identifier_test.cc
@@ -7,6 +7,9 @@
 
 #include <gtest/gtest.h>
 
+#include "maliput/common/assertion_error.h"
+
+
 namespace maliput {
 namespace api {
 namespace {
@@ -19,7 +22,7 @@ using CId = TypeSpecificIdentifier<C>;  // ID type specific to class C
 
 GTEST_TEST(TypeSpecificIdentifierTest, Construction) {
   EXPECT_NO_THROW(CId("x"));
-  EXPECT_THROW(CId(""), std::runtime_error);
+  EXPECT_THROW(CId(""), maliput::common::assertion_error);
 }
 
 

--- a/maliput/test/base/manual_rulebook_test.cc
+++ b/maliput/test/base/manual_rulebook_test.cc
@@ -5,6 +5,7 @@
 #include "maliput/api/rules/regions.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/speed_limit_rule.h"
+#include "maliput/common/assertion_error.h"
 #include "maliput/test_utilities/rules_direction_usage_compare.h"
 #include "maliput/test_utilities/rules_right_of_way_compare.h"
 #include "maliput/test_utilities/rules_speed_limit_compare.h"
@@ -59,10 +60,11 @@ TEST_F(ManualRulebookTest, AddGetRemoveRightOfWay) {
   EXPECT_THROW(dut.GetRule(kRightOfWay.id()), std::out_of_range);
   dut.AddRule(kRightOfWay);
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetRule(kRightOfWay.id()), kRightOfWay));
-  EXPECT_THROW(dut.AddRule(kRightOfWay), std::runtime_error);
+  EXPECT_THROW(dut.AddRule(kRightOfWay), maliput::common::assertion_error);
   dut.RemoveRule(kRightOfWay.id());
   EXPECT_THROW(dut.GetRule(kRightOfWay.id()), std::out_of_range);
-  EXPECT_THROW(dut.RemoveRule(kRightOfWay.id()), std::runtime_error);
+  EXPECT_THROW(dut.RemoveRule(kRightOfWay.id()),
+               maliput::common::assertion_error);
 }
 
 
@@ -72,10 +74,11 @@ TEST_F(ManualRulebookTest, AddGetRemoveSpeedLimit) {
   EXPECT_THROW(dut.GetRule(kSpeedLimit.id()), std::out_of_range);
   dut.AddRule(kSpeedLimit);
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetRule(kSpeedLimit.id()), kSpeedLimit));
-  EXPECT_THROW(dut.AddRule(kSpeedLimit), std::runtime_error);
+  EXPECT_THROW(dut.AddRule(kSpeedLimit), maliput::common::assertion_error);
   dut.RemoveRule(kSpeedLimit.id());
   EXPECT_THROW(dut.GetRule(kSpeedLimit.id()), std::out_of_range);
-  EXPECT_THROW(dut.RemoveRule(kSpeedLimit.id()), std::runtime_error);
+  EXPECT_THROW(dut.RemoveRule(kSpeedLimit.id()),
+               maliput::common::assertion_error);
 }
 
 TEST_F(ManualRulebookTest, AddGetRemoveDirectionUsage) {
@@ -85,10 +88,11 @@ TEST_F(ManualRulebookTest, AddGetRemoveDirectionUsage) {
   dut.AddRule(kDirectionUsage);
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetRule(kDirectionUsage.id()),
                                kDirectionUsage));
-  EXPECT_THROW(dut.AddRule(kDirectionUsage), std::runtime_error);
+  EXPECT_THROW(dut.AddRule(kDirectionUsage), maliput::common::assertion_error);
   dut.RemoveRule(kDirectionUsage.id());
   EXPECT_THROW(dut.GetRule(kDirectionUsage.id()), std::out_of_range);
-  EXPECT_THROW(dut.RemoveRule(kDirectionUsage.id()), std::runtime_error);
+  EXPECT_THROW(dut.RemoveRule(kDirectionUsage.id()),
+               maliput::common::assertion_error);
 }
 
 TEST_F(ManualRulebookTest, RemoveAll) {
@@ -99,11 +103,14 @@ TEST_F(ManualRulebookTest, RemoveAll) {
   dut.AddRule(kDirectionUsage);
   dut.RemoveAll();
   EXPECT_THROW(dut.GetRule(kRightOfWay.id()), std::out_of_range);
-  EXPECT_THROW(dut.RemoveRule(kRightOfWay.id()), std::runtime_error);
+  EXPECT_THROW(dut.RemoveRule(kRightOfWay.id()),
+               maliput::common::assertion_error);
   EXPECT_THROW(dut.GetRule(kSpeedLimit.id()), std::out_of_range);
-  EXPECT_THROW(dut.RemoveRule(kSpeedLimit.id()), std::runtime_error);
+  EXPECT_THROW(dut.RemoveRule(kSpeedLimit.id()),
+               maliput::common::assertion_error);
   EXPECT_THROW(dut.GetRule(kDirectionUsage.id()), std::out_of_range);
-  EXPECT_THROW(dut.RemoveRule(kDirectionUsage.id()), std::runtime_error);
+  EXPECT_THROW(dut.RemoveRule(kDirectionUsage.id()),
+               maliput::common::assertion_error);
 
   // Since the original rules are gone, it should be possible to re-add them.
   dut.AddRule(kRightOfWay);

--- a/maliput/test/common/maliput_throw_test.cc
+++ b/maliput/test/common/maliput_throw_test.cc
@@ -15,6 +15,12 @@ GTEST_TEST(MaliputThrowTest, ExpectThrowAndNoThrowTest) {
   EXPECT_NO_THROW({ MALIPUT_THROW_UNLESS(true); });
 }
 
+// Evaluates whether or not MALIPUT_THROW_UNLESS() throws.
+GTEST_TEST(MaliputThrowMessageTest, ExpectThrowWithMessageTest) {
+  EXPECT_THROW({ MALIPUT_THROW_MESSAGE("Exception description"); },
+               assertion_error);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace common

--- a/multilane/include/multilane/arc_road_curve.h
+++ b/multilane/include/multilane/arc_road_curve.h
@@ -2,10 +2,13 @@
 
 #include <cmath>
 
-#include "multilane/road_curve.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+
+#include "maliput/common/maliput_throw.h"
+
+#include "multilane/road_curve.h"
+
 
 namespace maliput {
 namespace multilane {
@@ -38,10 +41,12 @@ class ArcRoadCurve : public RoadCurve {
   /// @param computation_policy Policy to guide all computations. If geared
   /// towards speed, computations will make use of analytical expressions even
   /// if not actually correct for the curve as specified.
-  /// @throws std::runtime_error if @p radius is not a positive number.
-  /// @throws std::runtime_error if @p linear_tolerance is not a positive
-  /// number.
-  /// @throws std::runtime_error if @p scale_length is not a positive number.
+  /// @throws maliput::common::assertion_error if @p radius is not a positive
+  ///         number.
+  /// @throws maliput::common::assertion_error if @p linear_tolerance is not a
+  ///         positive number.
+  /// @throws maliput::common::assertion_error if @p scale_length is not a
+  ///         positive number.
   explicit ArcRoadCurve(
       const drake::Vector2<double>& center, double radius,
       double theta0, double d_theta,
@@ -53,7 +58,7 @@ class ArcRoadCurve : public RoadCurve {
                   elevation, superelevation,
                   computation_policy),
         center_(center), radius_(radius), theta0_(theta0), d_theta_(d_theta) {
-    DRAKE_THROW_UNLESS(radius > 0.0);
+    MALIPUT_THROW_UNLESS(radius > 0.0);
   }
 
   ~ArcRoadCurve() override = default;

--- a/multilane/include/multilane/line_road_curve.h
+++ b/multilane/include/multilane/line_road_curve.h
@@ -40,9 +40,10 @@ class LineRoadCurve : public RoadCurve {
   /// @param computation_policy Policy to guide all computations. If geared
   /// towards speed, computations will make use of analytical expressions even
   /// if not actually correct for the curve as specified.
-  /// @throws std::runtime_error if @p linear_tolerance is not a positive
-  /// number.
-  /// @throws std::runtime_error if @p scale_length is not a positive number.
+  /// @throws maliput::common::assertion_error if @p linear_tolerance is not a
+  /// positive number.
+  /// @throws maliput::common::assertion_error if @p scale_length is not a
+  /// positive number.
   explicit LineRoadCurve(
       const drake::Vector2<double>& xy0, const drake::Vector2<double>& dxy,
       const CubicPolynomial& elevation,

--- a/multilane/include/multilane/road_curve.h
+++ b/multilane/include/multilane/road_curve.h
@@ -130,8 +130,8 @@ class RoadCurve {
   ///         defined for all `s` values between 0 and the total path length of
   ///         the parallel curve (and throwing for any given value outside this
   ///         interval).
-  /// @throws std::runtime_error When `r` makes the radius of curvature be a non
-  ///                           positive number.
+  /// @throws maliput::common::assertion_error When `r` makes the radius of
+  ///         curvature be a non positive number.
   std::function<double(double)> OptimizeCalcPFromS(double r) const;
 
   /// Optimizes the computation of path length integral in the interval of the
@@ -141,8 +141,8 @@ class RoadCurve {
   ///         curve to longitudinal position s at the specified parallel curve,
   ///         defined for all p between 0 and 1 (and throwing for any given
   ///         value outside this interval).
-  /// @throws std::runtime_error When `r` makes the radius of curvature be a non
-  ///                           positive number.
+  /// @throws maliput::common::assertion_error When `r` makes the radius of
+  ///         curvature be a non positive number.
   std::function<double(double)> OptimizeCalcSFromP(double r) const;
 
   /// Computes the reference curve.
@@ -274,7 +274,8 @@ class RoadCurve {
   /// and accuracy. Actual behavior may vary across implementations.
   /// @pre The given @p scale_length is a positive number.
   /// @pre The given @p linear_tolerance is a positive number.
-  /// @throws std::runtime_error if any of the preconditions is not met.
+  /// @throws maliput::common::assertion_error if any of the preconditions is
+  ///         not met.
   ///
   /// @p elevation and @p superelevation are cubic-polynomial functions which
   /// define the elevation and superelevation as a function of position along
@@ -322,8 +323,8 @@ class RoadCurve {
   // curve using numerical methods.
   // @return The path length integral of the curve composed with the elevation
   // polynomial.
-  // @throws std::runtime_error When `r` makes the radius of curvature be a non
-  //                           positive number.
+  // @throws maliput::common::assertion_error When `r` makes the radius of
+  //         curvature be a non positive number.
   double CalcSFromP(double p, double r) const;
 
   // TODO(hidmic): Fast, analytical methods and the conditions in which these

--- a/multilane/src/multilane/builder.cc
+++ b/multilane/src/multilane/builder.cc
@@ -472,13 +472,13 @@ void Builder::AttachBranchPoint(
       DirectionOutFromLane(old_le.lane, old_le.end, kZeroROffset);
   if (direction.dot(old_direction) > 0.) {
     // Assert continuity before attaching the lane.
-    DRAKE_THROW_UNLESS(IsLaneContinuousAtBranchPoint(
+    MALIPUT_THROW_UNLESS(IsLaneContinuousAtBranchPoint(
         lane, end, bp->GetASide(), bp->GetBSide(),
         angular_tolerance_));
     bp->AddABranch({lane, end});
   } else {
     // Assert continuity before attaching the lane.
-    DRAKE_THROW_UNLESS(IsLaneContinuousAtBranchPoint(
+    MALIPUT_THROW_UNLESS(IsLaneContinuousAtBranchPoint(
         lane, end, bp->GetBSide(), bp->GetASide(),
         angular_tolerance_));
     bp->AddBBranch({lane, end});

--- a/multilane/src/multilane/loader.cc
+++ b/multilane/src/multilane/loader.cc
@@ -14,6 +14,7 @@
 #include "drake/common/text_logging.h"
 
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_throw.h"
 
 #include "multilane/builder.h"
 #include "multilane/connection.h"
@@ -175,7 +176,7 @@ ComputationPolicy ParseComputationPolicy(const YAML::Node& node) {
   if (policy == "prefer-speed") {
     return ComputationPolicy::kPreferSpeed;
   }
-  throw std::runtime_error("Unknown ComputationPolicy");
+  MALIPUT_THROW_MESSAGE("Unknown ComputationPolicy");
 }
 
 // Builds a LaneLayout based `node`'s lane node, the left and right shoulders.
@@ -233,7 +234,7 @@ Direction ResolveDirection(const std::string& direction_key) {
   } else if (direction_key == "reverse") {
     return Direction::kReverse;
   }
-  throw std::runtime_error("Unknown direction_key");
+  MALIPUT_THROW_MESSAGE("Unknown direction_key");
 }
 
 // Returns the Direction that `end_key` sets to the Endpoint / EndpointZ.
@@ -244,7 +245,7 @@ api::LaneEnd::Which ResolveEnd(const std::string& end_key) {
   } else if (end_key == "end") {
     return api::LaneEnd::Which::kFinish;
   }
-  throw std::runtime_error("Unknown end_key");
+  MALIPUT_THROW_MESSAGE("Unknown end_key");
 }
 
 // Returns a ParsedReference structure by extracting keywords from
@@ -280,7 +281,7 @@ ParsedReference ResolveEndpointReference(const std::string& endpoint_key) {
     parsed_reference.lane_id = pieces_match[3].str() == "ref"
         ? drake::nullopt : drake::optional<int>(std::atoi(pieces_match[3].str().c_str()));
   } else {
-    throw std::runtime_error("Unknown endpoint reference");
+    MALIPUT_THROW_MESSAGE("Unknown endpoint reference");
   }
   return parsed_reference;
 }
@@ -363,7 +364,7 @@ drake::optional<std::pair<ParsedAnchorPoint, StartSpec>> ResolveEndpoint(
           parsed_reference.end.value(), parsed_reference.direction);
     }
   } else {
-    throw std::runtime_error("Unknown endpoint");
+    MALIPUT_THROW_MESSAGE("Unknown endpoint");
   }
   return {{parsed_anchor_point, spec}};
 }
@@ -435,10 +436,10 @@ drake::optional<std::pair<ParsedAnchorPoint, EndSpec>> ResolveEndpointZ(
             parsed_reference.end.value(), parsed_reference.direction);
       }
     } else {
-      throw std::runtime_error("Unknown EndpointZ scalar");
+      MALIPUT_THROW_MESSAGE("Unknown EndpointZ scalar");
     }
   } else {
-    throw std::runtime_error("Unknown EndpointZ node type");
+    MALIPUT_THROW_MESSAGE("Unknown EndpointZ node type");
   }
   return {{parsed_anchor_point, spec}};
 }
@@ -547,7 +548,7 @@ const Connection* MaybeMakeConnection(
     }
   }
   MALIPUT_ABORT_MESSAGE("connection type of the start_spec is neither "
-                      "Connection::kArc nor Connection::kLine");
+                        "Connection::kArc nor Connection::kLine");
 }
 
 // Parses a YAML `node` that represents a RoadGeometry.

--- a/multilane/src/multilane/road_curve.cc
+++ b/multilane/src/multilane/road_curve.cc
@@ -3,12 +3,12 @@
 #include <algorithm>
 #include <memory>
 
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/scalar_dense_output.h"
 
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_throw.h"
 
 
 namespace maliput {
@@ -96,8 +96,8 @@ RoadCurve::RoadCurve(double linear_tolerance, double scale_length,
       superelevation_(superelevation),
       computation_policy_(computation_policy) {
   // Enforces preconditions.
-  DRAKE_THROW_UNLESS(scale_length > 0.);
-  DRAKE_THROW_UNLESS(linear_tolerance > 0.);
+  MALIPUT_THROW_UNLESS(scale_length > 0.);
+  MALIPUT_THROW_UNLESS(linear_tolerance > 0.);
   // Sets default parameter value at the beginning of the
   // curve to 0 by default.
   const double initial_p_value = 0.0;
@@ -168,7 +168,7 @@ bool RoadCurve::AreFastComputationsAccurate(double r) const {
 }
 
 std::function<double(double)> RoadCurve::OptimizeCalcSFromP(double r) const {
-  DRAKE_THROW_UNLESS(CalcMinimumRadiusAtOffset(r) > 0.0);
+  MALIPUT_THROW_UNLESS(CalcMinimumRadiusAtOffset(r) > 0.0);
   const double absolute_tolerance = relative_tolerance_ * 1.;
   if (computation_policy() == ComputationPolicy::kPreferAccuracy
       && !AreFastComputationsAccurate(r)) {
@@ -184,14 +184,14 @@ std::function<double(double)> RoadCurve::OptimizeCalcSFromP(double r) const {
     return [dense_output, absolute_tolerance] (double p) -> double {
       // Saturates p to lie within the [0., 1.] interval.
       const double saturated_p = std::min(std::max(p, 0.), 1.);
-      DRAKE_THROW_UNLESS(std::abs(saturated_p - p) < absolute_tolerance);
+      MALIPUT_THROW_UNLESS(std::abs(saturated_p - p) < absolute_tolerance);
       return dense_output->EvaluateScalar(saturated_p);
     };
   }
   return [this, r, absolute_tolerance] (double p) {
     // Saturates p to lie within the [0., 1.] interval.
     const double saturated_p = std::min(std::max(p, 0.), 1.);
-    DRAKE_THROW_UNLESS(std::abs(saturated_p - p) < absolute_tolerance);
+    MALIPUT_THROW_UNLESS(std::abs(saturated_p - p) < absolute_tolerance);
     return this->FastCalcSFromP(p, r);
   };
 }
@@ -204,7 +204,7 @@ double RoadCurve::CalcSFromP(double p, double r) const {
 }
 
 std::function<double(double)> RoadCurve::OptimizeCalcPFromS(double r) const {
-  DRAKE_THROW_UNLESS(CalcMinimumRadiusAtOffset(r) > 0.0);
+  MALIPUT_THROW_UNLESS(CalcMinimumRadiusAtOffset(r) > 0.0);
   const double full_length = CalcSFromP(1., r);
   const double absolute_tolerance = relative_tolerance_ * full_length;
   if (computation_policy() == ComputationPolicy::kPreferAccuracy
@@ -222,14 +222,14 @@ std::function<double(double)> RoadCurve::OptimizeCalcPFromS(double r) const {
             absolute_tolerance] (double s) -> double {
       // Saturates s to lie within the [0., full_length] interval.
       const double saturated_s = std::min(std::max(s, 0.), full_length);
-      DRAKE_THROW_UNLESS(std::abs(saturated_s - s) < absolute_tolerance);
+      MALIPUT_THROW_UNLESS(std::abs(saturated_s - s) < absolute_tolerance);
       return dense_output->EvaluateScalar(saturated_s);
     };
   }
   return [this, r, full_length, absolute_tolerance] (double s) {
     // Saturates s to lie within the [0., full_length] interval.
     const double saturated_s = std::min(std::max(s, 0.), full_length);
-    DRAKE_THROW_UNLESS(std::abs(saturated_s - s) < absolute_tolerance);
+    MALIPUT_THROW_UNLESS(std::abs(saturated_s - s) < absolute_tolerance);
     return this->FastCalcPFromS(s, r);
   };
 }

--- a/multilane/src/multilane_test_utilities/multilane_brute_force_integral.cc
+++ b/multilane/src/multilane_test_utilities/multilane_brute_force_integral.cc
@@ -4,8 +4,10 @@
 #include <cmath>
 #include <limits>
 
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+
+#include "maliput/common/maliput_throw.h"
+
 
 namespace maliput {
 namespace multilane {
@@ -14,10 +16,10 @@ namespace test {
 double BruteForcePathLengthIntegral(const RoadCurve& rc, double p_0, double p_1,
                                     double r, double h, int k_order,
                                     double* maximum_step) {
-  DRAKE_THROW_UNLESS(0. <= p_0);
-  DRAKE_THROW_UNLESS(p_0 <= p_1);
-  DRAKE_THROW_UNLESS(p_1 <= 1.);
-  DRAKE_THROW_UNLESS(k_order >= 0);
+  MALIPUT_THROW_UNLESS(0. <= p_0);
+  MALIPUT_THROW_UNLESS(p_0 <= p_1);
+  MALIPUT_THROW_UNLESS(p_1 <= 1.);
+  MALIPUT_THROW_UNLESS(k_order >= 0);
   double length = 0.0;
   const double d_p = (p_1 - p_0);
   const int iterations = std::pow(2, k_order);
@@ -47,7 +49,7 @@ double BruteForcePathLengthIntegral(const RoadCurve& rc, double p_0, double p_1,
 double AdaptiveBruteForcePathLengthIntegral(
     const RoadCurve& rc, double p_0, double p_1, double r,
     double h, double tolerance, int* k_order_hint) {
-  DRAKE_THROW_UNLESS(tolerance > 0.);
+  MALIPUT_THROW_UNLESS(tolerance > 0.);
   const double kInfinity = std::numeric_limits<double>::infinity();
   // Zero initializes the current k order unless a hint was provided.
   int k_order = k_order_hint != nullptr ? *k_order_hint : 0;

--- a/multilane/test/multilane/multilane_arc_road_curve_test.cc
+++ b/multilane/test/multilane/multilane_arc_road_curve_test.cc
@@ -4,8 +4,10 @@
 
 #include <gtest/gtest.h>
 
-#include "maliput/api/lane_data.h"
 #include "drake/common/eigen_types.h"
+
+#include "maliput/api/lane_data.h"
+#include "maliput/common/assertion_error.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 
 namespace maliput {
@@ -39,26 +41,26 @@ TEST_F(MultilaneArcRoadCurveTest, ConstructorTest) {
   EXPECT_THROW(ArcRoadCurve(kCenter, -kRadius, kTheta0, kDTheta, zp, zp,
                             kLinearTolerance, kScaleLength,
                             kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
                             kZeroTolerance, kScaleLength, kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
                             -kLinearTolerance, kScaleLength,
                             kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
                             kLinearTolerance, -kScaleLength,
                             kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
                             kLinearTolerance, kZeroScaleLength,
                             kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_NO_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
                                kLinearTolerance, kScaleLength,
@@ -83,8 +85,9 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
   // mapping evaluation along the centerline
   std::function<double(double)> p_from_s_at_r0 =
       dut.OptimizeCalcPFromS(kR0Offset);
-  EXPECT_THROW(s_from_p_at_r0(2.), std::runtime_error);
-  EXPECT_THROW(p_from_s_at_r0(2. * centerline_length), std::runtime_error);
+  EXPECT_THROW(s_from_p_at_r0(2.), maliput::common::assertion_error);
+  EXPECT_THROW(p_from_s_at_r0(2. * centerline_length),
+               maliput::common::assertion_error);
   // Checks that both `s` and `p` bounds are enforced on
   // mapping evaluation at an offset
   std::function<double(double)> s_from_p_at_r =
@@ -92,8 +95,9 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
   std::function<double(double)> p_from_s_at_r =
       dut.OptimizeCalcPFromS(kROffset);
   const double offset_line_length = s_from_p_at_r(1.);
-  EXPECT_THROW(s_from_p_at_r(2.), std::runtime_error);
-  EXPECT_THROW(p_from_s_at_r(2. * offset_line_length), std::runtime_error);
+  EXPECT_THROW(s_from_p_at_r(2.), maliput::common::assertion_error);
+  EXPECT_THROW(p_from_s_at_r(2. * offset_line_length),
+               maliput::common::assertion_error);
 
   // Checks the evaluation of xy at different values over the reference curve.
   EXPECT_TRUE(CompareMatrices(
@@ -274,10 +278,14 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
                               kComputationPolicy);
   EXPECT_DOUBLE_EQ(flat_dut.l_max(), kRadius * kDTheta);
   // Checks that functions throw when lateral offset is exceeded.
-  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(2.0 * kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.OptimizeCalcSFromP(2.0 * kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(kRadius),
+               maliput::common::assertion_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(2.0 * kRadius),
+               maliput::common::assertion_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(kRadius),
+               maliput::common::assertion_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcSFromP(2.0 * kRadius),
+               maliput::common::assertion_error);
   // Evaluates inverse function for different path length and offset values.
   for (double r : r_vector) {
     std::function<double(double)> p_from_s_at_r =

--- a/multilane/test/multilane/multilane_builder_test.cc
+++ b/multilane/test/multilane/multilane_builder_test.cc
@@ -10,11 +10,13 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/drake_copyable.h"
+
 #include "maliput/api/lane_data.h"
+#include "maliput/common/assertion_error.h"
 #include "maliput/test_utilities/check_id_indexing.h"
 #include "maliput/test_utilities/maliput_types_compare.h"
 #include "multilane_test_utilities/multilane_types_compare.h"
-#include "drake/common/drake_copyable.h"
 
 namespace maliput {
 namespace multilane {
@@ -1383,7 +1385,7 @@ TEST_P(MultilaneDiscontinuousBuildProcedureTest, ThrowingUponBuild) {
       const std::unique_ptr<const api::RoadGeometry> road_geometry =
           builder.Build(api::RoadGeometryId{"bad_road"});
     },
-    std::runtime_error);
+    maliput::common::assertion_error);
 }
 
 // Returns a collection of BuildProcedure instances that make use

--- a/multilane/test/multilane/multilane_line_road_curve_test.cc
+++ b/multilane/test/multilane/multilane_line_road_curve_test.cc
@@ -6,8 +6,10 @@
 
 #include <gtest/gtest.h>
 
-#include "maliput/api/lane_data.h"
 #include "drake/common/eigen_types.h"
+
+#include "maliput/api/lane_data.h"
+#include "maliput/common/assertion_error.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 
 namespace maliput {
@@ -54,8 +56,9 @@ TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
   // mapping evaluation along the centerline
   std::function<double(double)> p_from_s_at_r0 =
       dut.OptimizeCalcPFromS(kR0Offset);
-  EXPECT_THROW(s_from_p_at_r0(2.), std::runtime_error);
-  EXPECT_THROW(p_from_s_at_r0(2. * centerline_length), std::runtime_error);
+  EXPECT_THROW(s_from_p_at_r0(2.), maliput::common::assertion_error);
+  EXPECT_THROW(p_from_s_at_r0(2. * centerline_length),
+               maliput::common::assertion_error);
   // Checks that both `s` and `p` bounds are enforced on
   // mapping evaluation at an offset
   std::function<double(double)> s_from_p_at_r =
@@ -63,8 +66,9 @@ TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
   std::function<double(double)> p_from_s_at_r =
       dut.OptimizeCalcPFromS(kROffset);
   const double offset_line_length = s_from_p_at_r(1.);
-  EXPECT_THROW(s_from_p_at_r0(2.), std::runtime_error);
-  EXPECT_THROW(p_from_s_at_r0(2. * offset_line_length), std::runtime_error);
+  EXPECT_THROW(s_from_p_at_r0(2.), maliput::common::assertion_error);
+  EXPECT_THROW(p_from_s_at_r0(2. * offset_line_length),
+               maliput::common::assertion_error);
 
   // Check the evaluation of xy at different p values.
   EXPECT_TRUE(
@@ -95,19 +99,19 @@ TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
 TEST_F(MultilaneLineRoadCurveTest, ConstructorTest) {
   EXPECT_THROW(LineRoadCurve(kOrigin, kDirection, zp, zp, -kLinearTolerance,
                              kScaleLength, kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_THROW(LineRoadCurve(kOrigin, kDirection, zp, zp, kZeroTolerance,
                              kScaleLength, kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_THROW(LineRoadCurve(kOrigin, kDirection, zp, zp, kLinearTolerance,
                              -kScaleLength, kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_THROW(LineRoadCurve(kOrigin, kDirection, zp, zp, kLinearTolerance,
                              kZeroScaleLength, kComputationPolicy),
-               std::runtime_error);
+               maliput::common::assertion_error);
 
   EXPECT_NO_THROW(LineRoadCurve(kOrigin, kDirection, zp, zp, kLinearTolerance,
                                 kScaleLength, kComputationPolicy));


### PR DESCRIPTION
Part of #68, and goes on top of #73. 

It migrates `DRAKE_THROW_UNLESS()` to `MALIPUT_THROW_UNLESS()`.