### PR TITLE
Add pybind11-dev as a package.xml dependency.

### DIFF
--- a/dragway/package.xml
+++ b/dragway/package.xml
@@ -12,7 +12,7 @@
   <depend>drake_vendor</depend>
   <depend>maliput</depend>
   <depend>maliput-utilities</depend>
-  <depend>pybind11</depend>
+  <depend>pybind11-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/maliput/package.xml
+++ b/maliput/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>drake_vendor</depend>
-  <depend>pybind11</depend>
+  <depend>pybind11-dev</depend>
   <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
Connected to https://github.com/ToyotaResearchInstitute/dsim-repos-index/pull/111.