### PR TITLE
Adds RuleRegistry to RoadNetwork.

### DIFF
--- a/maliput/include/maliput/api/road_network.h
+++ b/maliput/include/maliput/api/road_network.h
@@ -11,6 +11,7 @@
 #include "maliput/api/rules/phase_ring_book.h"
 #include "maliput/api/rules/right_of_way_rule_state_provider.h"
 #include "maliput/api/rules/road_rulebook.h"
+#include "maliput/api/rules/rule_registry.h"
 #include "maliput/api/rules/speed_limit_rule.h"
 #include "maliput/api/rules/traffic_light_book.h"
 
@@ -33,7 +34,7 @@ class RoadNetwork {
               std::unique_ptr<IntersectionBook> intersection_book,
               std::unique_ptr<rules::PhaseRingBook> phase_ring_book,
               std::unique_ptr<rules::RightOfWayRuleStateProvider> right_of_way_rule_state_provider,
-              std::unique_ptr<rules::PhaseProvider> phase_provider);
+              std::unique_ptr<rules::PhaseProvider> phase_provider, std::unique_ptr<rules::RuleRegistry> rule_registry);
 
   virtual ~RoadNetwork() = default;
 
@@ -53,6 +54,8 @@ class RoadNetwork {
 
   const rules::PhaseProvider* phase_provider() const { return phase_provider_.get(); }
 
+  const rules::RuleRegistry* rule_registry() const { return rule_registry_.get(); }
+
  private:
   std::unique_ptr<const RoadGeometry> road_geometry_;
   std::unique_ptr<const rules::RoadRulebook> rulebook_;
@@ -61,6 +64,7 @@ class RoadNetwork {
   std::unique_ptr<rules::PhaseRingBook> phase_ring_book_;
   std::unique_ptr<rules::RightOfWayRuleStateProvider> right_of_way_rule_state_provider_;
   std::unique_ptr<rules::PhaseProvider> phase_provider_;
+  std::unique_ptr<rules::RuleRegistry> rule_registry_;
 };
 
 }  // namespace api

--- a/maliput/include/maliput/test_utilities/mock.h
+++ b/maliput/include/maliput/test_utilities/mock.h
@@ -14,6 +14,7 @@
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/right_of_way_rule_state_provider.h"
 #include "maliput/api/rules/road_rulebook.h"
+#include "maliput/api/rules/rule_registry.h"
 #include "maliput/api/rules/traffic_light_book.h"
 
 namespace maliput {
@@ -189,6 +190,9 @@ std::unique_ptr<rules::PhaseProvider> CreatePhaseProvider();
 
 /// Returns an arbitrary IntersectionBook.
 std::unique_ptr<IntersectionBook> CreateIntersectionBook();
+
+/// Returns an arbitrary rules::RuleRegistry.
+std::unique_ptr<rules::RuleRegistry> CreateRuleRegistry();
 
 }  // namespace test
 }  // namespace api

--- a/maliput/src/api/road_network.cc
+++ b/maliput/src/api/road_network.cc
@@ -15,14 +15,16 @@ RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
                          std::unique_ptr<IntersectionBook> intersection_book,
                          std::unique_ptr<rules::PhaseRingBook> phase_ring_book,
                          std::unique_ptr<rules::RightOfWayRuleStateProvider> right_of_way_rule_state_provider,
-                         std::unique_ptr<rules::PhaseProvider> phase_provider)
+                         std::unique_ptr<rules::PhaseProvider> phase_provider,
+                         std::unique_ptr<rules::RuleRegistry> rule_registry)
     : road_geometry_(std::move(road_geometry)),
       rulebook_(std::move(rulebook)),
       traffic_light_book_(std::move(traffic_light_book)),
       intersection_book_(std::move(intersection_book)),
       phase_ring_book_(std::move(phase_ring_book)),
       right_of_way_rule_state_provider_(std::move(right_of_way_rule_state_provider)),
-      phase_provider_(std::move(phase_provider)) {
+      phase_provider_(std::move(phase_provider)),
+      rule_registry_(std::move(rule_registry)) {
   MALIPUT_THROW_UNLESS(road_geometry_.get() != nullptr);
   MALIPUT_THROW_UNLESS(rulebook_.get() != nullptr);
   MALIPUT_THROW_UNLESS(traffic_light_book_.get() != nullptr);
@@ -30,6 +32,7 @@ RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
   MALIPUT_THROW_UNLESS(phase_ring_book_.get() != nullptr);
   MALIPUT_THROW_UNLESS(right_of_way_rule_state_provider_.get() != nullptr);
   MALIPUT_THROW_UNLESS(phase_provider_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(rule_registry_.get() != nullptr);
 }
 
 }  // namespace api

--- a/maliput/src/test_utilities/mock.cc
+++ b/maliput/src/test_utilities/mock.cc
@@ -563,6 +563,8 @@ std::unique_ptr<rules::PhaseProvider> CreatePhaseProvider() { return std::make_u
 
 std::unique_ptr<IntersectionBook> CreateIntersectionBook() { return std::make_unique<MockIntersectionBook>(); }
 
+std::unique_ptr<rules::RuleRegistry> CreateRuleRegistry() { return std::make_unique<rules::RuleRegistry>(); }
+
 }  // namespace test
 }  // namespace api
 }  // namespace maliput

--- a/maliput/test/api/road_network_test.cc
+++ b/maliput/test/api/road_network_test.cc
@@ -17,6 +17,8 @@ using rules::PhaseProvider;
 using rules::PhaseRingBook;
 using rules::RightOfWayRuleStateProvider;
 using rules::RoadRulebook;
+using rules::Rule;
+using rules::RuleRegistry;
 using rules::SpeedLimitRule;
 using rules::TrafficLightBook;
 
@@ -30,6 +32,7 @@ class RoadNetworkTest : public ::testing::Test {
     phase_ring_book_ = test::CreatePhaseRingBook();
     right_of_way_rule_state_provider_ = test::CreateRightOfWayRuleStateProvider();
     phase_provider_ = test::CreatePhaseProvider();
+    rule_registry_ = test::CreateRuleRegistry();
 
     road_geometry_ptr_ = road_geometry_.get();
     road_rulebook_ptr_ = road_rulebook_.get();
@@ -38,6 +41,7 @@ class RoadNetworkTest : public ::testing::Test {
     phase_ring_book_ptr_ = phase_ring_book_.get();
     right_of_way_rule_state_provider_ptr_ = right_of_way_rule_state_provider_.get();
     phase_provider_ptr_ = phase_provider_.get();
+    rule_registry_ptr_ = rule_registry_.get();
   }
 
   std::unique_ptr<RoadGeometry> road_geometry_;
@@ -47,6 +51,7 @@ class RoadNetworkTest : public ::testing::Test {
   std::unique_ptr<PhaseRingBook> phase_ring_book_;
   std::unique_ptr<RightOfWayRuleStateProvider> right_of_way_rule_state_provider_;
   std::unique_ptr<PhaseProvider> phase_provider_;
+  std::unique_ptr<RuleRegistry> rule_registry_;
 
   RoadGeometry* road_geometry_ptr_{};
   RoadRulebook* road_rulebook_ptr_{};
@@ -55,43 +60,50 @@ class RoadNetworkTest : public ::testing::Test {
   PhaseRingBook* phase_ring_book_ptr_{};
   RightOfWayRuleStateProvider* right_of_way_rule_state_provider_ptr_{};
   PhaseProvider* phase_provider_ptr_{};
+  RuleRegistry* rule_registry_ptr_{};
 };
 
 TEST_F(RoadNetworkTest, MissingParameters) {
-  EXPECT_THROW(RoadNetwork(nullptr, std::move(road_rulebook_), std::move(traffic_light_book_),
-                           std::move(intersection_book_), std::move(phase_ring_book_),
-                           std::move(right_of_way_rule_state_provider_), std::move(phase_provider_)),
-               std::exception);
-  EXPECT_THROW(RoadNetwork(std::move(road_geometry_), nullptr, std::move(traffic_light_book_),
-                           std::move(intersection_book_), std::move(phase_ring_book_),
-                           std::move(right_of_way_rule_state_provider_), std::move(phase_provider_)),
-               std::exception);
+  EXPECT_THROW(
+      RoadNetwork(nullptr, std::move(road_rulebook_), std::move(traffic_light_book_), std::move(intersection_book_),
+                  std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_), std::move(phase_provider_),
+                  std::move(rule_registry_)),
+      std::exception);
+  EXPECT_THROW(
+      RoadNetwork(std::move(road_geometry_), nullptr, std::move(traffic_light_book_), std::move(intersection_book_),
+                  std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_), std::move(phase_provider_),
+                  std::move(rule_registry_)),
+      std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), nullptr, std::move(intersection_book_),
                            std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_),
-                           std::move(phase_provider_)),
+                           std::move(phase_provider_), std::move(rule_registry_)),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            nullptr, std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_),
-                           std::move(phase_provider_)),
+                           std::move(phase_provider_), std::move(rule_registry_)),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            std::move(intersection_book_), nullptr, std::move(right_of_way_rule_state_provider_),
-                           std::move(phase_provider_)),
+                           std::move(phase_provider_), std::move(rule_registry_)),
                std::exception);
-  EXPECT_THROW(
-      RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
-                  std::move(intersection_book_), std::move(phase_ring_book_), nullptr, std::move(phase_provider_)),
-      std::exception);
+  EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
+                           std::move(intersection_book_), std::move(phase_ring_book_), nullptr,
+                           std::move(phase_provider_), std::move(rule_registry_)),
+               std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            std::move(intersection_book_), std::move(phase_ring_book_),
-                           std::move(right_of_way_rule_state_provider_), nullptr),
+                           std::move(right_of_way_rule_state_provider_), nullptr, std::move(rule_registry_)),
+               std::exception);
+  EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
+                           std::move(intersection_book_), std::move(phase_ring_book_),
+                           std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), nullptr),
                std::exception);
 }
 
 TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
   RoadNetwork dut(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                   std::move(intersection_book_), std::move(phase_ring_book_),
-                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_));
+                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), std::move(rule_registry_));
 
   EXPECT_EQ(dut.road_geometry(), road_geometry_ptr_);
   EXPECT_EQ(dut.rulebook(), road_rulebook_ptr_);
@@ -100,11 +112,13 @@ TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
   EXPECT_EQ(dut.phase_ring_book(), phase_ring_book_ptr_);
   EXPECT_EQ(dut.right_of_way_rule_state_provider(), right_of_way_rule_state_provider_ptr_);
   EXPECT_EQ(dut.phase_provider(), phase_provider_ptr_);
+  EXPECT_EQ(dut.rule_registry(), rule_registry_ptr_);
 }
+
 TEST_F(RoadNetworkTest, TestMemberMethodAccess) {
   RoadNetwork dut(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                   std::move(intersection_book_), std::move(phase_ring_book_),
-                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_));
+                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), std::move(rule_registry_));
 
   auto intersection = dut.intersection_book()->GetIntersection(Intersection::Id("Mock"));
   EXPECT_NE(intersection, nullptr);
@@ -115,6 +129,7 @@ TEST_F(RoadNetworkTest, TestMemberMethodAccess) {
   dut.phase_ring_book()->GetPhaseRing(rules::PhaseRing::Id("Mock"));
   dut.right_of_way_rule_state_provider()->GetState(rules::RightOfWayRule::Id("Mock"));
   dut.phase_provider()->GetPhase(rules::PhaseRing::Id("Mock"));
+  dut.rule_registry()->GetPossibleStatesOfRuleType(rules::Rule::TypeId("Mock"));
 }
 
 }  // namespace

--- a/maliput/test/api/road_network_validator_test.cc
+++ b/maliput/test/api/road_network_validator_test.cc
@@ -29,7 +29,8 @@ using rules::TrafficLightBook;
 GTEST_TEST(RoadNetworkValidatorTest, RuleCoverageTest) {
   RoadNetwork road_network(test::CreateOneLaneRoadGeometry(), test::CreateRoadRulebook(),
                            test::CreateTrafficLightBook(), test::CreateIntersectionBook(), test::CreatePhaseRingBook(),
-                           test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider());
+                           test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider(),
+                           test::CreateRuleRegistry());
 
   RoadNetworkValidatorOptions options{true /* check_direction_usage_rule_coverage */,
                                       false /* check_road_geometry_invariants */,
@@ -68,7 +69,8 @@ std::vector<RoadGeometryBuildFlags> HierarchyTestParameters() {
 TEST_P(RoadGeometryHierarchyTest, HierarchyTestThrows) {
   RoadNetwork road_network(CreateRoadGeometry(build_flags_), test::CreateRoadRulebook(), test::CreateTrafficLightBook(),
                            test::CreateIntersectionBook(), test::CreatePhaseRingBook(),
-                           test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider());
+                           test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider(),
+                           test::CreateRuleRegistry());
 
   const RoadNetworkValidatorOptions options{
       false /* check_direction_usage_rule_coverage */, false /* check_road_geometry_invariants */,
@@ -122,7 +124,8 @@ TEST_P(RelatedBulbGroupsTest, ChecksRelatedBulGroupsRelation) {
   RoadNetwork road_network(CreateRoadGeometry(), test::CreateRoadRulebook(build_flags_.rulebook_build_flags),
                            test::CreateTrafficLightBook(build_flags_.traffic_light_book_build_flags),
                            test::CreateIntersectionBook(), test::CreatePhaseRingBook(),
-                           test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider());
+                           test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider(),
+                           test::CreateRuleRegistry());
 
   const RoadNetworkValidatorOptions options{
       false /* check_direction_usage_rule_coverage */, false /* check_road_geometry_invariants */,


### PR DESCRIPTION
Parent meta issue: #108 

Towards integrating new rule API with the rest of maliput entities, this PR makes `RuleRegistry` a first-class citizen of `RoadNetwork`.