### PR TITLE
Adds maliput_hash.h and remove the dependency to drake::hash.

### DIFF
--- a/maliput/include/maliput/api/rules/direction_usage_rule.h
+++ b/maliput/include/maliput/api/rules/direction_usage_rule.h
@@ -137,7 +137,7 @@ class DirectionUsageRule final {
   }
 
   /// Maps DirectionUsageRule::State::Type enums to string representations.
-  static std::unordered_map<State::Type, const char*, drake::DefaultHash> StateTypeMapper();
+  static std::unordered_map<State::Type, const char*, maliput::common::DefaultHash> StateTypeMapper();
 
  private:
   Id id_;

--- a/maliput/include/maliput/api/rules/traffic_lights.h
+++ b/maliput/include/maliput/api/rules/traffic_lights.h
@@ -8,10 +8,10 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
-#include "drake/common/hash.h"
 #include "maliput/api/lane_data.h"
 #include "maliput/api/type_specific_identifier.h"
 #include "maliput/api/unique_id.h"
+#include "maliput/common/maliput_hash.h"
 #include "maliput/common/passkey.h"
 
 namespace maliput {
@@ -26,7 +26,7 @@ enum class BulbColor {
 };
 
 /// Maps BulbColor enums to string representations.
-std::unordered_map<BulbColor, const char*, drake::DefaultHash> BulbColorMapper();
+std::unordered_map<BulbColor, const char*, maliput::common::DefaultHash> BulbColorMapper();
 
 /// Defines the possible bulb types.
 enum class BulbType {
@@ -35,13 +35,13 @@ enum class BulbType {
 };
 
 /// Maps BulbType enums to string representations.
-std::unordered_map<BulbType, const char*, drake::DefaultHash> BulbTypeMapper();
+std::unordered_map<BulbType, const char*, maliput::common::DefaultHash> BulbTypeMapper();
 
 /// Defines the possible bulb states.
 enum class BulbState { kOff = 0, kOn, kBlinking };
 
 /// Maps BulbState enums to string representations.
-std::unordered_map<BulbState, const char*, drake::DefaultHash> BulbStateMapper();
+std::unordered_map<BulbState, const char*, maliput::common::DefaultHash> BulbStateMapper();
 
 /// Forward declaration of `UniqueBulbId` to be used by `Bulb`.
 class UniqueBulbId;
@@ -399,7 +399,7 @@ class UniqueBulbId : public UniqueId {
   /// Implements the @ref hash_append concept.
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const UniqueBulbId& id) noexcept {
-    using drake::hash_append;
+    using maliput::common::hash_append;
     hash_append(hasher, id.traffic_light_id_);
     hash_append(hasher, id.bulb_group_id_);
     hash_append(hasher, id.bulb_id_);
@@ -460,7 +460,7 @@ class UniqueBulbGroupId : public UniqueId {
   /// Implements the @ref hash_append concept.
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const UniqueBulbGroupId& id) noexcept {
-    using drake::hash_append;
+    using maliput::common::hash_append;
     hash_append(hasher, id.traffic_light_id_);
     hash_append(hasher, id.bulb_group_id_);
   }
@@ -481,7 +481,7 @@ namespace std {
 
 /// Specialization of std::hash for maliput::api::rules::UniqueBulbId.
 template <>
-struct hash<maliput::api::rules::UniqueBulbId> : public drake::DefaultHash {};
+struct hash<maliput::api::rules::UniqueBulbId> : public maliput::common::DefaultHash {};
 
 /// Specialization of std::less for maliput::api::rules::UniqueBulbId
 /// providing a strict ordering over maliput::api::rules::UniqueBulbId
@@ -503,7 +503,7 @@ struct less<maliput::api::rules::UniqueBulbId> {
 
 /// Specialization of std::hash for maliput::api::rules::UniqueBulbGroupId.
 template <>
-struct hash<maliput::api::rules::UniqueBulbGroupId> : public drake::DefaultHash {};
+struct hash<maliput::api::rules::UniqueBulbGroupId> : public maliput::common::DefaultHash {};
 
 /// Specialization of std::less for maliput::api::rules::UniqueBulbGroupId
 /// providing a strict ordering over maliput::api::rules::UniqueBulbGroupId

--- a/maliput/include/maliput/api/type_specific_identifier.h
+++ b/maliput/include/maliput/api/type_specific_identifier.h
@@ -5,8 +5,8 @@
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/hash.h"
 
+#include "maliput/common/maliput_hash.h"
 #include "maliput/common/maliput_throw.h"
 
 namespace maliput {
@@ -63,7 +63,7 @@ class TypeSpecificIdentifier {
   /// Implements the @ref hash_append concept.
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const TypeSpecificIdentifier& item) noexcept {
-    using drake::hash_append;
+    using maliput::common::hash_append;
     hash_append(hasher, item.string_);
   }
 
@@ -78,7 +78,7 @@ namespace std {
 
 /// Specialization of std::hash for maliput::api::TypeSpecificIdentifier<T>.
 template <typename T>
-struct hash<maliput::api::TypeSpecificIdentifier<T>> : public drake::DefaultHash {};
+struct hash<maliput::api::TypeSpecificIdentifier<T>> : public maliput::common::DefaultHash {};
 
 /// Specialization of std::less for maliput::api::TypeSpecificIdentifier<T>
 /// providing a strict ordering over maliput::api::TypeSpecificIdentifier<T>

--- a/maliput/include/maliput/api/unique_id.h
+++ b/maliput/include/maliput/api/unique_id.h
@@ -3,8 +3,8 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/hash.h"
 
+#include "maliput/common/maliput_hash.h"
 #include "maliput/common/maliput_throw.h"
 
 namespace maliput {
@@ -36,7 +36,7 @@ class UniqueId {
   /// Implements the @ref hash_append concept.
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const UniqueId& item) noexcept {
-    using drake::hash_append;
+    using maliput::common::hash_append;
     hash_append(hasher, item.string_);
   }
 
@@ -51,7 +51,7 @@ namespace std {
 
 /// Specialization of std::hash for maliput::api::UniqueId.
 template <>
-struct hash<maliput::api::UniqueId> : public drake::DefaultHash {};
+struct hash<maliput::api::UniqueId> : public maliput::common::DefaultHash {};
 
 /// Specialization of std::less for maliput::api::UniqueId providing a
 /// strict ordering over UniqueId suitable for use with ordered

--- a/maliput/include/maliput/common/maliput_hash.h
+++ b/maliput/include/maliput/common/maliput_hash.h
@@ -1,0 +1,266 @@
+#pragma once
+
+/// @file maliput_hash.h
+/// Code in this file is inspired by:
+/// https://github.com/RobotLocomotion/drake/blob/master/common/hash.h
+///
+/// Drake's license follows:
+///
+/// All components of Drake are licensed under the BSD 3-Clause License
+/// shown below. Where noted in the source code, some portions may
+/// be subject to other permissive, non-viral licenses.
+///
+/// Copyright 2012-2016 Robot Locomotion Group @ CSAIL
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions are
+/// met:
+///
+/// Redistributions of source code must retain the above copyright notice,
+/// this list of conditions and the following disclaimer.  Redistributions
+/// in binary form must reproduce the above copyright notice, this list of
+/// conditions and the following disclaimer in the documentation and/or
+/// other materials provided with the distribution.  Neither the name of
+/// the Massachusetts Institute of Technology nor the names of its
+/// contributors may be used to endorse or promote products derived from
+/// this software without specific prior written permission.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+/// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+/// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+/// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+/// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+/// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+/// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+/// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+/// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+/// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+/// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include <optional>
+
+#include "maliput/common/maliput_throw.h"
+
+/// Maliput uses the hash_append pattern as described by N3980.
+///
+/// For a full treatment of the hash_append pattern, refer to:
+/// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3980.html
+///
+/// <h3>Providing hash_append support within a class</h3>
+///
+/// Maliput types may implement a `hash_append` function.
+/// The function appends every hash-relevant member field into the hasher:
+/// @code
+/// class MyValue {
+///  public:
+///   ...
+///   /// Implements the @ref hash_append concept.
+///   template <class HashAlgorithm>
+///   friend void hash_append(
+///       HashAlgorithm& hasher, const MyValue& item) noexcept {
+///     using maliput::common::hash_append;
+///     hash_append(hasher, item.my_data_);
+///   }
+///   ...
+///  private:
+///   std::string my_data_;
+/// };
+/// @endcode
+///
+/// Checklist for reviewing a `hash_append` implementation:
+///
+/// - The function cites `@ref hash_append` in its Doxygen comment.
+/// - The function is marked `noexcept`.
+///
+/// <h3>Using hashable types</h3>
+///
+/// Types that implement this pattern may be used in unordered collections:
+/// @code
+/// std::unordered_set<MyValue, maliput::common::DefaultHash> foo;
+/// @endcode
+///
+/// Some Drake types may also choose to specialize `std::hash<MyValue>` to use
+/// `DefaultHash`, so that the second template argument to `std::unordered_set`
+/// can be omitted.
+
+namespace maliput {
+namespace common {
+
+/// Provides @ref hash_append for integral constants.
+template <class HashAlgorithm, class T>
+std::enable_if_t<std::is_integral<T>::value> hash_append(HashAlgorithm& hasher, const T& item) noexcept {
+  hasher(std::addressof(item), sizeof(item));
+}
+
+/// Provides @ref hash_append for enumerations.
+template <class HashAlgorithm, class T>
+std::enable_if_t<std::is_enum<T>::value> hash_append(HashAlgorithm& hasher, const T& item) noexcept {
+  hasher(std::addressof(item), sizeof(item));
+}
+
+/// Provides @ref hash_append for floating point values.
+template <class HashAlgorithm, class T>
+std::enable_if_t<std::is_floating_point<T>::value> hash_append(HashAlgorithm& hasher, const T& item) noexcept {
+  // Hashing a NaN makes no sense, since they cannot compare as equal.
+  MALIPUT_THROW_UNLESS(!std::isnan(item));
+  // +0.0 and -0.0 are equal, so must hash identically.
+  if (item == 0.0) {
+    const T zero{0.0};
+    hasher(std::addressof(zero), sizeof(zero));
+  } else {
+    hasher(std::addressof(item), sizeof(item));
+  }
+}
+
+/// Provides @ref hash_append for std::string.
+/// (Technically, any string based on `CharT = char`.)
+template <class HashAlgorithm, class Traits, class Allocator>
+void hash_append(HashAlgorithm& hasher, const std::basic_string<char, Traits, Allocator>& item) noexcept {
+  using maliput::common::hash_append;
+  hasher(item.data(), item.size());
+  // All collection types must send their size, after their contents.
+  // See the #hash_append_vector anchor in N3980.
+  hash_append(hasher, item.size());
+}
+
+/// Provides @ref hash_append for std::pair.
+template <class HashAlgorithm, class T1, class T2>
+void hash_append(HashAlgorithm& hasher, const std::pair<T1, T2>& item) noexcept {
+  using maliput::common::hash_append;
+  hash_append(hasher, item.first);
+  hash_append(hasher, item.second);
+}
+
+/// Provides @ref hash_append for std::optional.
+///
+/// Note that `std::hash<std::optional<T>>` provides the peculiar invariant
+/// that the hash of an `optional` bearing a value `v` shall evaluate to the
+/// same hash as that of the value `v` itself.  Hash operations implemented
+/// with this `hash_append` do *not* provide that invariant.
+template <class HashAlgorithm, class T>
+void hash_append(HashAlgorithm& hasher, const std::optional<T>& item) noexcept {
+  if (item) {
+    hash_append(hasher, *item);
+  }
+  hash_append(hasher, item.has_value());
+};
+
+/// Provides @ref hash_append for a range, as given by two iterators.
+template <class HashAlgorithm, class Iter>
+void hash_append_range(
+    // NOLINTNEXTLINE(runtime/references) Per hash_append convention.
+    HashAlgorithm& hasher, Iter begin, Iter end) noexcept {
+  using maliput::common::hash_append;
+  size_t count{0};
+  for (Iter iter = begin; iter != end; ++iter, ++count) {
+    hash_append(hasher, *iter);
+  }
+  // All collection types must send their size, after their contents.
+  // See the #hash_append_vector anchor in N3980.
+  hash_append(hasher, count);
+}
+
+/// Provides @ref hash_append for std::map.
+///
+/// Note that there is no `hash_append` overload for `std::unordered_map`, and
+/// such an overload must never appear.  See n3980.html#unordered for details.
+template <class HashAlgorithm, class T1, class T2, class Compare, class Allocator>
+void hash_append(HashAlgorithm& hasher, const std::map<T1, T2, Compare, Allocator>& item) noexcept {
+  return hash_append_range(hasher, item.begin(), item.end());
+};
+
+/// Provides @ref hash_append for std::set.
+///
+/// Note that there is no `hash_append` overload for `std::unordered_set`, and
+/// such an overload must never appear.  See n3980.html#unordered for details.
+template <class HashAlgorithm, class Key, class Compare, class Allocator>
+void hash_append(HashAlgorithm& hasher, const std::set<Key, Compare, Allocator>& item) noexcept {
+  return hash_append_range(hasher, item.begin(), item.end());
+};
+
+/// A hashing functor, somewhat like `std::hash`.  Given an item of type @p T,
+/// applies @ref hash_append to it, directing the bytes to append into the
+/// given @p HashAlgorithm, and then finally returning the algorithm's result.
+template <class HashAlgorithm>
+struct uhash {
+  using result_type = typename HashAlgorithm::result_type;
+
+  template <class T>
+  result_type operator()(const T& item) const noexcept {
+    HashAlgorithm hasher;
+    using maliput::common::hash_append;
+    hash_append(hasher, item);
+    return static_cast<result_type>(hasher);
+  }
+};
+
+namespace internal {
+/// The FNV1a hash algorithm, used for @ref hash_append.
+/// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+class FNV1aHasher {
+ public:
+  using result_type = size_t;
+
+  /// Feeds a block of memory into this hash.
+  void operator()(const void* data, size_t length) noexcept {
+    const uint8_t* const begin = static_cast<const uint8_t*>(data);
+    const uint8_t* const end = begin + length;
+    for (const uint8_t* iter = begin; iter < end; ++iter) {
+      hash_ = (hash_ ^ *iter) * kFnvPrime;
+    }
+  }
+
+  /// Feeds a single byte into this hash.
+  constexpr void add_byte(uint8_t byte) noexcept { hash_ = (hash_ ^ byte) * kFnvPrime; }
+
+  /// Returns the hash.
+  explicit constexpr operator size_t() noexcept { return hash_; }
+
+ private:
+  static_assert(sizeof(result_type) == (64 / 8), "We require a 64-bit size_t");
+  result_type hash_{0xcbf29ce484222325u};
+  static constexpr size_t kFnvPrime = 1099511628211u;
+};
+}  // namespace internal
+
+/// The default HashAlgorithm concept implementation across Maliput.  This is
+/// guaranteed to have a result_type of size_t to be compatible with std::hash.
+using DefaultHasher = internal::FNV1aHasher;
+
+/// The default hashing functor, akin to std::hash.
+using DefaultHash = maliput::common::uhash<DefaultHasher>;
+
+/// An adapter that forwards the HashAlgorithm::operator(data, length) function
+/// concept into a runtime-provided std::function of the same signature.  This
+/// is useful for passing a concrete HashAlgorithm implementation through into
+/// non-templated code, such as with an Impl or Cell pattern.
+struct DelegatingHasher {
+  /// A std::function whose signature matches HashAlgorithm::operator().
+  using Func = std::function<void(const void*, size_t)>;
+
+  /// Create a delegating hasher that calls the given @p func.
+  explicit DelegatingHasher(Func func) : func_(std::move(func)) {
+    // In order for operator() to be noexcept, it must have a non-empty func_.
+    MALIPUT_THROW_UNLESS(static_cast<bool>(func_));
+  }
+
+  /// Append [data, data + length) bytes into the wrapped algorithm.
+  void operator()(const void* data, size_t length) noexcept { func_(data, length); }
+
+ private:
+  const Func func_;
+};
+
+}  // namespace common
+}  // namespace maliput

--- a/maliput/src/api/rules/direction_usage_rule.cc
+++ b/maliput/src/api/rules/direction_usage_rule.cc
@@ -4,7 +4,7 @@ namespace maliput {
 namespace api {
 namespace rules {
 
-std::unordered_map<DirectionUsageRule::State::Type, const char*, drake::DefaultHash>
+std::unordered_map<DirectionUsageRule::State::Type, const char*, maliput::common::DefaultHash>
 DirectionUsageRule::StateTypeMapper() {
   return {{DirectionUsageRule::State::Type::kWithS, "WithS"},
           {DirectionUsageRule::State::Type::kAgainstS, "AgainstS"},

--- a/maliput/src/api/rules/traffic_lights.cc
+++ b/maliput/src/api/rules/traffic_lights.cc
@@ -10,23 +10,23 @@ namespace maliput {
 namespace api {
 namespace rules {
 
-std::unordered_map<BulbColor, const char*, drake::DefaultHash> BulbColorMapper() {
-  std::unordered_map<BulbColor, const char*, drake::DefaultHash> result;
+std::unordered_map<BulbColor, const char*, maliput::common::DefaultHash> BulbColorMapper() {
+  std::unordered_map<BulbColor, const char*, maliput::common::DefaultHash> result;
   result.emplace(BulbColor::kRed, "Red");
   result.emplace(BulbColor::kYellow, "Yellow");
   result.emplace(BulbColor::kGreen, "Green");
   return result;
 }
 
-std::unordered_map<BulbType, const char*, drake::DefaultHash> BulbTypeMapper() {
-  std::unordered_map<BulbType, const char*, drake::DefaultHash> result;
+std::unordered_map<BulbType, const char*, maliput::common::DefaultHash> BulbTypeMapper() {
+  std::unordered_map<BulbType, const char*, maliput::common::DefaultHash> result;
   result.emplace(BulbType::kRound, "Round");
   result.emplace(BulbType::kArrow, "Arrow");
   return result;
 }
 
-std::unordered_map<BulbState, const char*, drake::DefaultHash> BulbStateMapper() {
-  std::unordered_map<BulbState, const char*, drake::DefaultHash> result;
+std::unordered_map<BulbState, const char*, maliput::common::DefaultHash> BulbStateMapper() {
+  std::unordered_map<BulbState, const char*, maliput::common::DefaultHash> result;
   result.emplace(BulbState::kOff, "Off");
   result.emplace(BulbState::kOn, "On");
   result.emplace(BulbState::kBlinking, "Blinking");

--- a/maliput/src/base/manual_rulebook.cc
+++ b/maliput/src/base/manual_rulebook.cc
@@ -8,9 +8,9 @@
 #include <unordered_map>
 
 #include "drake/common/drake_optional.h"
-#include "drake/common/hash.h"
 
 #include "maliput/api/rules/rule.h"
+#include "maliput/common/maliput_hash.h"
 #include "maliput/common/maliput_throw.h"
 
 namespace maliput {
@@ -33,10 +33,10 @@ namespace {
 // using IdVariant = std::variant<RightOfWayRule::Id,
 //                                SpeedLimitRule::Id>;
 struct IdVariant {
-  drake::optional<RightOfWayRule::Id> r;
-  drake::optional<SpeedLimitRule::Id> s;
-  drake::optional<DirectionUsageRule::Id> d;
-  drake::optional<Rule::Id> rule;
+  std::optional<RightOfWayRule::Id> r;
+  std::optional<SpeedLimitRule::Id> s;
+  std::optional<DirectionUsageRule::Id> d;
+  std::optional<Rule::Id> rule;
 
   IdVariant() = default;
 
@@ -54,7 +54,7 @@ struct IdVariant {
 
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const IdVariant& item) noexcept {
-    using drake::hash_append;
+    using maliput::common::hash_append;
     hash_append(hasher, item.r);
     hash_append(hasher, item.s);
     hash_append(hasher, item.d);
@@ -258,7 +258,7 @@ class ManualRulebook::Impl {
     //                          like boost::interval_map, though if there are
     //                          not many rules attached to each individual
     //                          lane_id, this is probably good enough.
-    std::unordered_map<LaneId, std::unordered_multimap<IdVariant, SRange, drake::DefaultHash>> map_;
+    std::unordered_map<LaneId, std::unordered_multimap<IdVariant, SRange, maliput::common::DefaultHash>> map_;
   };
 
   // ID->Rule indices for each rule type.

--- a/maliput/test/common/CMakeLists.txt
+++ b/maliput/test/common/CMakeLists.txt
@@ -1,5 +1,6 @@
 ament_add_gtest(logger_test logger_test.cc)
 ament_add_gtest(maliput_abort_test maliput_abort_test.cc)
+ament_add_gtest(maliput_hash_test maliput_hash_test.cc)
 ament_add_gtest(maliput_passkey_test maliput_passkey_test.cc)
 ament_add_gtest(maliput_throw_test maliput_throw_test.cc)
 
@@ -25,5 +26,6 @@ endmacro()
 
 add_dependencies_to_test(logger_test)
 add_dependencies_to_test(maliput_abort_test)
+add_dependencies_to_test(maliput_hash_test)
 add_dependencies_to_test(maliput_passkey_test)
 add_dependencies_to_test(maliput_throw_test)

--- a/maliput/test/common/maliput_hash_test.cc
+++ b/maliput/test/common/maliput_hash_test.cc
@@ -1,0 +1,95 @@
+/// @file maliput_hash_test.cc
+/// Code in this file is inspired by:
+/// https://github.com/RobotLocomotion/drake/blob/master/common/test/hash_test.cc
+///
+/// Drake's license follows:
+///
+/// All components of Drake are licensed under the BSD 3-Clause License
+/// shown below. Where noted in the source code, some portions may
+/// be subject to other permissive, non-viral licenses.
+///
+/// Copyright 2012-2016 Robot Locomotion Group @ CSAIL
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions are
+/// met:
+///
+/// Redistributions of source code must retain the above copyright notice,
+/// this list of conditions and the following disclaimer.  Redistributions
+/// in binary form must reproduce the above copyright notice, this list of
+/// conditions and the following disclaimer in the documentation and/or
+/// other materials provided with the distribution.  Neither the name of
+/// the Massachusetts Institute of Technology nor the names of its
+/// contributors may be used to endorse or promote products derived from
+/// this software without specific prior written permission.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+/// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+/// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+/// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+/// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+/// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+/// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+/// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+/// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+/// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+/// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "maliput/common/maliput_hash.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace maliput {
+namespace common {
+namespace {
+
+// A hasher which simply records all of its invocations for later inspection
+class MockHasher {
+ public:
+  void operator()(const void* data, size_t length) noexcept {
+    const uint8_t* const begin = static_cast<const uint8_t*>(data);
+    const uint8_t* const end = begin + length;
+    record_.emplace_back(begin, end);
+  }
+
+  std::vector<std::vector<uint8_t>> record() const { return record_; }
+
+ private:
+  std::vector<std::vector<uint8_t>> record_;
+};
+
+GTEST_TEST(HashTest, HashAppendOptional) {
+  // Test basic functionality:  ensure two equal values get hashed the same way,
+  // and that an empty value and non-empty value are hashed differently
+  // (regardless of whether or not the hashes turn out the same).
+  std::optional<int> nonempty1(99);
+  std::optional<int> nonempty2(99);
+  MockHasher hash_nonempty1;
+  MockHasher hash_nonempty2;
+  hash_append(hash_nonempty1, nonempty1);
+  hash_append(hash_nonempty2, nonempty2);
+  EXPECT_EQ(hash_nonempty1.record(), hash_nonempty2.record());
+  EXPECT_EQ(hash_nonempty1.record().size(), 2);
+
+  std::optional<int> empty1;
+  std::optional<int> empty2;
+  MockHasher hash_empty1;
+  MockHasher hash_empty2;
+  hash_append(hash_empty1, empty1);
+  hash_append(hash_empty2, empty2);
+  EXPECT_EQ(hash_empty1.record(), hash_empty2.record());
+  EXPECT_EQ(hash_empty1.record().size(), 1);
+
+  // We specifically want to ensure that the hasher is called in a different
+  // way for the empty and non-empty cases.  Given that `hash_append` for
+  // `int` and `bool` each invoke the hasher once, the following expectation
+  // on total invocation counts reliably tests this:
+  EXPECT_NE(hash_empty1.record().size(), hash_nonempty1.record().size());
+}
+
+}  // namespace
+}  // namespace common
+}  // namespace maliput

--- a/maliput_utilities/include/maliput-utilities/mesh.h
+++ b/maliput_utilities/include/maliput-utilities/mesh.h
@@ -8,12 +8,11 @@
 #include <unordered_map>
 #include <vector>
 
-#include "drake/common/hash.h"
-
 #include "fmt/ostream.h"
 
 #include "maliput/api/lane.h"
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_hash.h"
 
 namespace maliput {
 namespace utility {
@@ -61,7 +60,7 @@ class UniqueIndexer {
 class GeoVertex {
  public:
   /// A hasher operation suitable for std::unordered_map.
-  using Hash = drake::DefaultHash;
+  using Hash = maliput::common::DefaultHash;
 
   /// An equivalence operation suitable for std::unordered_map.
   struct Equiv {
@@ -77,7 +76,7 @@ class GeoVertex {
   //// Implements the @ref hash_append concept.
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const GeoVertex& item) noexcept {
-    using drake::hash_append;
+    using maliput::common::hash_append;
     hash_append(hasher, item.v_.x());
     hash_append(hasher, item.v_.y());
     hash_append(hasher, item.v_.z());
@@ -91,7 +90,7 @@ class GeoVertex {
 class GeoNormal {
  public:
   /// A hasher operation suitable for std::unordered_map.
-  using Hash = drake::DefaultHash;
+  using Hash = maliput::common::DefaultHash;
 
   /// An equivalence operation suitable for std::unordered_map.
   struct Equiv {
@@ -107,7 +106,7 @@ class GeoNormal {
   //// Implements the @ref hash_append concept.
   template <class HashAlgorithm>
   friend void hash_append(HashAlgorithm& hasher, const GeoNormal& item) noexcept {
-    using drake::hash_append;
+    using maliput::common::hash_append;
     hash_append(hasher, item.n_.x());
     hash_append(hasher, item.n_.y());
     hash_append(hasher, item.n_.z());

--- a/maliput_utilities/include/maliput-utilities/mesh_simplification.h
+++ b/maliput_utilities/include/maliput-utilities/mesh_simplification.h
@@ -11,8 +11,8 @@
 
 #include <Eigen/Geometry>
 
-#include "drake/common/hash.h"
 #include "maliput-utilities/mesh.h"
+#include "maliput/common/maliput_hash.h"
 
 namespace maliput {
 namespace utility {
@@ -38,7 +38,7 @@ inline bool operator!=(const DirectedEdgeIndex& lhs, const DirectedEdgeIndex& rh
 /// Implements the @ref hash_append concept.
 template <class HashAlgorithm>
 void hash_append(HashAlgorithm& hasher, const DirectedEdgeIndex& item) noexcept {
-  using drake::hash_append;
+  using maliput::common::hash_append;
   hash_append(hasher, item.start_vertex_index);
   hash_append(hasher, item.end_vertex_index);
 }
@@ -63,7 +63,7 @@ inline bool operator!=(const FaceEdgeIndex& lhs, const FaceEdgeIndex& rhs) { ret
 /// The inverse of the mapping from face edges indices to their
 /// associated directed edge indices.
 /// @see ComputeInverseFaceEdgeMap
-using InverseFaceEdgeMap = std::unordered_map<DirectedEdgeIndex, FaceEdgeIndex, drake::DefaultHash>;
+using InverseFaceEdgeMap = std::unordered_map<DirectedEdgeIndex, FaceEdgeIndex, maliput::common::DefaultHash>;
 
 /// Computes the inverse of the mapping from face edges indices to their
 /// associated directed edge indices for the given @p faces collection.


### PR DESCRIPTION
PR containing the followings changes:
- `maliput_hash.h` was added in `maliput::common`.
- Drake/hash.h was removed from the repository.
- Code was adapted to `maliput_hash.h`.
