### PR TITLE
Replaces drake::Matrix3<double> by maliput::math::Matrix3

### DIFF
--- a/maliput/include/maliput/api/lane_data.h
+++ b/maliput/include/maliput/api/lane_data.h
@@ -10,6 +10,7 @@
 
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/common/maliput_throw.h"
+#include "maliput/math/matrix.h"
 #include "maliput/math/vector.h"
 
 namespace maliput {
@@ -152,7 +153,7 @@ class Rotation {
   void set_quat(const drake::Quaternion<double>& quaternion) { quaternion_ = quaternion.normalized(); }
 
   /// Provides a 3x3 rotation matrix representation of "this" rotation.
-  drake::Matrix3<double> matrix() const { return drake::math::RotationMatrix<double>(quaternion_).matrix(); }
+  math::Matrix3 matrix() const { return drake::math::RotationMatrix<double>(quaternion_).matrix(); }
 
   /// Provides a representation of rotation as a vector of angles
   /// `[roll, pitch, yaw]` (in radians).

--- a/maliput/test/api/lane_data_test.cc
+++ b/maliput/test/api/lane_data_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "maliput/common/assertion_error.h"
+#include "maliput/math/matrix.h"
 #include "maliput/math/vector.h"
 #include "maliput/test_utilities/eigen_matrix_compare.h"
 #include "maliput/test_utilities/maliput_types_compare.h"
@@ -69,6 +70,8 @@ GTEST_TEST(LanePositionTest, ComponentSetters) {
 
 #undef CHECK_ALL_LANE_POSITION_ACCESSORS
 
+// TODO(jadecastro) Use CompareMatrices() to implement the
+// GeoPosition::xyz() accessor checks once AutoDiff supported.
 #define CHECK_ALL_GEO_POSITION_ACCESSORS(dut, _x, _y, _z) \
   do {                                                    \
     EXPECT_EQ(dut.x(), _x);                               \
@@ -208,13 +211,13 @@ class RotationTest : public ::testing::Test {
   double twist_roll_;
   double twist_pitch_;
   double twist_yaw_;
-  drake::Matrix3<double> twist_matrix_;
+  math::Matrix3 twist_matrix_;
 };
 
 TEST_F(RotationTest, DefaultConstructor) {
   // Check that default constructor obeys its contract.
   Rotation dut;
-  CHECK_ALL_ROTATION_ACCESSORS(dut, 1., 0., 0., 0., 0., 0., 0., drake::Matrix3<double>::Identity());
+  CHECK_ALL_ROTATION_ACCESSORS(dut, 1., 0., 0., 0., 0., 0., 0., math::Matrix3::Identity());
 }
 
 TEST_F(RotationTest, ConstructionFromQuaternion) {


### PR DESCRIPTION
Addresses part of second bullet in #237.

Depends on #251 