### PR TITLE
Replace std::not1 with std::not_fn

### DIFF
--- a/maliput/src/geometry_base/filter_positions.cc
+++ b/maliput/src/geometry_base/filter_positions.cc
@@ -1,6 +1,7 @@
 #include "maliput/geometry_base/filter_positions.h"
 
 #include <algorithm>
+#include <functional>
 
 namespace maliput {
 namespace geometry_base {
@@ -9,8 +10,7 @@ std::vector<api::RoadPositionResult> FilterRoadPositionResults(
     const std::vector<api::RoadPositionResult>& road_position_results,
     const std::function<bool(const api::RoadPositionResult&)>& filter) {
   std::vector<api::RoadPositionResult> result(road_position_results);
-  // TODO(agalbachicar)   If this code is ever moved to C++17, use std::not_fn() instead.
-  result.erase(std::remove_if(result.begin(), result.end(), std::not1(filter)), result.end());
+  result.erase(std::remove_if(result.begin(), result.end(), std::not_fn(filter)), result.end());
   return result;
 }
 


### PR DESCRIPTION
`std::not1` is deprecated in c++17 and removed in c++20. `std::not_fn` is its replacement, and was added in `c++17`.

* https://en.cppreference.com/w/cpp/utility/functional/not_fn