### PR TITLE
Added clang-format/tidy to colcon test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,89 @@
+# Copyright 2019 Toyota Research Institute.  All rights reserved.
+#
+# clang-tidy lists all rules in a single YAML string, which makes it
+# hard to have inline comments.  Thus we'll add comments out-of-line
+# up here.
+#
+# Disabled checks have rationale documented here.
+
+# * cert-err58-cpp - This verifies that exceptions are not thrown
+#   during static initialization or destruction.  However, boost::test
+#   violates this, so we leave it off for now.
+
+# * cert-err60-cpp - This requires that exception types have noexcept
+#   copy constructors.  SystemError could do so, except that it
+#   contains a std::string, which can throw std::bad_alloc.  Hopefully
+#   soon C++ will delete std::bad_alloc entirely, but in the meantime,
+#   we disable this check.
+
+# * cppcoreguidelines-pro-type-vararg,hicpp-vararg - boost::test uses
+#   varargs, so for now we leave this disabled globally
+
+# * cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+#   hicpp-no-array-decay - every call to BOOST_ASSERT_MSG triggers
+#   this along with things like using std::cout
+
+# * cppcoreguidelines-pro-type-reinterpret-cast - we currently have a
+#   lot of reinterpret_casts that are required in order to perform low
+#   level bit manipulation.  It probably isn't worth annotating all of
+#   them yet.
+
+# * cppcoreguidelines-pro-bounds-pointer-arithmetic - until we get
+#   C++20's span or some similar construct, this will be difficult to
+#   satisfy.
+
+# * fuchsia-default-arguments - we currently permit C++ default
+#   arguments
+
+# * fuchsia-multiple-inheritance - we currently permit inheriting
+#   implementation and multiple inheritance
+
+# * fuchsia-overloaded-operator - we (and GSG) consider operator
+#   overloading fine
+
+# * fuchsia-statically-constructed-objects - boost::test uses
+#   statically constructed objects, so we leave this around.
+
+# * google-runtime-references - boost::asio widely uses the convention
+#   of passing io_service by mutable reference, as does the C++
+#   iostreams library
+
+# * hicpp-exception-baseclass - either boost::system::system_error
+#   doesn't inherit from std::exception or clang can't discover that
+#   it does.  In either case, this isn't important enough to figure
+#   out.
+
+# * readability-named-parameter - This requires that all parameters be
+#   named.  This rule seems to be of dubious value, since often the
+#   type alone of an argument is sufficient documentation.
+
+# * readability-redundant-declaration - C++14 requires static
+#   constexpr class members to have a separate definition.  Until we
+#   drop C++14 support, it is easiest to just ignore this warning.
+
+# * performance-unnecessary-copy-initialization,
+#   performance-unnecessary-value-param - These checks seem to be of
+#   dubious value, as the conditions they warn about would all likely
+#   be optimized away by a sane compiler and they require moderate
+#   contortions to satisfy.
+
+Checks: >
+    *,
+    -cert-err58-cpp,
+    -cert-err60-cpp,
+    -cppcoreguidelines-pro-type-vararg,
+    -hicpp-vararg,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+    -hicpp-no-array-decay,
+    -cppcoreguidelines-pro-type-reinterpret-cast,
+    -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+    -fuchsia-default-arguments,
+    -fuchsia-multiple-inheritance,
+    -fuchsia-overloaded-operator,
+    -fuchsia-statically-constructed-objects,
+    -google-runtime-references,
+    -hicpp-exception-baseclass,
+    -readability-named-parameter,
+    -readability-redundant-declaration,
+    -performance-unnecessary-copy-initialization,
+    -performance-unnecessary-value-param,

--- a/dragway/CMakeLists.txt
+++ b/dragway/CMakeLists.txt
@@ -42,6 +42,8 @@ add_subdirectory(src)
 if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
+  add_test(NAME CLANGFORMAT COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_format.sh dragway)
+  # add_test(NAME CLANGTIDY COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_tidy.sh dragway)
 endif()
 
 ##############################################################################

--- a/maliput/CMakeLists.txt
+++ b/maliput/CMakeLists.txt
@@ -42,6 +42,8 @@ ament_environment_hooks(
 if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
+  add_test(NAME CLANGFORMAT COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_format.sh maliput)
+  # add_test(NAME CLANGTIDY COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_tidy.sh maliput)
 endif()
 
 ##############################################################################

--- a/maliput_integration_tests/CMakeLists.txt
+++ b/maliput_integration_tests/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(dragway REQUIRED)
 if (BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
+  add_test(NAME CLANGFORMAT COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_format.sh maliput_integration_tests)
+  # add_test(NAME CLANGTIDY COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_tidy.sh maliput_integration_tests)
 endif()
 
 ament_package()

--- a/maliput_utilities/CMakeLists.txt
+++ b/maliput_utilities/CMakeLists.txt
@@ -41,6 +41,8 @@ add_subdirectory(src)
 if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
+  add_test(NAME CLANGFORMAT COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_format.sh maliput_utilities)
+  # add_test(NAME CLANGTIDY COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_tidy.sh maliput_utilities)
 endif()
 
 ##############################################################################

--- a/multilane/CMakeLists.txt
+++ b/multilane/CMakeLists.txt
@@ -35,6 +35,8 @@ add_subdirectory(resources)
 if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
+  add_test(NAME CLANGFORMAT COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_format.sh multilane)
+  # add_test(NAME CLANGTIDY COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/run_clang_tidy.sh multilane)
 endif()
 
 ##############################################################################

--- a/tools/run_clang_format.sh
+++ b/tools/run_clang_format.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+SCRIPT_PATH=$(realpath ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname $SCRIPT_PATH)
+REPO_DIR=$SCRIPT_DIR/..
+
+export PATH=$PATH:/home/$USER/.local/bin
+
+check_program_installed() {
+  if ! [ -x "$(command -v $1)" ]; then
+    printf "Error: %s was not found in your system.\n" "$1"
+    printf "Please install it by running:\n\n"
+    printf "sudo apt install %s\n\n" "$1"
+    exit 1
+  fi
+}
+
+check_program_installed ament_clang_format
+
+DIR_NAME='./'$1
+REGEX='/.*/.*\.\(c\|cc\|cpp\|cxx\|h\|hh\|hpp\|hxx\)$'
+
+declare -i CLANGFORMATFAILED=0
+
+# Exclude Dirs:
+#  - build/style helper scripts in ./tools
+#  - test helper scripts in test/utils
+#  - entry points in python/examples
+if [ "$CLANGFORMATFAILED" -eq "0" ]; then
+  pushd $REPO_DIR    
+  # Run ament_clang_format
+  find -regex $DIR_NAME$REGEX -printf '%h\n' | sort | uniq | xargs ament_clang_format --config=.clang-format || CLANGFORMATFAILED=1
+  popd
+else
+  echo $'\n*** ament_clang_format failed, not doing style formatting ***'
+  exit 1
+fi
+
+if [ "$CLANGFORMATFAILED" -ne "0" ]; then
+  echo $'\n*** ament_clang_format failed ***'
+  exit 1
+fi
+

--- a/tools/run_clang_tidy.sh
+++ b/tools/run_clang_tidy.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+SCRIPT_PATH=$(realpath ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname $SCRIPT_PATH)
+REPO_DIR=$SCRIPT_DIR/..
+
+export PATH=$PATH:/home/$USER/.local/bin
+
+check_program_installed() {
+  if ! [ -x "$(command -v $1)" ]; then
+    printf "Error: %s was not found in your system.\n" "$1"
+    printf "Please install it by running:\n\n"
+    printf "sudo apt install %s\n\n" "$1"
+    exit 1
+  fi
+}
+
+check_program_installed ament_clang_tidy
+
+DIR_NAME='./'$1
+REGEX='/.*/.*\.\(c\|cc\|cpp\|cxx\|h\|hh\|hpp\|hxx\)$'
+
+declare -i CLANGTIDYFAILED=0
+
+# Exclude Dirs:
+#  - build/style helper scripts in ./tools
+#  - test helper scripts in test/utils
+#  - entry points in python/examples
+if [ "$CLANGTIDYFAILED" -eq "0" ]; then
+  pushd $REPO_DIR    
+  # Run ament_clang_tidy
+  find -regex $DIR_NAME$REGEX -printf '%h\n' | sort | uniq | xargs ament_clang_tidy --config=.clang-tidy || CLANGTIDYFAILED=1
+  popd
+else
+  echo $'\n*** ament_clang_tidy failed, not doing style formatting ***'
+  exit 1
+fi
+
+if [ "$CLANGTIDYFAILED" -ne "0" ]; then
+  echo $'\n*** ament_clang_tidy failed ***'
+  exit 1
+fi
+


### PR DESCRIPTION
Add `ament-clang-format` utility to colcon test for maliput packages.  