### PR TITLE
Adds BulbGroup to RelatedUniqueIds of Right-Of-Way rules. (#183)

### DIFF
--- a/maliput/include/maliput/base/rule_registry.h
+++ b/maliput/include/maliput/base/rule_registry.h
@@ -87,4 +87,7 @@ api::rules::DiscreteValueRuleTypeAndValues BuildVehicleStopInZoneBehaviorRuleTyp
 /// by Right-Of-Way rules to yield to other rules.
 std::string RightOfWayYieldGroup();
 
+/// Returns "BulbGroupIds", which is the key to the `Rules::RelatedUniqueIds` of Right-Of-Way rules.
+std::string RightOfWayBulbGroup();
+
 }  // namespace maliput

--- a/maliput/src/api/rules/rule.cc
+++ b/maliput/src/api/rules/rule.cc
@@ -19,7 +19,7 @@ bool CompareMapAttributes(const std::map<std::string, std::vector<T>>& map_a,
     if (it == map_b.end()) {
       false;
     }
-    for (const auto value_id : key_val.second) {
+    for (const auto& value_id : key_val.second) {
       if (std::find(it->second.begin(), it->second.end(), value_id) == it->second.end()) {
         return false;
       }

--- a/maliput/src/base/road_rulebook_loader.cc
+++ b/maliput/src/base/road_rulebook_loader.cc
@@ -27,6 +27,7 @@ using maliput::api::rules::DiscreteValueRule;
 using maliput::api::rules::RightOfWayRule;
 using maliput::api::rules::Rule;
 using maliput::api::rules::TrafficLight;
+using maliput::api::rules::UniqueBulbGroupId;
 
 namespace YAML {
 
@@ -304,6 +305,14 @@ DiscreteValueRule BuildRightOfWayTypeDiscreteValueRule(const RightOfWayRule& rig
       {RightOfWayRule::State::Type::kStop, "Stop"},
       {RightOfWayRule::State::Type::kStopThenGo, "StopThenGo"},
   };
+
+  Rule::RelatedUniqueIds related_unique_ids{{RightOfWayBulbGroup(), {}}};
+  for (const auto& pair_traffic_light_id_vector_bulb_group_id : right_of_way_rule.related_bulb_groups()) {
+    for (const auto& bulb_group_id : pair_traffic_light_id_vector_bulb_group_id.second) {
+      related_unique_ids.at(RightOfWayBulbGroup())
+          .push_back(UniqueBulbGroupId{pair_traffic_light_id_vector_bulb_group_id.first, bulb_group_id});
+    }
+  }
   std::vector<DiscreteValueRule::DiscreteValue> discrete_values;
   for (const auto& state : right_of_way_rule.states()) {
     Rule::RelatedRules related_rules;
@@ -316,10 +325,10 @@ DiscreteValueRule BuildRightOfWayTypeDiscreteValueRule(const RightOfWayRule& rig
     if (rule_ids.size()) {
       related_rules.emplace(std::pair<std::string, std::vector<Rule::Id>>{RightOfWayYieldGroup(), rule_ids});
     }
-    discrete_values.push_back(api::rules::MakeDiscreteValue(Rule::State::kStrict, related_rules,
-                                                            Rule::RelatedUniqueIds{},
+    discrete_values.push_back(api::rules::MakeDiscreteValue(Rule::State::kStrict, related_rules, related_unique_ids,
                                                             right_of_way_rule_state_types.at(state.second.type())));
   }
+
   return DiscreteValueRule(GetRuleIdFrom(RightOfWayRuleTypeId(), right_of_way_rule.id()), RightOfWayRuleTypeId(),
                            right_of_way_rule.zone(), discrete_values);
 }

--- a/maliput/src/base/rule_registry.cc
+++ b/maliput/src/base/rule_registry.cc
@@ -58,4 +58,6 @@ api::rules::DiscreteValueRuleTypeAndValues BuildVehicleStopInZoneBehaviorRuleTyp
 
 std::string RightOfWayYieldGroup() { return "YieldGroup"; }
 
+std::string RightOfWayBulbGroup() { return "BulbGroupIds"; }
+
 }  // namespace maliput

--- a/maliput_integration_tests/test/road_rulebook_loader_test.cc
+++ b/maliput_integration_tests/test/road_rulebook_loader_test.cc
@@ -41,6 +41,7 @@ using maliput::api::rules::DiscreteValueRule;
 using maliput::api::rules::RightOfWayRule;
 using maliput::api::rules::Rule;
 using maliput::api::rules::TrafficLight;
+using maliput::api::rules::UniqueBulbGroupId;
 
 class TestLoading2x2IntersectionRules : public ::testing::Test {
  protected:
@@ -265,6 +266,26 @@ class TestLoading2x2IntersectionRules : public ::testing::Test {
                             discrete_value_it->related_rules.at(RightOfWayYieldGroup()).end(),
                             GetRuleIdFrom(RightOfWayRuleTypeId(), yield_id));
         EXPECT_NE(it, discrete_value_it->related_rules.at(RightOfWayYieldGroup()).end());
+      }
+    }
+
+    // Check the related unique ids of the discrete value.
+    int related_bulb_group_size{0};
+    for (const auto& traffic_light_id_vector_bulb_group_id : right_of_way_rule.related_bulb_groups()) {
+      related_bulb_group_size += traffic_light_id_vector_bulb_group_id.second.size();
+    }
+    for (const auto& discrete_value : right_of_way_discrete_rule.values()) {
+      EXPECT_EQ(discrete_value.related_unique_ids.at(RightOfWayBulbGroup()).size(), related_bulb_group_size);
+      for (const auto& unique_id : discrete_value.related_unique_ids.at(RightOfWayBulbGroup())) {
+        const auto related_bulb_group_it = find_if(
+            right_of_way_rule.related_bulb_groups().begin(), right_of_way_rule.related_bulb_groups().end(),
+            [unique_id](std::pair<TrafficLight::Id, std::vector<BulbGroup::Id>> traffic_light_id_vector_bulb_group_id) {
+              for (const auto& bulb_group_id : traffic_light_id_vector_bulb_group_id.second) {
+                return unique_id == UniqueBulbGroupId{traffic_light_id_vector_bulb_group_id.first, bulb_group_id};
+              }
+              return false;
+            });
+        EXPECT_NE(related_bulb_group_it, right_of_way_rule.related_bulb_groups().end());
       }
     }
   }


### PR DESCRIPTION
**It solves one step of #183 - _RelatedBulbGroups and new rules_**

*Branched from #193* 

**This PR contains the followings modifications:**
- Created `RightOfWayBulbGroup` function in rule_registry.h that returns a `std::string "BulbGroup"`.
- Building of RelatedUniqueIds of Right-Of-Way Rules from `RightOfWayRule::RelatedBulbGroup`.
- Tests were adapted to verify the equivalency between RelatedUniqueIds and RelatedBulbGroup.