### PR TITLE
Releases RelatedRules constraint on empty values.

### DIFF
--- a/maliput/include/maliput/api/rules/rule.h
+++ b/maliput/include/maliput/api/rules/rule.h
@@ -42,7 +42,7 @@ class Rule {
   /// Alias of a map holding groups of related rules. The name of each group is
   /// specified by the key, and the semantics vary based on the specific rule
   /// type. The group name must not be an empty string. Each vector of
-  /// Rule::Id must not be empty and must contain unique Rule::Ids.
+  /// Rule::Id must contain unique Rule::Ids.
   using RelatedRules = std::map<std::string, std::vector<Id>>;
 
   /// Defines a base state for a Rule.

--- a/maliput/src/api/rules/rule.cc
+++ b/maliput/src/api/rules/rule.cc
@@ -25,7 +25,6 @@ bool Rule::State::operator==(const State& other) const {
 void Rule::ValidateRelatedRules(const Rule::RelatedRules& related_rules) const {
   for (const auto& group_id_to_related_rules : related_rules) {
     MALIPUT_THROW_UNLESS(!group_id_to_related_rules.first.empty());
-    MALIPUT_THROW_UNLESS(!group_id_to_related_rules.second.empty());
     for (const Rule::Id& rule_id : group_id_to_related_rules.second) {
       MALIPUT_THROW_UNLESS(
           std::count(group_id_to_related_rules.second.begin(), group_id_to_related_rules.second.end(), rule_id) == 1);

--- a/maliput/test/api/rule_test.cc
+++ b/maliput/test/api/rule_test.cc
@@ -35,18 +35,18 @@ TEST_F(RuleTest, RangeValueRuleConstructor) {
 
   EXPECT_NO_THROW(RangeValueRule(kId, kTypeId, kZone, kRanges));
 
+  // Missing Rule::Ids in RelatedRules in RangeValueRule::Range.
+  const Rule::RelatedRules kMissingRelatedRules{{"RuleGroup", {}}};
+  const RangeValueRule::Range kRangeWithMissingRelatedRules =
+      MakeRange(Rule::State::kStrict, kMissingRelatedRules, "range_description_1", 123. /* min */, 456. /* max */);
+  EXPECT_NO_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithMissingRelatedRules}));
+
   // Duplicated Rule::Ids in RelatedRules in RangeValueRule::Range.
   const Rule::RelatedRules kDuplicatedRelatedRules{
       {"RuleGroup", {Rule::Id("RuleTypeIdB/RuleIdB"), Rule::Id("RuleTypeIdB/RuleIdB")}}};
   const RangeValueRule::Range kRangeWithDuplicatedRules =
       MakeRange(Rule::State::kStrict, kDuplicatedRelatedRules, "range_description_1", 123. /* min */, 456. /* max */);
   EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithDuplicatedRules}), maliput::common::assertion_error);
-
-  // Missing Rule::Ids in RelatedRules in RangeValueRule::Range.
-  const Rule::RelatedRules kMissingRelatedRules{{"RuleGroup", {}}};
-  const RangeValueRule::Range kRangeWithMissingRelatedRules =
-      MakeRange(Rule::State::kStrict, kMissingRelatedRules, "range_description_1", 123. /* min */, 456. /* max */);
-  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithMissingRelatedRules}), maliput::common::assertion_error);
 
   // Empty std::string for semantic group key in RelatedRules in RangeValueRule::Range.
   const Rule::RelatedRules kEmptyKeyRelatedRules{{"", {Rule::Id("RuleTypeIdB/RuleIdB")}}};
@@ -170,6 +170,12 @@ TEST_F(RuleTest, DiscreteValueRuleConstructor) {
 
   EXPECT_NO_THROW(DiscreteValueRule(kId, kTypeId, kZone, kDiscreteValues));
 
+  // Missing Rule::Ids in RelatedRules in DiscreteValueRule::DiscreteValue.
+  const Rule::RelatedRules kMissingRelatedRules{{"RuleGroup", {}}};
+  const DiscreteValueRule::DiscreteValue kDiscreteValueWithMissingRelatedRules =
+      MakeDiscreteValue(Rule::State::kStrict, kMissingRelatedRules, "rule_state_value");
+  EXPECT_NO_THROW(DiscreteValueRule(kId, kTypeId, kZone, {kDiscreteValueWithMissingRelatedRules}));
+
   // Negative severity.
   const int kSeverityInvalid{-1};
   EXPECT_THROW(DiscreteValueRule(
@@ -182,12 +188,6 @@ TEST_F(RuleTest, DiscreteValueRuleConstructor) {
   const DiscreteValueRule::DiscreteValue kDiscreteValueWithDuplicatedRules =
       MakeDiscreteValue(Rule::State::kStrict, kDuplicatedRelatedRules, "rule_state_value");
   EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {kDiscreteValueWithDuplicatedRules}),
-               maliput::common::assertion_error);
-  // Missing Rule::Ids in RelatedRules in DiscreteValueRule::DiscreteValue.
-  const Rule::RelatedRules kMissingRelatedRules{{"RuleGroup", {}}};
-  const DiscreteValueRule::DiscreteValue kDiscreteValueWithMissingRelatedRules =
-      MakeDiscreteValue(Rule::State::kStrict, kMissingRelatedRules, "rule_state_value");
-  EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {kDiscreteValueWithMissingRelatedRules}),
                maliput::common::assertion_error);
   // Duplicated ranges.
   const std::vector<DiscreteValueRule::DiscreteValue> kDuplicatedDiscreteValues{


### PR DESCRIPTION
An atomic section of PR #190, split as requested [here](https://github.com/ToyotaResearchInstitute/maliput/pull/190#pullrequestreview-310077962).