### PR TITLE
Replaces drake::VectorN<double> by maliput::math::VectorN.

### DIFF
--- a/maliput/include/maliput/api/lane.h
+++ b/maliput/include/maliput/api/lane.h
@@ -194,9 +194,6 @@ class Lane {
   virtual const LaneEndSet* DoGetOngoingBranches(const LaneEnd::Which which_end) const = 0;
 
   virtual std::optional<LaneEnd> DoGetDefaultBranch(const LaneEnd::Which which_end) const = 0;
-
-  // TODO(jadecastro): Template the entire `api::Lane` class to prevent explicit
-  // virtual functions for each member function.
   ///@}
 };
 

--- a/maliput/include/maliput/api/lane_data.h
+++ b/maliput/include/maliput/api/lane_data.h
@@ -4,15 +4,13 @@
 #include <ostream>
 #include <string>
 
-#include "drake/common/default_scalars.h"
-#include "drake/common/eigen_types.h"
-#include "drake/common/extract_double.h"
 #include "drake/math/quaternion.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
 
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/common/maliput_throw.h"
+#include "maliput/math/vector.h"
 
 namespace maliput {
 namespace api {
@@ -64,12 +62,13 @@ class GeoPosition {
   GeoPosition(double x, double y, double z) : xyz_(x, y, z) {}
 
   /// Constructs a GeoPosition from a 3-vector @p xyz of the form `[x, y, z]`.
-  static GeoPosition FromXyz(const drake::Vector3<double>& xyz) { return GeoPosition(xyz); }
+  static GeoPosition FromXyz(const math::Vector3& xyz) { return GeoPosition(xyz); }
 
   /// Returns all components as 3-vector `[x, y, z]`.
-  const drake::Vector3<double>& xyz() const { return xyz_; }
+  const math::Vector3& xyz() const { return xyz_; }
+
   /// Sets all components from 3-vector `[x, y, z]`.
-  void set_xyz(const drake::Vector3<double>& xyz) { xyz_ = xyz; }
+  void set_xyz(const math::Vector3& xyz) { xyz_ = xyz; }
 
   /// @name Getters and Setters
   //@{
@@ -112,9 +111,9 @@ class GeoPosition {
   GeoPosition operator*(double rhs) const { return GeoPosition::FromXyz(this->xyz() * rhs); }
 
  private:
-  explicit GeoPosition(const drake::Vector3<double>& xyz) : xyz_(xyz) {}
+  explicit GeoPosition(const math::Vector3& xyz) : xyz_(xyz) {}
 
-  drake::Vector3<double> xyz_;
+  math::Vector3 xyz_;
 };
 
 /// Streams a string representation of @p geo_position into @p out. Returns
@@ -137,16 +136,14 @@ class Rotation {
   /// Constructs a Rotation from @p rpy, a vector of `[roll, pitch, yaw]`,
   /// expressing a roll around X, followed by pitch around Y,
   /// followed by yaw around Z (with all angles in radians).
-  static Rotation FromRpy(const drake::Vector3<double>& rpy) {
+  static Rotation FromRpy(const math::Vector3& rpy) {
     return Rotation(drake::math::RollPitchYaw<double>(rpy).ToQuaternion());
   }
 
   /// Constructs a Rotation expressing a @p roll around X, followed by
   /// @p pitch around Y, followed by @p yaw around Z (with all angles
   /// in radians).
-  static Rotation FromRpy(double roll, double pitch, double yaw) {
-    return FromRpy(drake::Vector3<double>(roll, pitch, yaw));
-  }
+  static Rotation FromRpy(double roll, double pitch, double yaw) { return FromRpy(math::Vector3(roll, pitch, yaw)); }
 
   /// Provides a quaternion representation of the rotation.
   const drake::Quaternion<double>& quat() const { return quaternion_; }
@@ -213,12 +210,13 @@ class LanePosition {
   LanePosition(double s, double r, double h) : srh_(s, r, h) {}
 
   /// Constructs a LanePosition from a 3-vector @p srh of the form `[s, r, h]`.
-  static LanePosition FromSrh(const drake::Vector3<double>& srh) { return LanePosition(srh); }
+  static LanePosition FromSrh(const math::Vector3& srh) { return LanePosition(srh); }
 
   /// Returns all components as 3-vector `[s, r, h]`.
-  const drake::Vector3<double>& srh() const { return srh_; }
+  const math::Vector3& srh() const { return srh_; }
+
   /// Sets all components from 3-vector `[s, r, h]`.
-  void set_srh(const drake::Vector3<double>& srh) { srh_ = srh; }
+  void set_srh(const math::Vector3& srh) { srh_ = srh; }
 
   /// @name Getters and Setters
   //@{
@@ -237,9 +235,9 @@ class LanePosition {
   //@}
 
  private:
-  explicit LanePosition(const drake::Vector3<double>& srh) : srh_(srh) {}
+  explicit LanePosition(const math::Vector3& srh) : srh_(srh) {}
 
-  drake::Vector3<double> srh_;
+  math::Vector3 srh_;
 };
 
 /// Included in the return result of Lane::ToLanePosition().

--- a/maliput/include/maliput/api/rules/traffic_lights.h
+++ b/maliput/include/maliput/api/rules/traffic_lights.h
@@ -13,6 +13,7 @@
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/common/maliput_hash.h"
 #include "maliput/common/passkey.h"
+#include "maliput/math/vector.h"
 
 namespace maliput {
 namespace api {
@@ -76,8 +77,8 @@ class Bulb final {
     /// (-0.0889m, -0.1778m, -0.1778m) and a `p_BMax` of (0.0889m, 0.1778m,
     /// 0.1778m).
     BoundingBox() : p_BMin(-0.0889, -0.1778, -0.1778), p_BMax(0.0889, 0.1778, 0.1778) {}
-    Eigen::Vector3d p_BMin;
-    Eigen::Vector3d p_BMax;
+    maliput::math::Vector3 p_BMin;
+    maliput::math::Vector3 p_BMax;
   };
 
   /// Constructs a Bulb instance.

--- a/maliput/include/maliput/math/vector.h
+++ b/maliput/include/maliput/math/vector.h
@@ -9,7 +9,9 @@ namespace math {
 /// removal of `drake` out of `maliput` core is performed. A custom
 /// implementation of `Vector3` will be provided once the type migration is
 /// complete.
+using Vector2 = drake::Vector2<double>;
 using Vector3 = drake::Vector3<double>;
+using Vector4 = drake::Vector4<double>;
 
 }  // namespace math
 }  // namespace maliput

--- a/maliput/include/maliput/test_utilities/eigen_matrix_compare.h
+++ b/maliput/include/maliput/test_utilities/eigen_matrix_compare.h
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "maliput/common/logger.h"
+#include "maliput/math/vector.h"
 
 enum class MatrixCompareType { absolute, relative };
 

--- a/maliput/src/api/CMakeLists.txt
+++ b/maliput/src/api/CMakeLists.txt
@@ -31,11 +31,8 @@ target_link_libraries(api
   PUBLIC
     common
     drake::drake
+    math
 )
-target_link_libraries(api
-  PUBLIC
-    common
-    drake::drake)
 
 ##############################################################################
 # Export

--- a/maliput/src/base/traffic_light_book_loader.cc
+++ b/maliput/src/base/traffic_light_book_loader.cc
@@ -7,7 +7,6 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "drake/common/eigen_types.h"
 #include "drake/math/quaternion.h"
 
 #include "maliput/api/lane_data.h"
@@ -15,6 +14,7 @@
 #include "maliput/api/rules/traffic_lights.h"
 #include "maliput/base/traffic_light_book.h"
 #include "maliput/common/maliput_throw.h"
+#include "maliput/math/vector.h"
 
 using drake::Quaternion;
 using maliput::api::GeoPosition;
@@ -117,8 +117,8 @@ struct convert<Bulb::BoundingBox> {
     if (!max_node.IsDefined() || !max_node.IsSequence() || max_node.size() != 3) {
       return false;
     }
-    rhs.p_BMin = Eigen::Vector3d(min_node[0].as<double>(), min_node[1].as<double>(), min_node[2].as<double>());
-    rhs.p_BMax = Eigen::Vector3d(max_node[0].as<double>(), max_node[1].as<double>(), max_node[2].as<double>());
+    rhs.p_BMin = maliput::math::Vector3(min_node[0].as<double>(), min_node[1].as<double>(), min_node[2].as<double>());
+    rhs.p_BMax = maliput::math::Vector3(max_node[0].as<double>(), max_node[1].as<double>(), max_node[2].as<double>());
     return true;
   }
 };

--- a/maliput/test/api/lane_data_test.cc
+++ b/maliput/test/api/lane_data_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "maliput/common/assertion_error.h"
+#include "maliput/math/vector.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 #include "maliput/test_utilities/maliput_types_compare.h"
 
@@ -40,14 +41,14 @@ GTEST_TEST(LanePositionTest, ParameterizedConstructor) {
 
 GTEST_TEST(LanePositionTest, ConstructionFromVector) {
   // Check the conversion-construction from a 3-vector.
-  const LanePosition dut = LanePosition::FromSrh(drake::Vector3<double>(kX0, kX1, kX2));
+  const LanePosition dut = LanePosition::FromSrh(math::Vector3(kX0, kX1, kX2));
   CHECK_ALL_LANE_POSITION_ACCESSORS(dut, kX0, kX1, kX2);
 }
 
 GTEST_TEST(LanePositionTest, VectorSetter) {
   // Check the vector-based setter.
   LanePosition dut(kX0, kX1, kX2);
-  const drake::Vector3<double> srh(9., 7., 8.);
+  const math::Vector3 srh(9., 7., 8.);
   dut.set_srh(srh);
   CHECK_ALL_LANE_POSITION_ACCESSORS(dut, srh.x(), srh.y(), srh.z());
 }
@@ -94,14 +95,14 @@ GTEST_TEST(GeoPositionTest, ParameterizedConstructor) {
 
 GTEST_TEST(GeoPositionTest, ConstructionFromVector) {
   // Check the conversion-construction from a 3-vector.
-  const GeoPosition dut = GeoPosition::FromXyz(drake::Vector3<double>(kX0, kX1, kX2));
+  const GeoPosition dut = GeoPosition::FromXyz(math::Vector3(kX0, kX1, kX2));
   CHECK_ALL_GEO_POSITION_ACCESSORS(dut, kX0, kX1, kX2);
 }
 
 GTEST_TEST(GeoPositionTest, VectorSetter) {
   // Check the vector-based setter.
   GeoPosition dut(kX0, kX1, kX2);
-  const drake::Vector3<double> xyz(9., 7., 8.);
+  const math::Vector3 xyz(9., 7., 8.);
   dut.set_xyz(xyz);
   CHECK_ALL_GEO_POSITION_ACCESSORS(dut, xyz.x(), xyz.y(), xyz.z());
 }
@@ -172,25 +173,26 @@ GTEST_TEST(GeoPosition, DistanceTest) {
   const GeoPosition dut(25., 85., 12.);
   EXPECT_NEAR(dut.Distance({66.0, 90.0, -25.0}), 55.452682532047085, kLinearTolerance);
 }
+
 // An arbitrary very small number (that passes the tests).
 const double kRotationTolerance = 1e-15;
 
-#define CHECK_ALL_ROTATION_ACCESSORS(dut, _w, _x, _y, _z, _ro, _pi, _ya, _ma)                                      \
-  do {                                                                                                             \
-    EXPECT_TRUE(CompareMatrices(dut.quat().coeffs(), drake::Vector4<double>(_x, _y, _z, _w), kRotationTolerance)); \
-    EXPECT_TRUE(CompareMatrices(dut.rpy().vector(), drake::Vector3<double>(_ro, _pi, _ya), kRotationTolerance));   \
-    EXPECT_NEAR(dut.roll(), _ro, kRotationTolerance);                                                              \
-    EXPECT_NEAR(dut.pitch(), _pi, kRotationTolerance);                                                             \
-    EXPECT_NEAR(dut.yaw(), _ya, kRotationTolerance);                                                               \
-    EXPECT_TRUE(CompareMatrices(dut.matrix(), _ma, kRotationTolerance));                                           \
+#define CHECK_ALL_ROTATION_ACCESSORS(dut, _w, _x, _y, _z, _ro, _pi, _ya, _ma)                             \
+  do {                                                                                                    \
+    EXPECT_TRUE(CompareMatrices(dut.quat().coeffs(), math::Vector4(_x, _y, _z, _w), kRotationTolerance)); \
+    EXPECT_TRUE(CompareMatrices(dut.rpy().vector(), math::Vector3(_ro, _pi, _ya), kRotationTolerance));   \
+    EXPECT_NEAR(dut.roll(), _ro, kRotationTolerance);                                                     \
+    EXPECT_NEAR(dut.pitch(), _pi, kRotationTolerance);                                                    \
+    EXPECT_NEAR(dut.yaw(), _ya, kRotationTolerance);                                                      \
+    EXPECT_TRUE(CompareMatrices(dut.matrix(), _ma, kRotationTolerance));                                  \
   } while (0)
 
 class RotationTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // A quaternion that rotates x->y, y->z, z->x...
-    twist_quat_ = drake::Quaternion<double>(
-        Eigen::AngleAxis<double>(M_PI * 2. / 3., drake::Vector3<double>(1.0, 1.0, 1.0).normalized()));
+    twist_quat_ =
+        drake::Quaternion<double>(Eigen::AngleAxis<double>(M_PI * 2. / 3., math::Vector3(1.0, 1.0, 1.0).normalized()));
 
     nonnormalized_twist_quat_ = drake::Quaternion<double>(7. * twist_quat_.coeffs());
 

--- a/maliput_utilities/include/maliput-utilities/generate_obj.h
+++ b/maliput_utilities/include/maliput-utilities/generate_obj.h
@@ -66,11 +66,11 @@ enum MaterialType { Asphalt, Lane, Marker, HBounds, BranchPointGlow, GrayedAspha
 /// Material information for built meshes.
 struct Material {
   std::string name;
-  drake::Vector3<double> diffuse;   /// Kd
-  drake::Vector3<double> ambient;   /// Ka
-  drake::Vector3<double> specular;  /// Ks
-  double shinines;                  /// Ns
-  double transparency;              /// 1.0 - d
+  math::Vector3 diffuse;   /// Kd
+  math::Vector3 ambient;   /// Ka
+  math::Vector3 specular;  /// Ks
+  double shinines;         /// Ns
+  double transparency;     /// 1.0 - d
 
   friend bool operator==(const Material& matA, const Material& matB) { return matA.name == matB.name; }
 

--- a/maliput_utilities/include/maliput-utilities/mesh_simplification.h
+++ b/maliput_utilities/include/maliput-utilities/mesh_simplification.h
@@ -13,6 +13,7 @@
 
 #include "maliput-utilities/mesh.h"
 #include "maliput/common/maliput_hash.h"
+#include "maliput/math/vector.h"
 
 namespace maliput {
 namespace utility {
@@ -99,13 +100,13 @@ using Hyperplane3 = Eigen::Hyperplane<T, 3>;
 /// @pre Given @p vertex belongs to the @p mesh.
 /// @warning If any of the preconditions is not met, this function will
 ///          abort execution.
-const drake::Vector3<double>& GetMeshFaceVertexPosition(const GeoMesh& mesh, const IndexFace::Vertex& vertex);
+const math::Vector3& GetMeshFaceVertexPosition(const GeoMesh& mesh, const IndexFace::Vertex& vertex);
 
 /// Gets normal vector of the @p vertex in the given @p mesh.
 /// @pre Given @p vertex belongs to the @p mesh.
 /// @warning If any of the preconditions is not met, this function will
 ///          abort execution.
-const drake::Vector3<double>& GetMeshFaceVertexNormal(const GeoMesh& mesh, const IndexFace::Vertex& vertex);
+const math::Vector3& GetMeshFaceVertexNormal(const GeoMesh& mesh, const IndexFace::Vertex& vertex);
 
 /// Checks if all the IndexFace::Vertex instances, from @p first to
 /// @p last, in the given @p mesh lie on the provided @p plane by
@@ -119,8 +120,8 @@ template <typename InputIt>
 bool DoMeshVerticesLieOnPlane(const GeoMesh& mesh, InputIt first, InputIt last, const Hyperplane3<double>& plane,
                               double tolerance) {
   return std::all_of(first, last, [&mesh, &plane, tolerance](const IndexFace::Vertex& vertex) {
-    const drake::Vector3<double>& x = GetMeshFaceVertexPosition(mesh, vertex);
-    const drake::Vector3<double>& n = GetMeshFaceVertexNormal(mesh, vertex);
+    const math::Vector3& x = GetMeshFaceVertexPosition(mesh, vertex);
+    const math::Vector3& n = GetMeshFaceVertexNormal(mesh, vertex);
     const double ctheta = std::abs(plane.normal().dot(n.normalized()));
     return (ctheta != 0. && plane.absDistance(x) / ctheta < tolerance);
   });

--- a/maliput_utilities/src/maliput-utilities/CMakeLists.txt
+++ b/maliput_utilities/src/maliput-utilities/CMakeLists.txt
@@ -23,10 +23,11 @@ ament_target_dependencies(maliput-utilities
 )
 
 target_link_libraries(maliput-utilities
-    multilane::multilane
+    drake::drake
     maliput::api
     maliput::common
-    drake::drake
+    maliput::math
+    multilane::multilane
 )
 
 add_executable(yaml_to_obj

--- a/maliput_utilities/src/maliput-utilities/generate_obj.cc
+++ b/maliput_utilities/src/maliput-utilities/generate_obj.cc
@@ -20,6 +20,7 @@
 #include "maliput/api/road_geometry.h"
 #include "maliput/api/segment.h"
 #include "maliput/common/maliput_abort.h"
+#include "maliput/math/vector.h"
 
 namespace maliput {
 namespace utility {
@@ -52,7 +53,7 @@ const std::vector<Material> kMaterial{
     {kGrayedLaneHaze, {0.9, 0.9, 0.9}, {0.9, 0.9, 0.9}, {0.9, 0.9, 0.9}, 10., 0.9},
     {kGrayedMarkerPaint, {0.8, 0.8, 0.0}, {1.0, 1.0, 0.0}, {1.0, 1.0, 0.5}, 10., 0.9}};
 
-std::string FormatDrakeVector3AsRow(const drake::Vector3<double>& vec) {
+std::string FormatDrakeVector3AsRow(const math::Vector3& vec) {
   return fmt::format("{} {} {}", std::to_string(vec.x()), std::to_string(vec.y()), std::to_string(vec.z()));
 }
 
@@ -562,11 +563,10 @@ void RenderBranchPoint(const api::BranchPoint* const branch_point, const double 
     // If distance in sr-plane is too close and distance along h-axis is
     // too close, then increase elevation and try again.
     for (const api::GeoPosition& previous_xyz : *previous_centers) {
-      const drake::Vector3<double> delta_xyz = previous_xyz.xyz() - center_xyz.xyz();
-      const drake::Vector3<double> delta_srh = orientation.matrix().transpose() * delta_xyz;
+      const math::Vector3 delta_xyz = previous_xyz.xyz() - center_xyz.xyz();
+      const math::Vector3 delta_srh = orientation.matrix().transpose() * delta_xyz;
 
-      if ((drake::Vector2<double>(delta_srh.x(), delta_srh.y()).norm() < sr_margin) &&
-          (std::abs(delta_srh.z()) < h_margin)) {
+      if ((math::Vector2(delta_srh.x(), delta_srh.y()).norm() < sr_margin) && (std::abs(delta_srh.z()) < h_margin)) {
         has_conflict = true;
         elevation += height;
         break;

--- a/maliput_utilities/src/maliput-utilities/mesh_simplification.cc
+++ b/maliput_utilities/src/maliput-utilities/mesh_simplification.cc
@@ -46,11 +46,11 @@ FaceAdjacencyMap ComputeFaceAdjacencyMap(const std::vector<IndexFace>& faces) {
   return adjacent_faces_map;
 }
 
-const drake::Vector3<double>& GetMeshFaceVertexPosition(const GeoMesh& mesh, const IndexFace::Vertex& vertex) {
+const math::Vector3& GetMeshFaceVertexPosition(const GeoMesh& mesh, const IndexFace::Vertex& vertex) {
   return mesh.vertices().at(vertex.vertex_index)->v().xyz();
 }
 
-const drake::Vector3<double>& GetMeshFaceVertexNormal(const GeoMesh& mesh, const IndexFace::Vertex& vertex) {
+const math::Vector3& GetMeshFaceVertexNormal(const GeoMesh& mesh, const IndexFace::Vertex& vertex) {
   return mesh.normals().at(vertex.normal_index)->n().xyz();
 }
 
@@ -64,8 +64,8 @@ bool IsMeshFacePlanar(const GeoMesh& mesh, const IndexFace& face, double toleran
   MALIPUT_DEMAND(plane != nullptr);
   const std::vector<IndexFace::Vertex>& face_vertices = face.vertices();
   MALIPUT_DEMAND(face_vertices.size() >= 3);
-  const drake::Vector3<double>& x0 = GetMeshFaceVertexPosition(mesh, face_vertices[0]);
-  const drake::Vector3<double>& n0 = GetMeshFaceVertexNormal(mesh, face_vertices[0]);
+  const math::Vector3& x0 = GetMeshFaceVertexPosition(mesh, face_vertices[0]);
+  const math::Vector3& n0 = GetMeshFaceVertexNormal(mesh, face_vertices[0]);
   *plane = Hyperplane3<double>(n0.normalized(), x0);
   return DoMeshVerticesLieOnPlane(mesh, face_vertices.begin() + 1, face_vertices.end(), *plane, tolerance);
 }
@@ -177,7 +177,7 @@ std::vector<FaceVertexIndex> SimplifyMeshFacesContour(const GeoMesh& mesh,
       [&mesh](const FaceVertexIndex& face_vertex_index) {
         return GetMeshFaceVertexPosition(mesh, MeshFaceVertexAt(mesh, face_vertex_index));
       },
-      [](const drake::Vector3<double>& start_vertex, const drake::Vector3<double>& end_vertex) {
+      [](const math::Vector3& start_vertex, const math::Vector3& end_vertex) {
         return ParametrizedLine3<double>{start_vertex, (end_vertex - start_vertex).normalized()};
       },
       tolerance, std::back_inserter(simplified_contour_indices));

--- a/maliput_utilities/test/mesh_simplification_test.cc
+++ b/maliput_utilities/test/mesh_simplification_test.cc
@@ -132,16 +132,16 @@ class GeoMeshSimplificationTest : public ::testing::Test {
   const int kVertexHIndex{7};
   const int kVertexIIndex{8};
 
-  const drake::Vector3<double> kNormalVector{0., 0., 1.};
-  const drake::Vector3<double> kVertexAPosition{0., 0., 0.};
-  const drake::Vector3<double> kVertexBPosition{1., 0., 0.};
-  const drake::Vector3<double> kVertexCPosition{1., 1., 0.};
-  const drake::Vector3<double> kVertexDPosition{0., 1., 0.};
-  const drake::Vector3<double> kVertexEPosition{2., 0., 0.};
-  const drake::Vector3<double> kVertexFPosition{2., 1., 0.};
-  const drake::Vector3<double> kVertexGPosition{3., 1., 1.};
-  const drake::Vector3<double> kVertexHPosition{2., 2., -1.};
-  const drake::Vector3<double> kVertexIPosition{0., 2., 1.};
+  const math::Vector3 kNormalVector{0., 0., 1.};
+  const math::Vector3 kVertexAPosition{0., 0., 0.};
+  const math::Vector3 kVertexBPosition{1., 0., 0.};
+  const math::Vector3 kVertexCPosition{1., 1., 0.};
+  const math::Vector3 kVertexDPosition{0., 1., 0.};
+  const math::Vector3 kVertexEPosition{2., 0., 0.};
+  const math::Vector3 kVertexFPosition{2., 1., 0.};
+  const math::Vector3 kVertexGPosition{3., 1., 1.};
+  const math::Vector3 kVertexHPosition{2., 2., -1.};
+  const math::Vector3 kVertexIPosition{0., 2., 1.};
 
   const int kFirstQuadIndex{0};
   const int kSecondQuadIndex{1};

--- a/multilane/include/multilane/arc_road_curve.h
+++ b/multilane/include/multilane/arc_road_curve.h
@@ -2,11 +2,10 @@
 
 #include <cmath>
 
-#include "drake/common/eigen_types.h"
-
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/common/maliput_throw.h"
 #include "maliput/common/maliput_unused.h"
+#include "maliput/math/vector.h"
 
 #include "multilane/road_curve.h"
 
@@ -47,7 +46,7 @@ class ArcRoadCurve : public RoadCurve {
   ///         positive number.
   /// @throws maliput::common::assertion_error if @p scale_length is not a
   ///         positive number.
-  explicit ArcRoadCurve(const drake::Vector2<double>& center, double radius, double theta0, double d_theta,
+  explicit ArcRoadCurve(const math::Vector2& center, double radius, double theta0, double d_theta,
                         const CubicPolynomial& elevation, const CubicPolynomial& superelevation,
                         double linear_tolerance, double scale_length, ComputationPolicy computation_policy)
       : RoadCurve(linear_tolerance, scale_length, elevation, superelevation, computation_policy),
@@ -60,16 +59,16 @@ class ArcRoadCurve : public RoadCurve {
 
   ~ArcRoadCurve() override = default;
 
-  drake::Vector2<double> xy_of_p(double p) const override {
+  math::Vector2 xy_of_p(double p) const override {
     // The result will be computed with the following function:
     //      [x;y] = center + [radius * cos(θ); radius * sin(θ)]
     // and:
     //      θ = θ₀ + (p * Δθ)
     const double theta = theta_of_p(p);
-    return center_ + drake::Vector2<double>(radius_ * std::cos(theta), radius_ * std::sin(theta));
+    return center_ + math::Vector2(radius_ * std::cos(theta), radius_ * std::sin(theta));
   }
 
-  drake::Vector2<double> xy_dot_of_p(double p) const override {
+  math::Vector2 xy_dot_of_p(double p) const override {
     // Given:
     //      [x;y] = center + [radius * cos(θ); radius * sin(θ)]
     // and:
@@ -79,7 +78,7 @@ class ArcRoadCurve : public RoadCurve {
     //      [dx/dp; dy/dp] = [-radius * sin(θ) * dθ/dp; radius * cos(θ) * dθ/dp]
     //                     = [-radius * sin(θ) * Δθ; radius * cos(θ) * Δθ]
     const double theta = theta_of_p(p);
-    return drake::Vector2<double>(-radius_ * std::sin(theta) * d_theta_, radius_ * std::cos(theta) * d_theta_);
+    return math::Vector2(-radius_ * std::sin(theta) * d_theta_, radius_ * std::cos(theta) * d_theta_);
   }
 
   double heading_of_p(double p) const override {
@@ -105,8 +104,8 @@ class ArcRoadCurve : public RoadCurve {
 
   double l_max() const override { return radius_ * std::abs(d_theta_); }
 
-  drake::Vector3<double> ToCurveFrame(const drake::Vector3<double>& geo_coordinate, double r_min, double r_max,
-                                      const api::HBounds& height_bounds) const override;
+  math::Vector3 ToCurveFrame(const math::Vector3& geo_coordinate, double r_min, double r_max,
+                             const api::HBounds& height_bounds) const override;
 
   bool IsValid(double r_min, double r_max, const api::HBounds& height_bounds) const override;
 
@@ -131,7 +130,7 @@ class ArcRoadCurve : public RoadCurve {
 
   // Center of rotation in z=0 plane, world coordinates, for the arc reference
   // curve.
-  const drake::Vector2<double> center_;
+  const math::Vector2 center_;
   // The length of the radius of the arc.
   const double radius_{};
   // The angular position at which the piece of arc starts.

--- a/multilane/include/multilane/lane.h
+++ b/multilane/include/multilane/lane.h
@@ -19,9 +19,6 @@ namespace multilane {
 
 class BranchPoint;
 
-typedef drake::Vector2<double> V2;
-typedef drake::Vector3<double> V3;
-
 /// Base class for the multilane implementation of api::Lane.
 class Lane : public api::Lane {
  public:

--- a/multilane/include/multilane/line_road_curve.h
+++ b/multilane/include/multilane/line_road_curve.h
@@ -4,13 +4,11 @@
 #include <limits>
 #include <utility>
 
-#include "drake/common/drake_throw.h"
-#include "drake/common/eigen_types.h"
-
 #include "maliput/api/lane_data.h"
 #include "maliput/common/maliput_abort.h"
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/common/maliput_unused.h"
+#include "maliput/math/vector.h"
 
 #include "multilane/road_curve.h"
 
@@ -43,9 +41,9 @@ class LineRoadCurve : public RoadCurve {
   /// positive number.
   /// @throws maliput::common::assertion_error if @p scale_length is not a
   /// positive number.
-  explicit LineRoadCurve(const drake::Vector2<double>& xy0, const drake::Vector2<double>& dxy,
-                         const CubicPolynomial& elevation, const CubicPolynomial& superelevation,
-                         double linear_tolerance, double scale_length, ComputationPolicy computation_policy)
+  explicit LineRoadCurve(const math::Vector2& xy0, const math::Vector2& dxy, const CubicPolynomial& elevation,
+                         const CubicPolynomial& superelevation, double linear_tolerance, double scale_length,
+                         ComputationPolicy computation_policy)
       : RoadCurve(linear_tolerance, scale_length, elevation, superelevation, computation_policy),
         p0_(xy0),
         dp_(dxy),
@@ -55,9 +53,9 @@ class LineRoadCurve : public RoadCurve {
 
   ~LineRoadCurve() override = default;
 
-  drake::Vector2<double> xy_of_p(double p) const override { return p0_ + p * dp_; }
+  math::Vector2 xy_of_p(double p) const override { return p0_ + p * dp_; }
 
-  drake::Vector2<double> xy_dot_of_p(double p) const override {
+  math::Vector2 xy_dot_of_p(double p) const override {
     maliput::common::unused(p);
     return dp_;
   }
@@ -74,8 +72,8 @@ class LineRoadCurve : public RoadCurve {
 
   double l_max() const override { return dp_.norm(); }
 
-  drake::Vector3<double> ToCurveFrame(const drake::Vector3<double>& geo_coordinate, double r_min, double r_max,
-                                      const api::HBounds& height_bounds) const override;
+  math::Vector3 ToCurveFrame(const math::Vector3& geo_coordinate, double r_min, double r_max,
+                             const api::HBounds& height_bounds) const override;
 
   bool IsValid(double r_min, double r_max, const api::HBounds& height_bounds) const override {
     maliput::common::unused(r_min);
@@ -96,10 +94,10 @@ class LineRoadCurve : public RoadCurve {
 
   // The first point in world coordinates over the z=0 plane of the reference
   // curve.
-  const drake::Vector2<double> p0_{};
+  const math::Vector2 p0_{};
   // The difference vector that joins the end point of the reference curve with
   // the first one, p0_.
-  const drake::Vector2<double> dp_{};
+  const math::Vector2 dp_{};
   // The constant angle deviation of dp_ with respect to the x axis of the world
   // frame.
   const double heading_{};

--- a/multilane/src/multilane/CMakeLists.txt
+++ b/multilane/src/multilane/CMakeLists.txt
@@ -30,9 +30,10 @@ ament_target_dependencies(multilane
 )
 
 target_link_libraries(multilane
+  drake::drake
   maliput::api
   maliput::common
-  drake::drake
+  maliput::math
   yaml-cpp
 )
 

--- a/multilane/src/multilane/arc_road_curve.cc
+++ b/multilane/src/multilane/arc_road_curve.cc
@@ -74,16 +74,16 @@ double saturate_on_wrapped_bounds(double theta, double theta_min, double theta_m
 
 }  // namespace
 
-drake::Vector3<double> ArcRoadCurve::ToCurveFrame(const drake::Vector3<double>& geo_coordinate, double r_min,
-                                                  double r_max, const api::HBounds& height_bounds) const {
+math::Vector3 ArcRoadCurve::ToCurveFrame(const math::Vector3& geo_coordinate, double r_min, double r_max,
+                                         const api::HBounds& height_bounds) const {
   MALIPUT_DEMAND(r_min <= r_max);
   // TODO(jadecastro): Lift the zero superelevation and zero elevation gradient
   // restriction.
-  const drake::Vector2<double> q(geo_coordinate.x(), geo_coordinate.y());
+  const math::Vector2 q(geo_coordinate.x(), geo_coordinate.y());
   MALIPUT_DEMAND(q != center_);
 
   // Define a vector from q to the center of the arc.
-  const drake::Vector2<double> v = q - center_;
+  const math::Vector2 v = q - center_;
 
   const double theta_min = std::min(theta0_, d_theta_ + theta0_);
   const double theta_max = std::max(theta0_, d_theta_ + theta0_);
@@ -108,7 +108,7 @@ drake::Vector3<double> ArcRoadCurve::ToCurveFrame(const drake::Vector3<double>& 
   // `a` coefficient is normalized by lane length).
   const double h_unsaturated = geo_coordinate.z() - elevation().a() * l_max();
   const double h = drake::math::saturate(h_unsaturated, height_bounds.min(), height_bounds.max());
-  return drake::Vector3<double>(p, r, h);
+  return math::Vector3(p, r, h);
 }
 
 bool ArcRoadCurve::IsValid(double r_min, double r_max, const api::HBounds& height_bounds) const {

--- a/multilane/src/multilane/builder.cc
+++ b/multilane/src/multilane/builder.cc
@@ -146,8 +146,8 @@ const Connection* Builder::Connect(const std::string& id, const LaneLayout& lane
   // Gets the initial heading and superelevation.
   const double start_heading = start_spec.endpoint().xy().heading();
   const double start_superelevation = start_spec.endpoint().z().theta();
-  const drake::Vector3<double> start_lane_position(start_spec.endpoint().xy().x(), start_spec.endpoint().xy().y(),
-                                                   start_spec.endpoint().z().z());
+  const math::Vector3 start_lane_position(start_spec.endpoint().xy().x(), start_spec.endpoint().xy().y(),
+                                          start_spec.endpoint().z().z());
   const double start_lane_offset =
       -lane_layout.ref_r0() + lane_width_ * static_cast<double>(start_spec.lane_id() - lane_layout.ref_lane());
 
@@ -155,8 +155,8 @@ const Connection* Builder::Connect(const std::string& id, const LaneLayout& lane
   // point to start_reference_position.
   const api::Rotation start_rotation =
       api::Rotation::FromRpy(start_superelevation, -std::atan(start_spec.endpoint().z().z_dot()), start_heading);
-  const drake::Vector3<double> start_reference_position =
-      start_lane_position + start_rotation.matrix() * drake::Vector3<double>(0., -start_lane_offset, 0.);
+  const math::Vector3 start_reference_position =
+      start_lane_position + start_rotation.matrix() * math::Vector3(0., -start_lane_offset, 0.);
 
   // Assigns the start endpoint.
   Endpoint start{EndpointXy(start_reference_position.x(), start_reference_position.y(), start_heading),
@@ -202,10 +202,10 @@ const Connection* Builder::Connect(const std::string& id, const LaneLayout& lane
   // point to start_reference_position.
   const api::Rotation start_rotation =
       api::Rotation::FromRpy(start_superelevation, -std::atan(start_z_dot), start_spec.endpoint().xy().heading());
-  const drake::Vector3<double> start_lane_position{start_spec.endpoint().xy().x(), start_spec.endpoint().xy().y(),
-                                                   start_spec.endpoint().z().z()};
-  const drake::Vector3<double> start_reference_position =
-      start_lane_position + start_rotation.matrix() * drake::Vector3<double>(0., -start_lane_offset, 0.);
+  const math::Vector3 start_lane_position{start_spec.endpoint().xy().x(), start_spec.endpoint().xy().y(),
+                                          start_spec.endpoint().z().z()};
+  const math::Vector3 start_reference_position =
+      start_lane_position + start_rotation.matrix() * math::Vector3(0., -start_lane_offset, 0.);
 
   // Assigns the start endpoint.
   Endpoint start{
@@ -255,9 +255,8 @@ namespace {
 
 // Determine the heading direction at an `r_offset` leftwards of the `lane`
 // centerline when traveling outwards from the specified `end`.
-drake::Vector3<double> DirectionOutFromLane(const api::Lane* const lane, const api::LaneEnd::Which end,
-                                            double r_offset) {
-  const drake::Vector3<double> s_hat = drake::Vector3<double>::UnitX();
+math::Vector3 DirectionOutFromLane(const api::Lane* const lane, const api::LaneEnd::Which end, double r_offset) {
+  const math::Vector3 s_hat = math::Vector3::UnitX();
   switch (end) {
     case api::LaneEnd::kStart: {
       return -(lane->GetOrientation({0., -r_offset, 0.}).matrix() * s_hat);
@@ -273,13 +272,13 @@ drake::Vector3<double> DirectionOutFromLane(const api::Lane* const lane, const a
 // leftwards of the centerlines when traveling outwards from their specified
 // end in `set` matches the reference `direction_at_r_offset`, down to the
 // given `angular_tolerance`.
-bool AreLanesDirectionsWithinTolerance(const drake::Vector3<double>& direction_at_r_offset, double r_offset,
+bool AreLanesDirectionsWithinTolerance(const math::Vector3& direction_at_r_offset, double r_offset,
                                        const api::LaneEndSet* set, double angular_tolerance) {
   MALIPUT_DEMAND(set != nullptr);
 
   for (int i = 0; i < set->size(); ++i) {
     const api::LaneEnd& le = set->get(i);
-    const drake::Vector3<double> other_direction = DirectionOutFromLane(le.lane, le.end, r_offset);
+    const math::Vector3 other_direction = DirectionOutFromLane(le.lane, le.end, r_offset);
     const double angular_deviation = std::acos(direction_at_r_offset.dot(other_direction));
     if (angular_deviation > angular_tolerance) {
       return false;
@@ -302,7 +301,7 @@ bool IsLaneContinuousAtBranchPointAlongROffset(const api::Lane* lane, const api:
   MALIPUT_DEMAND(parallel_set != nullptr);
   MALIPUT_DEMAND(antiparallel_set != nullptr);
 
-  const drake::Vector3<double> direction = DirectionOutFromLane(lane, end, r_offset);
+  const math::Vector3 direction = DirectionOutFromLane(lane, end, r_offset);
   return (AreLanesDirectionsWithinTolerance(direction, r_offset, parallel_set, angular_tolerance) &&
           AreLanesDirectionsWithinTolerance(-direction, r_offset, antiparallel_set, angular_tolerance));
 }
@@ -375,9 +374,9 @@ void Builder::AttachBranchPoint(const Endpoint& point, Lane* const lane, const a
   // other, B-side.  Do this by examining the dot-product of the heading
   // vectors (rather than goofing around with cyclic angle arithmetic).
   constexpr double kZeroROffset{0.};
-  const drake::Vector3<double> direction = DirectionOutFromLane(lane, end, kZeroROffset);
+  const math::Vector3 direction = DirectionOutFromLane(lane, end, kZeroROffset);
   const api::LaneEnd& old_le = bp->GetASide()->get(0);
-  const drake::Vector3<double> old_direction = DirectionOutFromLane(old_le.lane, old_le.end, kZeroROffset);
+  const math::Vector3 old_direction = DirectionOutFromLane(old_le.lane, old_le.end, kZeroROffset);
   if (direction.dot(old_direction) > 0.) {
     // Assert continuity before attaching the lane.
     MALIPUT_THROW_UNLESS(IsLaneContinuousAtBranchPoint(lane, end, bp->GetASide(), bp->GetBSide(), angular_tolerance_));

--- a/multilane/src/multilane/connection.cc
+++ b/multilane/src/multilane/connection.cc
@@ -116,7 +116,7 @@ Connection::Connection(const std::string& id, const Endpoint& start, const Endpo
 Endpoint Connection::LaneStart(int lane_index) const {
   MALIPUT_DEMAND(lane_index >= 0 && lane_index < num_lanes_);
   const double r = lane_offset(lane_index);
-  const drake::Vector3<double> position = road_curve_->W_of_prh(0., r, 0.);
+  const math::Vector3 position = road_curve_->W_of_prh(0., r, 0.);
   const Rot3 rotation = road_curve_->Orientation(0., r, 0.);
   // Let t be the arc-length xy projection of the lane centerline and t_of_p be
   // a linear function of p (given that p <--> s is a linear relation too).
@@ -127,7 +127,7 @@ Endpoint Connection::LaneStart(int lane_index) const {
   // The same applies to theta_dot.
 
   // Computes w_prime to obtain ∂z/∂p.
-  const drake::Vector3<double> w_prime =
+  const math::Vector3 w_prime =
       road_curve_->W_prime_of_prh(0., r, 0., road_curve_->Rabg_of_p(0.), road_curve_->elevation().f_dot_p(0.));
   // Computes ∂p/∂t based on Connection geometry type.
 
@@ -150,7 +150,7 @@ Endpoint Connection::LaneStart(int lane_index) const {
 Endpoint Connection::LaneEnd(int lane_index) const {
   MALIPUT_DEMAND(lane_index >= 0 && lane_index < num_lanes_);
   const double r = lane_offset(lane_index);
-  const drake::Vector3<double> position = road_curve_->W_of_prh(1., r, 0.);
+  const math::Vector3 position = road_curve_->W_of_prh(1., r, 0.);
   const Rot3 rotation = road_curve_->Orientation(1., r, 0.);
   // Let t be the arc-length xy projection of the lane centerline and t_of_p be
   // a linear function of p (given that p <--> s is a linear relation too).
@@ -161,7 +161,7 @@ Endpoint Connection::LaneEnd(int lane_index) const {
   // The same applies to theta_dot.
 
   // Computes w_prime to obtain ∂z/∂p.
-  const drake::Vector3<double> w_prime =
+  const math::Vector3 w_prime =
       road_curve_->W_prime_of_prh(1., r, 0., road_curve_->Rabg_of_p(1.), road_curve_->elevation().f_dot_p(1.));
   // Computes ∂p/∂t based on Connection geometry type.
 
@@ -198,8 +198,8 @@ CubicPolynomial MakeCubic(double dX, double Y0, double dY, double Ydot0, double 
 std::unique_ptr<RoadCurve> Connection::CreateRoadCurve() const {
   switch (type_) {
     case Connection::kLine: {
-      const drake::Vector2<double> xy0(start_.xy().x(), start_.xy().y());
-      const drake::Vector2<double> dxy(end_.xy().x() - start_.xy().x(), end_.xy().y() - start_.xy().y());
+      const math::Vector2 xy0(start_.xy().x(), start_.xy().y());
+      const math::Vector2 dxy(end_.xy().x() - start_.xy().x(), end_.xy().y() - start_.xy().y());
       const CubicPolynomial elevation(
           MakeCubic(dxy.norm(), start_.z().z(), end_.z().z() - start_.z().z(), start_.z().z_dot(), end_.z().z_dot()));
       const CubicPolynomial superelevation(MakeCubic(dxy.norm(), start_.z().theta(),
@@ -209,7 +209,7 @@ std::unique_ptr<RoadCurve> Connection::CreateRoadCurve() const {
                                              computation_policy_);
     };
     case Connection::kArc: {
-      const drake::Vector2<double> center(cx_, cy_);
+      const math::Vector2 center(cx_, cy_);
       const double arc_length = radius_ * std::abs(d_theta_);
       const CubicPolynomial elevation(
           MakeCubic(arc_length, start_.z().z(), end_.z().z() - start_.z().z(), start_.z().z_dot(), end_.z().z_dot()));

--- a/multilane/src/multilane/lane.cc
+++ b/multilane/src/multilane/lane.cc
@@ -38,7 +38,7 @@ std::optional<api::LaneEnd> Lane::DoGetDefaultBranch(api::LaneEnd::Which which_e
 api::GeoPosition Lane::DoToGeoPosition(const api::LanePosition& lane_pos) const {
   // Recover parameter p from arc-length position s.
   const double p = p_from_s_at_r0_(lane_pos.s());
-  const drake::Vector3<double> xyz = road_curve_->W_of_prh(p, lane_pos.r() + r0_, lane_pos.h());
+  const math::Vector3 xyz = road_curve_->W_of_prh(p, lane_pos.r() + r0_, lane_pos.h());
   return {xyz.x(), xyz.y(), xyz.z()};
 }
 
@@ -78,7 +78,7 @@ api::LanePositionResult Lane::DoToLanePosition(const api::GeoPosition& geo_posit
   // Lane position is over the segment's road curve frame, so a change is
   // needed. That implies getting the path length s from p and translating the r
   // coordinate because of the offset.
-  const V3 lane_position_in_segment_curve_frame =
+  const math::Vector3 lane_position_in_segment_curve_frame =
       road_curve_->ToCurveFrame(geo_position.xyz(), r_min, r_max, elevation_bounds_);
   const double s = s_from_p_at_r0_(lane_position_in_segment_curve_frame[0]);
   const api::LanePosition lane_position =

--- a/multilane/src/multilane_test_utilities/CMakeLists.txt
+++ b/multilane/src/multilane_test_utilities/CMakeLists.txt
@@ -19,11 +19,12 @@ target_include_directories(
 )
 
 target_link_libraries(multilane_test_utilities
-  multilane
+  drake::drake
   maliput::api
   maliput::common
   maliput::maliput_test_utilities
-  drake::drake
+  maliput::math
+  multilane
 )
 
 install(

--- a/multilane/src/multilane_test_utilities/multilane_brute_force_integral.cc
+++ b/multilane/src/multilane_test_utilities/multilane_brute_force_integral.cc
@@ -4,9 +4,8 @@
 #include <cmath>
 #include <limits>
 
-#include "drake/common/eigen_types.h"
-
 #include "maliput/common/maliput_throw.h"
+#include "maliput/math/vector.h"
 
 namespace maliput {
 namespace multilane {
@@ -28,10 +27,10 @@ double BruteForcePathLengthIntegral(const RoadCurve& rc, double p_0, double p_1,
   // in the global frame for each interval boundary and sums up the path lengths
   // of the segments in the global frame that correspond to each one of those
   // intervals.
-  drake::Vector3<double> geo_position_at_prev_p = rc.W_of_prh(p_0, r, h);
+  math::Vector3 geo_position_at_prev_p = rc.W_of_prh(p_0, r, h);
   for (int i = 1; i <= iterations; ++i) {
     const double p = p_0 + d_p * static_cast<double>(i) / iterations;
-    const drake::Vector3<double> geo_position_at_p = rc.W_of_prh(p, r, h);
+    const math::Vector3 geo_position_at_p = rc.W_of_prh(p, r, h);
     const double ith_step_length = (geo_position_at_p - geo_position_at_prev_p).norm();
     if (maximum_step != nullptr) {
       // Keep track of the maximum step taken.

--- a/multilane/test/multilane/CMakeLists.txt
+++ b/multilane/test/multilane/CMakeLists.txt
@@ -24,10 +24,11 @@ macro(add_dependencies_to_test target)
       )
 
       target_link_libraries(${target}
+          drake::drake
           maliput::api
           maliput::common
-          multilane_test_utilities
-          drake::drake)
+          maliput::math
+          multilane_test_utilities)
 
     endif()
 endmacro()

--- a/multilane/test/multilane/multilane_arc_road_curve_test.cc
+++ b/multilane/test/multilane/multilane_arc_road_curve_test.cc
@@ -4,10 +4,9 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/eigen_types.h"
-
 #include "maliput/api/lane_data.h"
 #include "maliput/common/assertion_error.h"
+#include "maliput/math/vector.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 
 namespace maliput {
@@ -16,7 +15,7 @@ namespace {
 
 class MultilaneArcRoadCurveTest : public ::testing::Test {
  protected:
-  const drake::Vector2<double> kCenter{10.0, 10.0};
+  const math::Vector2 kCenter{10.0, 10.0};
   const double kRadius{10.0};
   const double kTheta0{M_PI / 4.0};
   const double kTheta1{3.0 * M_PI / 4.0};
@@ -89,28 +88,24 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
 
   // Checks the evaluation of xy at different values over the reference curve.
   EXPECT_TRUE(CompareMatrices(
-      dut.xy_of_p(0.0), kCenter + drake::Vector2<double>(kRadius * std::cos(kTheta0), kRadius * std::sin(kTheta0)),
-      kVeryExact));
-  EXPECT_TRUE(CompareMatrices(dut.xy_of_p(0.5),
-                              kCenter + drake::Vector2<double>(kRadius * std::cos(kTheta0 + kDTheta * 0.5),
-                                                               kRadius * std::sin(kTheta0 + kDTheta * 0.5)),
-                              kVeryExact));
+      dut.xy_of_p(0.0), kCenter + math::Vector2(kRadius * std::cos(kTheta0), kRadius * std::sin(kTheta0)), kVeryExact));
   EXPECT_TRUE(CompareMatrices(
-      dut.xy_of_p(1.0), kCenter + drake::Vector2<double>(kRadius * std::cos(kTheta1), kRadius * std::sin(kTheta1)),
+      dut.xy_of_p(0.5),
+      kCenter + math::Vector2(kRadius * std::cos(kTheta0 + kDTheta * 0.5), kRadius * std::sin(kTheta0 + kDTheta * 0.5)),
       kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.xy_of_p(1.0), kCenter + math::Vector2(kRadius * std::cos(kTheta1), kRadius * std::sin(kTheta1)), kVeryExact));
   // Checks the derivative of xy at different values over the reference curve.
   EXPECT_TRUE(CompareMatrices(
       dut.xy_dot_of_p(0.0),
-      drake::Vector2<double>(-kRadius * std::sin(kTheta0) * kDTheta, kRadius * std::cos(kTheta0) * kDTheta),
-      kVeryExact));
+      math::Vector2(-kRadius * std::sin(kTheta0) * kDTheta, kRadius * std::cos(kTheta0) * kDTheta), kVeryExact));
   EXPECT_TRUE(CompareMatrices(dut.xy_dot_of_p(0.5),
-                              drake::Vector2<double>(-kRadius * std::sin(kTheta0 + 0.5 * kDTheta) * kDTheta,
-                                                     kRadius * std::cos(kTheta0 + 0.5 * kDTheta) * kDTheta),
+                              math::Vector2(-kRadius * std::sin(kTheta0 + 0.5 * kDTheta) * kDTheta,
+                                            kRadius * std::cos(kTheta0 + 0.5 * kDTheta) * kDTheta),
                               kVeryExact));
   EXPECT_TRUE(CompareMatrices(
       dut.xy_dot_of_p(1.0),
-      drake::Vector2<double>(-kRadius * std::sin(kTheta1) * kDTheta, kRadius * std::cos(kTheta1) * kDTheta),
-      kVeryExact));
+      math::Vector2(-kRadius * std::sin(kTheta1) * kDTheta, kRadius * std::cos(kTheta1) * kDTheta), kVeryExact));
   // Checks the heading at different values.
   EXPECT_NEAR(dut.heading_of_p(0.0), kTheta0 + M_PI / 2.0, kVeryExact);
   EXPECT_NEAR(dut.heading_of_p(0.5), kTheta0 + kDTheta / 2.0 + M_PI / 2.0, kVeryExact);
@@ -131,7 +126,7 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
 // - Larger than the radius bounds.
 // - Bounds equal to the radius.
 GTEST_TEST(MultilaneArcRoadCurve, IsValidTest) {
-  const drake::Vector2<double> kZeroCenter(0.0, 0.0);
+  const math::Vector2 kZeroCenter(0.0, 0.0);
   const double kRadius = 10.0;
   const double kInitTheta = 0.0;
   const double kEndTheta1 = M_PI / 2.0;
@@ -182,31 +177,31 @@ TEST_F(MultilaneArcRoadCurveTest, ToCurveFrameTest) {
   const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp, kLinearTolerance, kScaleLength,
                          kComputationPolicy);
   // Checks points over the composed curve.
-  EXPECT_TRUE(CompareMatrices(dut.ToCurveFrame(drake::Vector3<double>(kCenter(0) + kRadius * std::cos(kTheta0),
-                                                                      kCenter(1) + kRadius * std::sin(kTheta0), 0.0),
+  EXPECT_TRUE(CompareMatrices(dut.ToCurveFrame(math::Vector3(kCenter(0) + kRadius * std::cos(kTheta0),
+                                                             kCenter(1) + kRadius * std::sin(kTheta0), 0.0),
                                                kRMin, kRMax, height_bounds),
-                              drake::Vector3<double>(0.0, 0.0, 0.0), kVeryExact));
-  EXPECT_TRUE(CompareMatrices(
-      dut.ToCurveFrame(drake::Vector3<double>(kCenter(0) + kRadius * std::cos(kTheta0 + kDTheta / 2.0),
-                                              kCenter(1) + kRadius * std::sin(kTheta0 + kDTheta / 2.0), 0.0),
-                       kRMin, kRMax, height_bounds),
-      drake::Vector3<double>(0.5, 0.0, 0.0), kVeryExact));
-  EXPECT_TRUE(CompareMatrices(dut.ToCurveFrame(drake::Vector3<double>(kCenter(0) + kRadius * std::cos(kTheta1),
-                                                                      kCenter(1) + kRadius * std::sin(kTheta1), 0.0),
+                              math::Vector3(0.0, 0.0, 0.0), kVeryExact));
+  EXPECT_TRUE(
+      CompareMatrices(dut.ToCurveFrame(math::Vector3(kCenter(0) + kRadius * std::cos(kTheta0 + kDTheta / 2.0),
+                                                     kCenter(1) + kRadius * std::sin(kTheta0 + kDTheta / 2.0), 0.0),
+                                       kRMin, kRMax, height_bounds),
+                      math::Vector3(0.5, 0.0, 0.0), kVeryExact));
+  EXPECT_TRUE(CompareMatrices(dut.ToCurveFrame(math::Vector3(kCenter(0) + kRadius * std::cos(kTheta1),
+                                                             kCenter(1) + kRadius * std::sin(kTheta1), 0.0),
                                                kRMin, kRMax, height_bounds),
-                              drake::Vector3<double>(1., 0.0, 0.0), kVeryExact));
+                              math::Vector3(1., 0.0, 0.0), kVeryExact));
   // Checks with lateral and vertical deviations.
   EXPECT_TRUE(CompareMatrices(
-      dut.ToCurveFrame(drake::Vector3<double>(kCenter(0) + (kRadius + 1.0) * std::cos(kTheta0 + M_PI / 8.0),
-                                              kCenter(1) + (kRadius + 1.0) * std::sin(kTheta0 + M_PI / 8.0), 6.0),
+      dut.ToCurveFrame(math::Vector3(kCenter(0) + (kRadius + 1.0) * std::cos(kTheta0 + M_PI / 8.0),
+                                     kCenter(1) + (kRadius + 1.0) * std::sin(kTheta0 + M_PI / 8.0), 6.0),
                        kRMin, kRMax, height_bounds),
-      drake::Vector3<double>(0.25, -1.0, 6.0), kVeryExact));
+      math::Vector3(0.25, -1.0, 6.0), kVeryExact));
   EXPECT_TRUE(CompareMatrices(
       dut.ToCurveFrame(
-          drake::Vector3<double>(kCenter(0) + (kRadius - 2.0) * std::cos(kTheta0 + kDTheta / 2.0 + M_PI / 8.0),
-                                 kCenter(1) + (kRadius - 2.0) * std::sin(kTheta0 + kDTheta / 2.0 + M_PI / 8.0), 3.0),
+          math::Vector3(kCenter(0) + (kRadius - 2.0) * std::cos(kTheta0 + kDTheta / 2.0 + M_PI / 8.0),
+                        kCenter(1) + (kRadius - 2.0) * std::sin(kTheta0 + kDTheta / 2.0 + M_PI / 8.0), 3.0),
           kRMin, kRMax, height_bounds),
-      drake::Vector3<double>(0.75, 2.0, 3.0), kVeryExact));
+      math::Vector3(0.75, 2.0, 3.0), kVeryExact));
 }
 
 // Checks that l_max(), p_from_s() and s_from_p() with constant
@@ -268,15 +263,14 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
   // Checks for a flat curve.
   const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp, kLinearTolerance, kScaleLength,
                               kComputationPolicy);
-  const drake::Vector3<double> kGeoCenter(kCenter.x(), kCenter.y(), 0.);
+  const math::Vector3 kGeoCenter(kCenter.x(), kCenter.y(), 0.);
   for (double p : p_vector) {
     for (double r : r_vector) {
       for (double h : h_vector) {
         const Rot3 flat_rotation(0., 0., flat_dut.heading_of_p(p));
         const double angle = kTheta0 + kDTheta * p;
-        const drake::Vector3<double> geo_position =
-            kGeoCenter + kRadius * drake::Vector3<double>(std::cos(angle), std::sin(angle), 0.) +
-            flat_rotation.apply({0., r, h});
+        const math::Vector3 geo_position = kGeoCenter + kRadius * math::Vector3(std::cos(angle), std::sin(angle), 0.) +
+                                           flat_rotation.apply({0., r, h});
         EXPECT_TRUE(CompareMatrices(flat_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
       }
     }
@@ -289,7 +283,7 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
   const ArcRoadCurve elevated_dut(kCenter, kRadius, kTheta0, kDTheta, linear_elevation, zp, kLinearTolerance,
                                   kScaleLength, kComputationPolicy);
   // Computes the rotation along the RoadCurve.
-  const drake::Vector3<double> z_vector(0., 0., kRadius * kDTheta);
+  const math::Vector3 z_vector(0., 0., kRadius * kDTheta);
   const double kZeroRoll{0.};
   const double kLinearElevatedPitch = -std::atan(linear_elevation.f_dot_p(0.));
   for (double p : p_vector) {
@@ -297,9 +291,8 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
       for (double h : h_vector) {
         const Rot3 elevated_rotation(kZeroRoll, kLinearElevatedPitch, flat_dut.heading_of_p(p));
         const double angle = kTheta0 + kDTheta * p;
-        const drake::Vector3<double> geo_position =
-            kGeoCenter + kRadius * drake::Vector3<double>(std::cos(angle), std::sin(angle), 0.) +
-            linear_elevation.f_p(p) * z_vector + elevated_rotation.apply({0., r, h});
+        const math::Vector3 geo_position = kGeoCenter + kRadius * math::Vector3(std::cos(angle), std::sin(angle), 0.) +
+                                           linear_elevation.f_p(p) * z_vector + elevated_rotation.apply({0., r, h});
         EXPECT_TRUE(CompareMatrices(elevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
       }
     }
@@ -315,9 +308,8 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
       for (double h : h_vector) {
         const Rot3 superelevated_rotation(kSuperelevationOffset, 0., flat_dut.heading_of_p(p));
         const double angle = kTheta0 + kDTheta * p;
-        const drake::Vector3<double> geo_position =
-            kGeoCenter + kRadius * drake::Vector3<double>(std::cos(angle), std::sin(angle), 0.) +
-            superelevated_rotation.apply({0., r, h});
+        const math::Vector3 geo_position = kGeoCenter + kRadius * math::Vector3(std::cos(angle), std::sin(angle), 0.) +
+                                           superelevated_rotation.apply({0., r, h});
         EXPECT_TRUE(CompareMatrices(superelevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
       }
     }
@@ -339,28 +331,26 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
   const double kDifferential = 1e-3;
   // Numerically evaluates the derivative of a road curve world function
   // with respect to p at [p, r, h] with a five-point stencil.
-  auto numeric_w_prime_of_prh = [kDifferential](const RoadCurve& dut, double p, double r,
-                                                double h) -> drake::Vector3<double> {
-    const drake::Vector3<double> dw =
-        -dut.W_of_prh(p + 2. * kDifferential, r, h) + 8. * dut.W_of_prh(p + kDifferential, r, h) -
-        8. * dut.W_of_prh(p - kDifferential, r, h) + dut.W_of_prh(p - 2. * kDifferential, r, h);
+  auto numeric_w_prime_of_prh = [kDifferential](const RoadCurve& dut, double p, double r, double h) -> math::Vector3 {
+    const math::Vector3 dw = -dut.W_of_prh(p + 2. * kDifferential, r, h) + 8. * dut.W_of_prh(p + kDifferential, r, h) -
+                             8. * dut.W_of_prh(p - kDifferential, r, h) + dut.W_of_prh(p - 2. * kDifferential, r, h);
     return dw / (12. * kDifferential);
   };
 
   // Checks for a flat curve.
   const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp, kLinearTolerance, kScaleLength,
                               kComputationPolicy);
-  const drake::Vector3<double> kGeoCenter(kCenter.x(), kCenter.y(), 0.);
+  const math::Vector3 kGeoCenter(kCenter.x(), kCenter.y(), 0.);
   for (double p : p_vector) {
     for (double r : r_vector) {
       for (double h : h_vector) {
         // Computes the rotation along the RoadCurve at [p, r, h].
         const Rot3 rotation = flat_dut.Rabg_of_p(p);
         const double g_prime = flat_dut.elevation().f_dot_p(p);
-        const drake::Vector3<double> w_prime = flat_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
-        const drake::Vector3<double> numeric_w_prime = numeric_w_prime_of_prh(flat_dut, p, r, h);
+        const math::Vector3 w_prime = flat_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
+        const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(flat_dut, p, r, h);
         EXPECT_TRUE(CompareMatrices(w_prime, numeric_w_prime, kQuiteExact));
-        const drake::Vector3<double> s_hat = flat_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
+        const math::Vector3 s_hat = flat_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
         EXPECT_TRUE(CompareMatrices(w_prime.normalized(), s_hat, kVeryExact));
       }
     }
@@ -378,10 +368,10 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
         // Computes the rotation along the RoadCurve at [p, r, h].
         const Rot3 rotation = elevated_dut.Rabg_of_p(p);
         const double g_prime = elevated_dut.elevation().f_dot_p(p);
-        const drake::Vector3<double> w_prime = elevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
-        const drake::Vector3<double> numeric_w_prime = numeric_w_prime_of_prh(elevated_dut, p, r, h);
+        const math::Vector3 w_prime = elevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
+        const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(elevated_dut, p, r, h);
         EXPECT_TRUE(CompareMatrices(w_prime, numeric_w_prime, kQuiteExact));
-        const drake::Vector3<double> s_hat = elevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
+        const math::Vector3 s_hat = elevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
         EXPECT_TRUE(CompareMatrices(w_prime.normalized(), s_hat, kVeryExact));
       }
     }
@@ -398,10 +388,10 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
         // Computes the rotation along the RoadCurve at [p, r, h].
         const Rot3 rotation = superelevated_dut.Rabg_of_p(p);
         const double g_prime = superelevated_dut.elevation().f_dot_p(p);
-        const drake::Vector3<double> w_prime = superelevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
-        const drake::Vector3<double> numeric_w_prime = numeric_w_prime_of_prh(superelevated_dut, p, r, h);
+        const math::Vector3 w_prime = superelevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
+        const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(superelevated_dut, p, r, h);
         EXPECT_TRUE(CompareMatrices(w_prime, numeric_w_prime, kQuiteExact));
-        const drake::Vector3<double> s_hat = superelevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
+        const math::Vector3 s_hat = superelevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
         EXPECT_TRUE(CompareMatrices(w_prime.normalized(), s_hat, kVeryExact));
       }
     }
@@ -432,29 +422,29 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), 3. * M_PI / 4., kVeryExact);
-    drake::Vector3<double> r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(-0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    math::Vector3 r_hat = flat_dut.r_hat_of_Rabg(rotation);
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(-0.707106781186548, -0.707106781186548, 0.), kVeryExact));
 
     rotation = flat_dut.Rabg_of_p(0.5);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -M_PI, kVeryExact);
     r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0., -1., 0.), kVeryExact));
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(0., -1., 0.), kVeryExact));
 
     rotation = flat_dut.Rabg_of_p(0.75);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -7. * M_PI / 8., kVeryExact);
     r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0.382683432365090, -0.923879532511287, 0.), kVeryExact));
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(0.382683432365090, -0.923879532511287, 0.), kVeryExact));
 
     rotation = flat_dut.Rabg_of_p(1.);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -3. * M_PI / 4., kVeryExact);
     r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(0.707106781186548, -0.707106781186548, 0.), kVeryExact));
   }
 
   // Checks for a linearly elevated curve.
@@ -472,29 +462,29 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), 3. * M_PI / 4., kVeryExact);
-    drake::Vector3<double> r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(-0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    math::Vector3 r_hat = elevated_dut.r_hat_of_Rabg(rotation);
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(-0.707106781186548, -0.707106781186548, 0.), kVeryExact));
 
     rotation = elevated_dut.Rabg_of_p(0.5);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -M_PI, kVeryExact);
     r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0., -1., 0.), kVeryExact));
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(0., -1., 0.), kVeryExact));
 
     rotation = elevated_dut.Rabg_of_p(0.75);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -7. * M_PI / 8., kVeryExact);
     r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0.382683432365090, -0.923879532511287, 0.), kVeryExact));
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(0.382683432365090, -0.923879532511287, 0.), kVeryExact));
 
     rotation = elevated_dut.Rabg_of_p(1.);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -3. * M_PI / 4., kVeryExact);
     r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(0.707106781186548, -0.707106781186548, 0.), kVeryExact));
   }
 
   // Checks for a curve with constant non zero superelevation.
@@ -510,32 +500,32 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(wrap(rotation.roll()), kSuperelevationOffset, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), 3. * M_PI / 4., kVeryExact);
-    drake::Vector3<double> r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(
-        r_hat, drake::Vector3<double>(-0.353553390593274, -0.353553390593274, 0.866025403784439), kVeryExact));
+    math::Vector3 r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
+    EXPECT_TRUE(
+        CompareMatrices(r_hat, math::Vector3(-0.353553390593274, -0.353553390593274, 0.866025403784439), kVeryExact));
 
     rotation = superelevated_dut.Rabg_of_p(0.5);
     EXPECT_NEAR(rotation.roll(), kSuperelevationOffset, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -M_PI, kVeryExact);
     r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0.0, -0.5, 0.866025403784439), kVeryExact));
+    EXPECT_TRUE(CompareMatrices(r_hat, math::Vector3(0.0, -0.5, 0.866025403784439), kVeryExact));
 
     rotation = superelevated_dut.Rabg_of_p(0.75);
     EXPECT_NEAR(rotation.roll(), kSuperelevationOffset, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -7. * M_PI / 8., kVeryExact);
     r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0.191341716182545, -0.461939766255643, 0.866025403784439),
-                                kVeryExact));
+    EXPECT_TRUE(
+        CompareMatrices(r_hat, math::Vector3(0.191341716182545, -0.461939766255643, 0.866025403784439), kVeryExact));
 
     rotation = superelevated_dut.Rabg_of_p(1.);
     EXPECT_NEAR(rotation.roll(), kSuperelevationOffset, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -3. * M_PI / 4., kVeryExact);
     r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareMatrices(r_hat, drake::Vector3<double>(0.353553390593274, -0.353553390593274, 0.866025403784439),
-                                kVeryExact));
+    EXPECT_TRUE(
+        CompareMatrices(r_hat, math::Vector3(0.353553390593274, -0.353553390593274, 0.866025403784439), kVeryExact));
   }
 }
 

--- a/multilane/test/multilane/multilane_builder_test.cc
+++ b/multilane/test/multilane/multilane_builder_test.cc
@@ -13,6 +13,7 @@
 #include "maliput/api/lane_data.h"
 #include "maliput/common/assertion_error.h"
 #include "maliput/common/maliput_copyable.h"
+#include "maliput/math/vector.h"
 #include "maliput/test_utilities/check_id_indexing.h"
 #include "maliput/test_utilities/maliput_types_compare.h"
 #include "multilane_test_utilities/multilane_types_compare.h"
@@ -469,15 +470,15 @@ TEST_F(MultilaneBuilderReferenceCurvePrimitivesTest, LineSegment) {
   EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
   EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
 
-  const drake::Vector3<double> r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
-  const drake::Vector3<double> start_reference_curve(kStart.xy().x(), kStart.xy().y(), kStart.z().z());
+  const math::Vector3 r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
+  const math::Vector3 start_reference_curve(kStart.xy().x(), kStart.xy().y(), kStart.z().z());
   for (int i = 0; i < kNumLanes; i++) {
     const api::Lane* lane = rg->junction(0)->segment(0)->lane(i);
     // Checks Lane's ID.
     EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
     // Checks lane start geo position to verify that spacing is correctly
     // applied.
-    const drake::Vector3<double> lane_start_geo =
+    const math::Vector3 lane_start_geo =
         start_reference_curve + (kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
     EXPECT_TRUE(api::test::IsGeoPositionClose(lane->ToGeoPosition({0., 0., 0.}),
                                               api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
@@ -516,15 +517,15 @@ TEST_F(MultilaneBuilderReferenceCurvePrimitivesTest, ArcSegment) {
   EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
   EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
 
-  const drake::Vector3<double> r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
-  const drake::Vector3<double> start_reference_curve(kStart.xy().x(), kStart.xy().y(), kStart.z().z());
+  const math::Vector3 r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
+  const math::Vector3 start_reference_curve(kStart.xy().x(), kStart.xy().y(), kStart.z().z());
   for (int i = 0; i < kNumLanes; i++) {
     const api::Lane* const lane = rg->junction(0)->segment(0)->lane(i);
     // Checks Lane's ID.
     EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
     // Checks lane start geo position to verify that spacing is correctly
     // applied.
-    const drake::Vector3<double> lane_start_geo =
+    const math::Vector3 lane_start_geo =
         start_reference_curve + (kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
     EXPECT_TRUE(api::test::IsGeoPositionClose(lane->ToGeoPosition({0., 0., 0.}),
                                               api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
@@ -670,16 +671,16 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, FlatLineSegment) {
   EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
   EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
 
-  const drake::Vector3<double> r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
-  const drake::Vector3<double> start_reference_curve =
-      drake::Vector3<double>(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor;
+  const math::Vector3 r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
+  const math::Vector3 start_reference_curve =
+      math::Vector3(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor;
   for (int i = 0; i < kNumLanes; i++) {
     const api::Lane* lane = rg->junction(0)->segment(0)->lane(i);
     // Checks Lane's ID.
     EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
     // Checks lane start geo position to verify that spacing is correctly
     // applied.
-    const drake::Vector3<double> lane_start_geo =
+    const math::Vector3 lane_start_geo =
         start_reference_curve + (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
     EXPECT_TRUE(api::test::IsGeoPositionClose(lane->ToGeoPosition({0., 0., 0.}),
                                               api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
@@ -718,12 +719,12 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ElevatedEndLineSegment) {
   EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
   EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
 
-  const drake::Vector3<double> r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
-  const drake::Vector3<double> start_reference_curve =
-      drake::Vector3<double>(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor;
-  const drake::Vector3<double> end_reference_curve =
-      start_reference_curve + kLength * drake::Vector3<double>(std::cos(kStartHeading), std::sin(kStartHeading), 0.) +
-      drake::Vector3<double>(0., 0., 5.);
+  const math::Vector3 r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
+  const math::Vector3 start_reference_curve =
+      math::Vector3(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor;
+  const math::Vector3 end_reference_curve =
+      start_reference_curve + kLength * math::Vector3(std::cos(kStartHeading), std::sin(kStartHeading), 0.) +
+      math::Vector3(0., 0., 5.);
 
   for (int i = 0; i < kNumLanes; i++) {
     const api::Lane* lane = rg->junction(0)->segment(0)->lane(i);
@@ -731,7 +732,7 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ElevatedEndLineSegment) {
     EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
     // Checks lane start geo position to verify that spacing is correctly
     // applied.
-    const drake::Vector3<double> r_offset = (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
+    const math::Vector3 r_offset = (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
     EXPECT_TRUE(api::test::IsGeoPositionClose(lane->ToGeoPosition({0., 0., 0.}),
                                               api::GeoPosition::FromXyz(start_reference_curve + r_offset),
                                               kLinearTolerance));
@@ -774,16 +775,16 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ArcSegment) {
   EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
   EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
 
-  const drake::Vector3<double> r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
-  const drake::Vector3<double> start_reference_curve =
-      drake::Vector3<double>(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor;
+  const math::Vector3 r_versor(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
+  const math::Vector3 start_reference_curve =
+      math::Vector3(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor;
   for (int i = 0; i < kNumLanes; i++) {
     const api::Lane* const lane = rg->junction(0)->segment(0)->lane(i);
     // Checks Lane's ID.
     EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
     // Checks lane start geo position to verify that spacing is correctly
     // applied.
-    const drake::Vector3<double> lane_start_geo =
+    const math::Vector3 lane_start_geo =
         start_reference_curve + (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
     EXPECT_TRUE(api::test::IsGeoPositionClose(lane->ToGeoPosition({0., 0., 0.}),
                                               api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
@@ -822,13 +823,12 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ElevatedEndArcSegment) {
   EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
   EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
 
-  const drake::Vector3<double> r_versor_start(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
-  const drake::Vector3<double> start_reference_curve =
-      drake::Vector3<double>(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor_start;
-  const drake::Vector3<double> r_versor_end(-std::sin(kStartHeading + kDTheta), std::cos(kStartHeading + kDTheta), 0.);
-  const drake::Vector3<double> end_reference_curve = start_reference_curve +
-                                                     kRadius * drake::Vector3<double>(std::sqrt(2.), 0., 0.) +
-                                                     drake::Vector3<double>(0., 0., 5.);
+  const math::Vector3 r_versor_start(-std::sin(kStartHeading), std::cos(kStartHeading), 0.);
+  const math::Vector3 start_reference_curve =
+      math::Vector3(kStart.xy().x(), kStart.xy().y(), kStart.z().z()) + (kRefR0 - kLaneWidth) * r_versor_start;
+  const math::Vector3 r_versor_end(-std::sin(kStartHeading + kDTheta), std::cos(kStartHeading + kDTheta), 0.);
+  const math::Vector3 end_reference_curve =
+      start_reference_curve + kRadius * math::Vector3(std::sqrt(2.), 0., 0.) + math::Vector3(0., 0., 5.);
 
   for (int i = 0; i < kNumLanes; i++) {
     const api::Lane* const lane = rg->junction(0)->segment(0)->lane(i);
@@ -836,12 +836,12 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ElevatedEndArcSegment) {
     EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
     // Checks lane start geo position to verify that spacing is correctly
     // applied.
-    const drake::Vector3<double> r_offset_start = (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor_start;
+    const math::Vector3 r_offset_start = (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor_start;
     EXPECT_TRUE(api::test::IsGeoPositionClose(lane->ToGeoPosition({0., 0., 0.}),
                                               api::GeoPosition::FromXyz(start_reference_curve + r_offset_start),
                                               kLinearTolerance));
     // Checks lane end geo position to verify elevation is correctly applied.
-    const drake::Vector3<double> r_offset_end = (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor_end;
+    const math::Vector3 r_offset_end = (-kRefR0 + static_cast<double>(i) * kLaneWidth) * r_versor_end;
     EXPECT_TRUE(api::test::IsGeoPositionClose(lane->ToGeoPosition({lane->length(), 0., 0.}),
                                               api::GeoPosition::FromXyz(end_reference_curve + r_offset_end),
                                               kLinearTolerance));
@@ -954,7 +954,7 @@ class TurnBuildProcedure : public BuildProcedure {
       // the straight lane by construction, the resulting orientation is
       // rotated pi radians about the h-axis.
       const api::Rotation rrotation = curved_lane->GetOrientation({kS, -r, kH});
-      const drake::Quaternion<double> pi_rotation(drake::AngleAxis<double>(M_PI, drake::Vector3<double>::UnitZ()));
+      const drake::Quaternion<double> pi_rotation(drake::AngleAxis<double>(M_PI, math::Vector3::UnitZ()));
       EXPECT_TRUE(api::test::IsRotationClose(straight_lane->GetOrientation({kS, r, kH}),
                                              // Applies a pi radians rotation around the h-axis to the curved
                                              // lane orientation (i.e. apply an intrinsic pi radians rotation

--- a/multilane/test/multilane/multilane_connection_test.cc
+++ b/multilane/test/multilane/multilane_connection_test.cc
@@ -8,6 +8,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "maliput/math/vector.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 #include "multilane/arc_road_curve.h"
 #include "multilane/cubic_polynomial.h"
@@ -196,20 +197,17 @@ TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
   std::unique_ptr<RoadCurve> road_curve = flat_dut.CreateRoadCurve();
   EXPECT_NE(dynamic_cast<ArcRoadCurve*>(road_curve.get()), nullptr);
   // Checks that the road curve starts and ends at given endpoints.
-  const drake::Vector3<double> flat_origin = road_curve->W_of_prh(0., 0., 0.);
-  EXPECT_TRUE(CompareMatrices(
-      drake::Vector3<double>(flat_dut.start().xy().x(), flat_dut.start().xy().y(), flat_dut.start().z().z()),
-      flat_origin, kZeroTolerance));
+  const math::Vector3 flat_origin = road_curve->W_of_prh(0., 0., 0.);
   EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+      CompareMatrices(math::Vector3(flat_dut.start().xy().x(), flat_dut.start().xy().y(), flat_dut.start().z().z()),
                       flat_origin, kZeroTolerance));
-  const drake::Vector3<double> flat_end = road_curve->W_of_prh(1., 0., 0.);
-  EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()),
-                      flat_end, kVeryExact));
-  EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()),
-                      flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                              flat_origin, kZeroTolerance));
+  const math::Vector3 flat_end = road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(math::Vector3(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()),
+                              flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(math::Vector3(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()),
+                              flat_end, kVeryExact));
   // Checks that elevation and superelevation polynomials are correctly built
   // for the trivial case of a flat dut.
   EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->elevation(), CubicPolynomial(), kZeroTolerance));
@@ -221,20 +219,19 @@ TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
                                kRightShoulder, kArcOffset, kLinearTolerance, kScaleLength, kComputationPolicy);
   std::unique_ptr<RoadCurve> complex_road_curve = complex_dut.CreateRoadCurve();
   // Checks that the road curve starts and ends at given endpoints.
-  const drake::Vector3<double> complex_origin = complex_road_curve->W_of_prh(0., 0., 0.);
+  const math::Vector3 complex_origin = complex_road_curve->W_of_prh(0., 0., 0.);
   EXPECT_TRUE(CompareMatrices(
-      drake::Vector3<double>(complex_dut.start().xy().x(), complex_dut.start().xy().y(), complex_dut.start().z().z()),
+      math::Vector3(complex_dut.start().xy().x(), complex_dut.start().xy().y(), complex_dut.start().z().z()),
       complex_origin, kZeroTolerance));
+  EXPECT_TRUE(CompareMatrices(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                              complex_origin, kZeroTolerance));
+  const math::Vector3 complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
   EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
-                      complex_origin, kZeroTolerance));
-  const drake::Vector3<double> complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
+      CompareMatrices(math::Vector3(complex_dut.end().xy().x(), complex_dut.end().xy().y(), complex_dut.end().z().z()),
+                      complex_end, kVeryExact));
   EXPECT_TRUE(CompareMatrices(
-      drake::Vector3<double>(complex_dut.end().xy().x(), complex_dut.end().xy().y(), complex_dut.end().z().z()),
+      math::Vector3(kEndElevatedEndpoint.xy().x(), kEndElevatedEndpoint.xy().y(), kEndElevatedEndpoint.z().z()),
       complex_end, kVeryExact));
-  EXPECT_TRUE(CompareMatrices(drake::Vector3<double>(kEndElevatedEndpoint.xy().x(), kEndElevatedEndpoint.xy().y(),
-                                                     kEndElevatedEndpoint.z().z()),
-                              complex_end, kVeryExact));
   EXPECT_TRUE(test::IsCubicPolynomialClose(
       complex_road_curve->elevation(), CubicPolynomial(0., 0., -0.32476276288217043, 0.549841841921447), kVeryExact));
   EXPECT_TRUE(test::IsCubicPolynomialClose(complex_road_curve->superelevation(),
@@ -253,20 +250,17 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
   EXPECT_NE(dynamic_cast<LineRoadCurve*>(road_curve.get()), nullptr);
 
   // Checks that the road curve starts and ends at given endpoints.
-  const drake::Vector3<double> flat_origin = road_curve->W_of_prh(0., 0., 0.);
-  EXPECT_TRUE(CompareMatrices(
-      drake::Vector3<double>(flat_dut.start().xy().x(), flat_dut.start().xy().y(), flat_dut.start().z().z()),
-      flat_origin, kZeroTolerance));
+  const math::Vector3 flat_origin = road_curve->W_of_prh(0., 0., 0.);
   EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+      CompareMatrices(math::Vector3(flat_dut.start().xy().x(), flat_dut.start().xy().y(), flat_dut.start().z().z()),
                       flat_origin, kZeroTolerance));
-  const drake::Vector3<double> flat_end = road_curve->W_of_prh(1., 0., 0.);
-  EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()),
-                      flat_end, kVeryExact));
-  EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()),
-                      flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                              flat_origin, kZeroTolerance));
+  const math::Vector3 flat_end = road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(math::Vector3(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()),
+                              flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(math::Vector3(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()),
+                              flat_end, kVeryExact));
   // Checks that elevation and superelevation polynomials are correctly built
   // for the trivial case of a flat dut.
   EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->elevation(), CubicPolynomial(), kZeroTolerance));
@@ -279,20 +273,19 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
   std::unique_ptr<RoadCurve> complex_road_curve = complex_dut.CreateRoadCurve();
 
   // Checks that the road curve starts and ends at given endpoints.
-  const drake::Vector3<double> complex_origin = complex_road_curve->W_of_prh(0., 0., 0.);
+  const math::Vector3 complex_origin = complex_road_curve->W_of_prh(0., 0., 0.);
   EXPECT_TRUE(CompareMatrices(
-      drake::Vector3<double>(complex_dut.start().xy().x(), complex_dut.start().xy().y(), complex_dut.start().z().z()),
+      math::Vector3(complex_dut.start().xy().x(), complex_dut.start().xy().y(), complex_dut.start().z().z()),
       complex_origin, kZeroTolerance));
+  EXPECT_TRUE(CompareMatrices(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                              complex_origin, kZeroTolerance));
+  const math::Vector3 complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
   EXPECT_TRUE(
-      CompareMatrices(drake::Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
-                      complex_origin, kZeroTolerance));
-  const drake::Vector3<double> complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
+      CompareMatrices(math::Vector3(complex_dut.end().xy().x(), complex_dut.end().xy().y(), complex_dut.end().z().z()),
+                      complex_end, kVeryExact));
   EXPECT_TRUE(CompareMatrices(
-      drake::Vector3<double>(complex_dut.end().xy().x(), complex_dut.end().xy().y(), complex_dut.end().z().z()),
+      math::Vector3(kEndElevatedEndpoint.xy().x(), kEndElevatedEndpoint.xy().y(), kEndElevatedEndpoint.z().z()),
       complex_end, kVeryExact));
-  EXPECT_TRUE(CompareMatrices(drake::Vector3<double>(kEndElevatedEndpoint.xy().x(), kEndElevatedEndpoint.xy().y(),
-                                                     kEndElevatedEndpoint.z().z()),
-                              complex_end, kVeryExact));
   EXPECT_TRUE(test::IsCubicPolynomialClose(complex_road_curve->elevation(),
                                            CubicPolynomial(0., 0., -0.646446609406726, 0.764297739604484), kVeryExact));
   EXPECT_TRUE(test::IsCubicPolynomialClose(complex_road_curve->superelevation(),
@@ -400,8 +393,8 @@ TEST_P(MultilaneConnectionEndpointZTest, LineLaneEndpoints) {
   const LineOffset kLineOffset{kLineLength};
   const Connection dut(kId, start_endpoint, end_z, num_lanes, r0, kLaneWidth, kLeftShoulder, kRightShoulder,
                        kLineOffset, kLinearTolerance, kScaleLength, kComputationPolicy);
-  const drake::Vector2<double> kDirection{45. - kStartXy.x(), 5. - kStartXy.y()};
-  const drake::Vector2<double> kNormalDirection = drake::Vector2<double>(kDirection.y(), -kDirection.x()).normalized();
+  const math::Vector2 kDirection{45. - kStartXy.x(), 5. - kStartXy.y()};
+  const math::Vector2 kNormalDirection = math::Vector2(kDirection.y(), -kDirection.x()).normalized();
 
   for (int i = 0; i < num_lanes; i++) {
     // Start endpoints.

--- a/multilane/test/multilane/multilane_road_curve_accuracy_test.cc
+++ b/multilane/test/multilane/multilane_road_curve_accuracy_test.cc
@@ -10,6 +10,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "maliput/math/vector.h"
 #include "multilane/arc_road_curve.h"
 #include "multilane/cubic_polynomial.h"
 #include "multilane/line_road_curve.h"
@@ -28,7 +29,7 @@ GTEST_TEST(BruteForceIntegralTest, ArcRoadCurvePathLength) {
   const double kTheta0{M_PI / 4.0};
   const double kTheta1{3.0 * M_PI / 4.0};
   const double kDTheta{kTheta1 - kTheta0};
-  const drake::Vector2<double> kCenter{10.0, 10.0};
+  const math::Vector2 kCenter{10.0, 10.0};
   const double kLinearTolerance{0.01};
   const double kScaleLength{1.};
   const ComputationPolicy kComputationPolicy{ComputationPolicy::kPreferAccuracy};
@@ -103,8 +104,8 @@ std::vector<CubicPolynomial> GetCubicPolynomials() {
 // that are simple enough for fast analytical computations to be
 // accurate.
 std::vector<std::shared_ptr<RoadCurve>> GetSimpleLineRoadCurves() {
-  const drake::Vector2<double> kStart{1., 1.};
-  const drake::Vector2<double> kEnd{10., -8.};
+  const math::Vector2 kStart{1., 1.};
+  const math::Vector2 kEnd{10., -8.};
   const double kLinearTolerance{0.01};
   const double kScaleLength{1.};
   const CubicPolynomial zp{0., 0., 0., 0.};
@@ -122,8 +123,8 @@ std::vector<std::shared_ptr<RoadCurve>> GetSimpleLineRoadCurves() {
 
 // Returns a collection of LineRoadCurve instances for testing.
 std::vector<std::shared_ptr<RoadCurve>> GetLineRoadCurves() {
-  const drake::Vector2<double> kStart{0., 0.};
-  const drake::Vector2<double> kEnd{10., -8.};
+  const math::Vector2 kStart{0., 0.};
+  const math::Vector2 kEnd{10., -8.};
   const double kLinearTolerance{0.01};
   const double kScaleLength{1.};
 
@@ -142,7 +143,7 @@ std::vector<std::shared_ptr<RoadCurve>> GetLineRoadCurves() {
 // that are simple enough for fast analytical computations to be
 // accurate.
 std::vector<std::shared_ptr<RoadCurve>> GetSimpleArcRoadCurves() {
-  const drake::Vector2<double> kCenter{1., 1.};
+  const math::Vector2 kCenter{1., 1.};
   const double kRadius{12.0};
   const double kTheta0{M_PI / 9.};
   const double kDTheta{M_PI / 3.};
@@ -163,7 +164,7 @@ std::vector<std::shared_ptr<RoadCurve>> GetSimpleArcRoadCurves() {
 
 // Returns a collection of ArcRoadCurve instances for testing.
 std::vector<std::shared_ptr<RoadCurve>> GetArcRoadCurves() {
-  const drake::Vector2<double> kCenter{0., 0.};
+  const math::Vector2 kCenter{0., 0.};
   const double kRadius{10.0};
   const double kTheta0{M_PI / 6.};
   const double kDTheta{M_PI / 2.};

--- a/multilane/test/multilane/multilane_segments_test.cc
+++ b/multilane/test/multilane/multilane_segments_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "maliput/math/vector.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 #include "maliput/test_utilities/maliput_types_compare.h"
 #include "multilane/arc_road_curve.h"
@@ -34,9 +35,8 @@ GTEST_TEST(MultilaneSegmentsTest, MultipleLanes) {
   const ComputationPolicy kComputationPolicy{ComputationPolicy::kPreferAccuracy};
 
   RoadGeometry rg(api::RoadGeometryId{"apple"}, kLinearTolerance, kAngularTolerance, kScaleLength);
-  std::unique_ptr<RoadCurve> road_curve_1 =
-      std::make_unique<LineRoadCurve>(drake::Vector2<double>(100., -75.), drake::Vector2<double>(100., 50.), zp, zp,
-                                      kLinearTolerance, kScaleLength, kComputationPolicy);
+  std::unique_ptr<RoadCurve> road_curve_1 = std::make_unique<LineRoadCurve>(
+      math::Vector2(100., -75.), math::Vector2(100., 50.), zp, zp, kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s1 = rg.NewJunction(api::JunctionId{"j1"})
                     ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1), kRMin, kRMax, {0., kMaxHeight});
   EXPECT_EQ(s1->id(), api::SegmentId("s1"));


### PR DESCRIPTION
Relates to second task in #237. Replaces `drake::VectorN<double>` by `maliput::math::VectorN` and removes when unnecessary calls to `drake::VectorN`.