### PR TITLE
Confirm RightOfWayRule state exists before accessing it

### DIFF
--- a/maliput/src/base/phase_ring_book_loader.cc
+++ b/maliput/src/base/phase_ring_book_loader.cc
@@ -209,6 +209,7 @@ DiscreteValueRuleStates LoadDiscreteValueRuleStates(const RuleStates& rule_state
     const Rule::Id rule_id = GetRuleIdFrom(RightOfWayRuleTypeId(), row_it.first);
     const DiscreteValueRule rule = rulebook->GetDiscreteValueRule(rule_id);
     const RightOfWayRule right_of_way_rule = rulebook->GetRule(row_it.first);
+    MALIPUT_THROW_UNLESS(right_of_way_rule.states().find(row_it.second) != right_of_way_rule.states().end());
     MALIPUT_THROW_UNLESS(discrete_value_rule_states
                              .emplace(rule_id, FindDiscreteValueFromRightOfWayRuleState(
                                                    row_it.first, right_of_way_rule.states().at(row_it.second),


### PR DESCRIPTION
Improves the PhaseRingBook loader to check that a RightOfWayRule State
exists before accessing it. This results in a more meaningful error message.

Error message before patch:
```
IndexError: _Map_base::at
```

Error message after patch:
```
AssertionError: MaliputAssertionError: Failure at external/maliput/maliput/src/base/phase_ring_book_loader.cc:213 in LoadDiscreteValueRuleStates(): condition 'row_rule_states.find(row_it.second) != row_rule_states.end()' failed.
```