### PR TITLE
Migrate SpeedLimitRuleTypeId function to Maliput

### DIFF
--- a/maliput/include/maliput/base/rule_registry.h
+++ b/maliput/include/maliput/base/rule_registry.h
@@ -90,4 +90,8 @@ std::string RightOfWayYieldGroup();
 /// Returns "BulbGroupIds", which is the key to the `Rules::RelatedUniqueIds` of Right-Of-Way rules.
 std::string RightOfWayBulbGroup();
 
+/// Returns a maliput::api::rules::Rule::TypeId initialized with
+/// "Speed Limit Rule Type".
+api::rules::Rule::TypeId SpeedLimitRuleTypeId();
+
 }  // namespace maliput

--- a/maliput/src/base/rule_registry.cc
+++ b/maliput/src/base/rule_registry.cc
@@ -60,4 +60,6 @@ std::string RightOfWayYieldGroup() { return "YieldGroup"; }
 
 std::string RightOfWayBulbGroup() { return "BulbGroupIds"; }
 
+api::rules::Rule::TypeId SpeedLimitRuleTypeId() { return api::rules::Rule::TypeId{"Speed Limit Rule Type"}; }
+
 }  // namespace maliput

--- a/maliput/test/base/rule_registry_test.cc
+++ b/maliput/test/base/rule_registry_test.cc
@@ -27,6 +27,10 @@ GTEST_TEST(VehicleStopInZoneBehaviorRuleTypeIdTest, Initialization) {
   EXPECT_EQ(VehicleStopInZoneBehaviorRuleTypeId().string(), "Vehicle Stop In Zone Behavior Rule Type");
 }
 
+GTEST_TEST(SpeedLimitRuleTypeIdTest, Initialization) {
+  EXPECT_EQ(SpeedLimitRuleTypeId().string(), "Speed Limit Rule Type");
+}
+
 // Holds the information to evaluate the rule type built by `builder` function.
 struct BuildDiscreteValueRuleTypeExpectedValues {
   std::string type_id;


### PR DESCRIPTION
**It is needed in PR #202**

Add ```api::rules::Rule::TypeId SpeedLimitRuleTypeId()``` function to maliput/base/rule_registry.h .

This function returns : ``` api::rules::Rule::TypeId{"Speed Limit Rule Type"} ```