### PR TITLE
Add case for branch point glow so clang9 warnings go away

### DIFF
--- a/maliput_utilities/src/maliput-utilities/generate_obj.cc
+++ b/maliput_utilities/src/maliput-utilities/generate_obj.cc
@@ -770,6 +770,11 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
       }
       break;
     }
+    case BranchPointGlow: {
+      // Shouldn't occur due to above assertion, but handle anyway to quash warnings
+      MALIPUT_THROW_MESSAGE("BranchPointGlow is not a valid Mesh Material type within this function call.");
+      break;
+    }
   }
 
   return std::make_pair(std::move(mesh), GetMaterialFromMesh(mesh_material));


### PR DESCRIPTION
Fixes https://github.com/ToyotaResearchInstitute/maliput/issues/224