### PR TITLE
Adds new RuleStateProviders to RoadNetwork.

### DIFF
--- a/maliput/include/maliput/api/road_network.h
+++ b/maliput/include/maliput/api/road_network.h
@@ -7,8 +7,10 @@
 #include "maliput/api/intersection_book.h"
 #include "maliput/api/road_geometry.h"
 #include "maliput/api/rules/direction_usage_rule.h"
+#include "maliput/api/rules/discrete_value_rule_state_provider.h"
 #include "maliput/api/rules/phase_provider.h"
 #include "maliput/api/rules/phase_ring_book.h"
+#include "maliput/api/rules/range_value_rule_state_provider.h"
 #include "maliput/api/rules/right_of_way_rule_state_provider.h"
 #include "maliput/api/rules/road_rulebook.h"
 #include "maliput/api/rules/rule_registry.h"
@@ -34,7 +36,9 @@ class RoadNetwork {
               std::unique_ptr<IntersectionBook> intersection_book,
               std::unique_ptr<rules::PhaseRingBook> phase_ring_book,
               std::unique_ptr<rules::RightOfWayRuleStateProvider> right_of_way_rule_state_provider,
-              std::unique_ptr<rules::PhaseProvider> phase_provider, std::unique_ptr<rules::RuleRegistry> rule_registry);
+              std::unique_ptr<rules::PhaseProvider> phase_provider, std::unique_ptr<rules::RuleRegistry> rule_registry,
+              std::unique_ptr<rules::DiscreteValueRuleStateProvider> discrete_value_rule_state_provider,
+              std::unique_ptr<rules::RangeValueRuleStateProvider> range_value_rule_state_provider);
 
   virtual ~RoadNetwork() = default;
 
@@ -56,6 +60,14 @@ class RoadNetwork {
 
   const rules::RuleRegistry* rule_registry() const { return rule_registry_.get(); }
 
+  const rules::DiscreteValueRuleStateProvider* discrete_value_rule_state_provider() const {
+    return discrete_value_rule_state_provider_.get();
+  }
+
+  const rules::RangeValueRuleStateProvider* range_value_rule_state_provider() const {
+    return range_value_rule_state_provider_.get();
+  }
+
  private:
   std::unique_ptr<const RoadGeometry> road_geometry_;
   std::unique_ptr<const rules::RoadRulebook> rulebook_;
@@ -65,6 +77,8 @@ class RoadNetwork {
   std::unique_ptr<rules::RightOfWayRuleStateProvider> right_of_way_rule_state_provider_;
   std::unique_ptr<rules::PhaseProvider> phase_provider_;
   std::unique_ptr<rules::RuleRegistry> rule_registry_;
+  std::unique_ptr<rules::DiscreteValueRuleStateProvider> discrete_value_rule_state_provider_;
+  std::unique_ptr<rules::RangeValueRuleStateProvider> range_value_rule_state_provider_;
 };
 
 }  // namespace api

--- a/maliput/include/maliput/test_utilities/mock.h
+++ b/maliput/include/maliput/test_utilities/mock.h
@@ -7,10 +7,12 @@
 #include "maliput/api/road_geometry.h"
 #include "maliput/api/rules/direction_usage_rule.h"
 #include "maliput/api/rules/discrete_value_rule.h"
+#include "maliput/api/rules/discrete_value_rule_state_provider.h"
 #include "maliput/api/rules/phase_provider.h"
 #include "maliput/api/rules/phase_ring.h"
 #include "maliput/api/rules/phase_ring_book.h"
 #include "maliput/api/rules/range_value_rule.h"
+#include "maliput/api/rules/range_value_rule_state_provider.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/right_of_way_rule_state_provider.h"
 #include "maliput/api/rules/road_rulebook.h"
@@ -199,6 +201,12 @@ std::unique_ptr<IntersectionBook> CreateIntersectionBook();
 
 /// Returns an arbitrary rules::RuleRegistry.
 std::unique_ptr<rules::RuleRegistry> CreateRuleRegistry();
+
+/// Returns an arbitrary rules::DiscreteValueRuleStateProvider.
+std::unique_ptr<rules::DiscreteValueRuleStateProvider> CreateDiscreteValueRuleStateProvider();
+
+/// Returns an arbitrary rules::RangeValueRuleStateProvider.
+std::unique_ptr<rules::RangeValueRuleStateProvider> CreateRangeValueRuleStateProvider();
 
 }  // namespace test
 }  // namespace api

--- a/maliput/src/api/road_network.cc
+++ b/maliput/src/api/road_network.cc
@@ -16,7 +16,9 @@ RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
                          std::unique_ptr<rules::PhaseRingBook> phase_ring_book,
                          std::unique_ptr<rules::RightOfWayRuleStateProvider> right_of_way_rule_state_provider,
                          std::unique_ptr<rules::PhaseProvider> phase_provider,
-                         std::unique_ptr<rules::RuleRegistry> rule_registry)
+                         std::unique_ptr<rules::RuleRegistry> rule_registry,
+                         std::unique_ptr<rules::DiscreteValueRuleStateProvider> discrete_value_rule_state_provider,
+                         std::unique_ptr<rules::RangeValueRuleStateProvider> range_value_rule_state_provider)
     : road_geometry_(std::move(road_geometry)),
       rulebook_(std::move(rulebook)),
       traffic_light_book_(std::move(traffic_light_book)),
@@ -24,7 +26,9 @@ RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
       phase_ring_book_(std::move(phase_ring_book)),
       right_of_way_rule_state_provider_(std::move(right_of_way_rule_state_provider)),
       phase_provider_(std::move(phase_provider)),
-      rule_registry_(std::move(rule_registry)) {
+      rule_registry_(std::move(rule_registry)),
+      discrete_value_rule_state_provider_(std::move(discrete_value_rule_state_provider)),
+      range_value_rule_state_provider_(std::move(range_value_rule_state_provider)) {
   MALIPUT_THROW_UNLESS(road_geometry_.get() != nullptr);
   MALIPUT_THROW_UNLESS(rulebook_.get() != nullptr);
   MALIPUT_THROW_UNLESS(traffic_light_book_.get() != nullptr);
@@ -33,6 +37,8 @@ RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
   MALIPUT_THROW_UNLESS(right_of_way_rule_state_provider_.get() != nullptr);
   MALIPUT_THROW_UNLESS(phase_provider_.get() != nullptr);
   MALIPUT_THROW_UNLESS(rule_registry_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(discrete_value_rule_state_provider_.get() != nullptr);
+  MALIPUT_THROW_UNLESS(range_value_rule_state_provider_.get() != nullptr);
 }
 
 }  // namespace api

--- a/maliput/src/test_utilities/mock.cc
+++ b/maliput/src/test_utilities/mock.cc
@@ -409,6 +409,28 @@ class MockIntersectionBook final : public IntersectionBook {
   MockIntersection intersection_;
 };
 
+class MockDiscreteValueRuleStateProvider : public rules::DiscreteValueRuleStateProvider {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockDiscreteValueRuleStateProvider);
+  MockDiscreteValueRuleStateProvider() = default;
+
+ private:
+  drake::optional<rules::DiscreteValueRuleStateProvider::StateResult> DoGetState(const Rule::Id&) const override {
+    return drake::nullopt;
+  }
+};
+
+class MockRangeValueRuleStateProvider : public rules::RangeValueRuleStateProvider {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockRangeValueRuleStateProvider);
+  MockRangeValueRuleStateProvider() = default;
+
+ private:
+  drake::optional<rules::RangeValueRuleStateProvider::StateResult> DoGetState(const Rule::Id&) const override {
+    return drake::nullopt;
+  }
+};
+
 }  // namespace
 
 LaneSRoute CreateLaneSRoute() {
@@ -581,6 +603,14 @@ std::unique_ptr<rules::PhaseProvider> CreatePhaseProvider() { return std::make_u
 std::unique_ptr<IntersectionBook> CreateIntersectionBook() { return std::make_unique<MockIntersectionBook>(); }
 
 std::unique_ptr<rules::RuleRegistry> CreateRuleRegistry() { return std::make_unique<rules::RuleRegistry>(); }
+
+std::unique_ptr<rules::DiscreteValueRuleStateProvider> CreateDiscreteValueRuleStateProvider() {
+  return std::make_unique<MockDiscreteValueRuleStateProvider>();
+}
+
+std::unique_ptr<rules::RangeValueRuleStateProvider> CreateRangeValueRuleStateProvider() {
+  return std::make_unique<MockRangeValueRuleStateProvider>();
+}
 
 }  // namespace test
 }  // namespace api

--- a/maliput/test/api/road_network_test.cc
+++ b/maliput/test/api/road_network_test.cc
@@ -13,8 +13,10 @@ namespace api {
 namespace {
 
 using rules::DirectionUsageRule;
+using rules::DiscreteValueRuleStateProvider;
 using rules::PhaseProvider;
 using rules::PhaseRingBook;
+using rules::RangeValueRuleStateProvider;
 using rules::RightOfWayRuleStateProvider;
 using rules::RoadRulebook;
 using rules::Rule;
@@ -33,6 +35,8 @@ class RoadNetworkTest : public ::testing::Test {
     right_of_way_rule_state_provider_ = test::CreateRightOfWayRuleStateProvider();
     phase_provider_ = test::CreatePhaseProvider();
     rule_registry_ = test::CreateRuleRegistry();
+    discrete_value_rule_state_provider_ = test::CreateDiscreteValueRuleStateProvider();
+    range_value_rule_state_provider_ = test::CreateRangeValueRuleStateProvider();
 
     road_geometry_ptr_ = road_geometry_.get();
     road_rulebook_ptr_ = road_rulebook_.get();
@@ -42,6 +46,8 @@ class RoadNetworkTest : public ::testing::Test {
     right_of_way_rule_state_provider_ptr_ = right_of_way_rule_state_provider_.get();
     phase_provider_ptr_ = phase_provider_.get();
     rule_registry_ptr_ = rule_registry_.get();
+    discrete_value_rule_state_provider_ptr_ = discrete_value_rule_state_provider_.get();
+    range_value_rule_state_provider_ptr_ = range_value_rule_state_provider_.get();
   }
 
   std::unique_ptr<RoadGeometry> road_geometry_;
@@ -52,6 +58,8 @@ class RoadNetworkTest : public ::testing::Test {
   std::unique_ptr<RightOfWayRuleStateProvider> right_of_way_rule_state_provider_;
   std::unique_ptr<PhaseProvider> phase_provider_;
   std::unique_ptr<RuleRegistry> rule_registry_;
+  std::unique_ptr<DiscreteValueRuleStateProvider> discrete_value_rule_state_provider_;
+  std::unique_ptr<RangeValueRuleStateProvider> range_value_rule_state_provider_;
 
   RoadGeometry* road_geometry_ptr_{};
   RoadRulebook* road_rulebook_ptr_{};
@@ -61,49 +69,70 @@ class RoadNetworkTest : public ::testing::Test {
   RightOfWayRuleStateProvider* right_of_way_rule_state_provider_ptr_{};
   PhaseProvider* phase_provider_ptr_{};
   RuleRegistry* rule_registry_ptr_{};
+  DiscreteValueRuleStateProvider* discrete_value_rule_state_provider_ptr_{};
+  RangeValueRuleStateProvider* range_value_rule_state_provider_ptr_{};
 };
 
 TEST_F(RoadNetworkTest, MissingParameters) {
   EXPECT_THROW(
       RoadNetwork(nullptr, std::move(road_rulebook_), std::move(traffic_light_book_), std::move(intersection_book_),
                   std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_), std::move(phase_provider_),
-                  std::move(rule_registry_)),
+                  std::move(rule_registry_), std::move(discrete_value_rule_state_provider_),
+                  std::move(range_value_rule_state_provider_)),
       std::exception);
   EXPECT_THROW(
       RoadNetwork(std::move(road_geometry_), nullptr, std::move(traffic_light_book_), std::move(intersection_book_),
                   std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_), std::move(phase_provider_),
-                  std::move(rule_registry_)),
+                  std::move(rule_registry_), std::move(discrete_value_rule_state_provider_),
+                  std::move(range_value_rule_state_provider_)),
       std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), nullptr, std::move(intersection_book_),
                            std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_),
-                           std::move(phase_provider_), std::move(rule_registry_)),
+                           std::move(phase_provider_), std::move(rule_registry_),
+                           std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_)),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            nullptr, std::move(phase_ring_book_), std::move(right_of_way_rule_state_provider_),
-                           std::move(phase_provider_), std::move(rule_registry_)),
+                           std::move(phase_provider_), std::move(rule_registry_),
+                           std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_)),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            std::move(intersection_book_), nullptr, std::move(right_of_way_rule_state_provider_),
-                           std::move(phase_provider_), std::move(rule_registry_)),
+                           std::move(phase_provider_), std::move(rule_registry_),
+                           std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_)),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            std::move(intersection_book_), std::move(phase_ring_book_), nullptr,
-                           std::move(phase_provider_), std::move(rule_registry_)),
+                           std::move(phase_provider_), std::move(rule_registry_),
+                           std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_)),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            std::move(intersection_book_), std::move(phase_ring_book_),
-                           std::move(right_of_way_rule_state_provider_), nullptr, std::move(rule_registry_)),
+                           std::move(right_of_way_rule_state_provider_), nullptr, std::move(rule_registry_),
+                           std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_)),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                            std::move(intersection_book_), std::move(phase_ring_book_),
-                           std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), nullptr),
+                           std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), nullptr,
+                           std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_)),
+               std::exception);
+  EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
+                           std::move(intersection_book_), std::move(phase_ring_book_),
+                           std::move(right_of_way_rule_state_provider_), std::move(phase_provider_),
+                           std::move(rule_registry_), nullptr, std::move(range_value_rule_state_provider_)),
+               std::exception);
+  EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
+                           std::move(intersection_book_), std::move(phase_ring_book_),
+                           std::move(right_of_way_rule_state_provider_), std::move(phase_provider_),
+                           std::move(rule_registry_), std::move(discrete_value_rule_state_provider_), nullptr),
                std::exception);
 }
 
 TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
   RoadNetwork dut(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                   std::move(intersection_book_), std::move(phase_ring_book_),
-                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), std::move(rule_registry_));
+                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), std::move(rule_registry_),
+                  std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_));
 
   EXPECT_EQ(dut.road_geometry(), road_geometry_ptr_);
   EXPECT_EQ(dut.rulebook(), road_rulebook_ptr_);
@@ -113,12 +142,15 @@ TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
   EXPECT_EQ(dut.right_of_way_rule_state_provider(), right_of_way_rule_state_provider_ptr_);
   EXPECT_EQ(dut.phase_provider(), phase_provider_ptr_);
   EXPECT_EQ(dut.rule_registry(), rule_registry_ptr_);
+  EXPECT_EQ(dut.discrete_value_rule_state_provider(), discrete_value_rule_state_provider_ptr_);
+  EXPECT_EQ(dut.range_value_rule_state_provider(), range_value_rule_state_provider_ptr_);
 }
 
 TEST_F(RoadNetworkTest, TestMemberMethodAccess) {
   RoadNetwork dut(std::move(road_geometry_), std::move(road_rulebook_), std::move(traffic_light_book_),
                   std::move(intersection_book_), std::move(phase_ring_book_),
-                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), std::move(rule_registry_));
+                  std::move(right_of_way_rule_state_provider_), std::move(phase_provider_), std::move(rule_registry_),
+                  std::move(discrete_value_rule_state_provider_), std::move(range_value_rule_state_provider_));
 
   auto intersection = dut.intersection_book()->GetIntersection(Intersection::Id("Mock"));
   EXPECT_NE(intersection, nullptr);
@@ -130,6 +162,8 @@ TEST_F(RoadNetworkTest, TestMemberMethodAccess) {
   dut.right_of_way_rule_state_provider()->GetState(rules::RightOfWayRule::Id("Mock"));
   dut.phase_provider()->GetPhase(rules::PhaseRing::Id("Mock"));
   dut.rule_registry()->GetPossibleStatesOfRuleType(rules::Rule::TypeId("Mock"));
+  dut.discrete_value_rule_state_provider()->GetState(rules::Rule::Id("Mock"));
+  dut.range_value_rule_state_provider()->GetState(rules::Rule::Id("Mock"));
 }
 
 }  // namespace

--- a/maliput/test/api/road_network_validator_test.cc
+++ b/maliput/test/api/road_network_validator_test.cc
@@ -30,7 +30,8 @@ GTEST_TEST(RoadNetworkValidatorTest, RuleCoverageTest) {
   RoadNetwork road_network(test::CreateOneLaneRoadGeometry(), test::CreateRoadRulebook(),
                            test::CreateTrafficLightBook(), test::CreateIntersectionBook(), test::CreatePhaseRingBook(),
                            test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider(),
-                           test::CreateRuleRegistry());
+                           test::CreateRuleRegistry(), test::CreateDiscreteValueRuleStateProvider(),
+                           test::CreateRangeValueRuleStateProvider());
 
   RoadNetworkValidatorOptions options{true /* check_direction_usage_rule_coverage */,
                                       false /* check_road_geometry_invariants */,
@@ -70,7 +71,8 @@ TEST_P(RoadGeometryHierarchyTest, HierarchyTestThrows) {
   RoadNetwork road_network(CreateRoadGeometry(build_flags_), test::CreateRoadRulebook(), test::CreateTrafficLightBook(),
                            test::CreateIntersectionBook(), test::CreatePhaseRingBook(),
                            test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider(),
-                           test::CreateRuleRegistry());
+                           test::CreateRuleRegistry(), test::CreateDiscreteValueRuleStateProvider(),
+                           test::CreateRangeValueRuleStateProvider());
 
   const RoadNetworkValidatorOptions options{
       false /* check_direction_usage_rule_coverage */, false /* check_road_geometry_invariants */,
@@ -125,7 +127,8 @@ TEST_P(RelatedBulbGroupsTest, ChecksRelatedBulGroupsRelation) {
                            test::CreateTrafficLightBook(build_flags_.traffic_light_book_build_flags),
                            test::CreateIntersectionBook(), test::CreatePhaseRingBook(),
                            test::CreateRightOfWayRuleStateProvider(), test::CreatePhaseProvider(),
-                           test::CreateRuleRegistry());
+                           test::CreateRuleRegistry(), test::CreateDiscreteValueRuleStateProvider(),
+                           test::CreateRangeValueRuleStateProvider());
 
   const RoadNetworkValidatorOptions options{
       false /* check_direction_usage_rule_coverage */, false /* check_road_geometry_invariants */,


### PR DESCRIPTION
Parent meta issue: #108

Towards integrating new rule API with the rest of maliput entities, this PR makes `DiscreteValueRuleStateProvider` and `RangeValueRuleStateProvider` first-class citizens of `RoadNetwork`.