### PR TITLE
Remove drake dependencies from maliput core.

### DIFF
--- a/dragway/src/bindings/dragway_py.cc
+++ b/dragway/src/bindings/dragway_py.cc
@@ -1,4 +1,3 @@
-#include "pybind11/eigen.h"
 #include "pybind11/pybind11.h"
 
 #include "dragway/road_geometry.h"

--- a/maliput/CMakeLists.txt
+++ b/maliput/CMakeLists.txt
@@ -13,7 +13,6 @@ message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
-find_package(drake_vendor REQUIRED)
 find_package(fmt 4.0.0 EXACT REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
@@ -84,7 +83,6 @@ install(
 ament_export_include_directories(include)
 
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(drake)
 ament_export_dependencies(yaml-cpp)
 ament_export_interfaces(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_package()

--- a/maliput/include/maliput/api/road_geometry.h
+++ b/maliput/include/maliput/api/road_geometry.h
@@ -25,7 +25,7 @@ class Junction;
 using RoadGeometryId = TypeSpecificIdentifier<class RoadGeometry>;
 
 // TODO(maddog@tri.global)  This entire API should be templated on a
-//                          scalar type T like everything else in drake.
+//                          scalar type T.
 /// Abstract API for the geometry of a road network, including both
 /// the network topology and the geometry of its embedding in 3-space.
 class RoadGeometry {

--- a/maliput/include/maliput/geometry_base/branch_point.h
+++ b/maliput/include/maliput/geometry_base/branch_point.h
@@ -50,7 +50,6 @@ class BranchPoint : public api::BranchPoint {
 
   ~BranchPoint() override = default;
 
-#ifndef DRAKE_DOXYGEN_CXX
   // Notifies BranchPoint of its parent RoadGeometry.
   // This may only be called, once, by a RoadGeometry.
   //
@@ -59,7 +58,6 @@ class BranchPoint : public api::BranchPoint {
   // @pre `road_geometry` is non-null.
   // @pre Parent RoadGeometry has not already been set.
   void AttachToRoadGeometry(common::Passkey<RoadGeometry>, const api::RoadGeometry* road_geometry);
-#endif  // DRAKE_DOXYGEN_CXX
 
  private:
   // Common implementation for AddABranch() and AddBBranch().

--- a/maliput/include/maliput/geometry_base/junction.h
+++ b/maliput/include/maliput/geometry_base/junction.h
@@ -51,7 +51,6 @@ class Junction : public api::Junction {
 
   ~Junction() override = default;
 
-#ifndef DRAKE_DOXYGEN_CXX
   // Notifies Junction of its parent RoadGeometry.
   // This may only be called, once, by a RoadGeometry.
   //
@@ -70,7 +69,6 @@ class Junction : public api::Junction {
   void AttachToRoadGeometry(common::Passkey<RoadGeometry>, const api::RoadGeometry* road_geometry,
                             const std::function<void(const api::Segment*)>& segment_indexing_callback,
                             const std::function<void(const api::Lane*)>& lane_indexing_callback);
-#endif  // DRAKE_DOXYGEN_CXX
 
  private:
   // The non-template implementation of AddSegment<T>()

--- a/maliput/include/maliput/geometry_base/lane.h
+++ b/maliput/include/maliput/geometry_base/lane.h
@@ -37,7 +37,6 @@ class Lane : public api::Lane {
   /// or nullptr if the finish end hasn't been added to a BranchPoint yet.
   BranchPoint* mutable_finish_branch_point() { return finish_branch_point_; }
 
-#ifndef DRAKE_DOXYGEN_CXX
   // Notifies Lane of its parent Segment.
   // This may only be called, once, by a Segment.
   //
@@ -66,7 +65,6 @@ class Lane : public api::Lane {
   // @pre `branch_point` is non-null.
   // @pre The "finish" BranchPoint has not already been set.
   void SetFinishBranchPoint(common::Passkey<BranchPoint>, BranchPoint* branch_point);
-#endif  // DRAKE_DOXYGEN_CXX
 
   ~Lane() override = default;
 

--- a/maliput/include/maliput/geometry_base/segment.h
+++ b/maliput/include/maliput/geometry_base/segment.h
@@ -58,7 +58,6 @@ class Segment : public api::Segment {
     return raw_pointer;
   }
 
-#ifndef DRAKE_DOXYGEN_CXX
   // Notifies Segment of its parent Junction.
   // This may only be called, once, by a Junction.
   //
@@ -77,7 +76,6 @@ class Segment : public api::Segment {
   // @pre `callback` is non-empty.
   // @pre The lane indexing callback has not already been set.
   void SetLaneIndexingCallback(common::Passkey<Junction>, const std::function<void(const api::Lane*)>& callback);
-#endif  // DRAKE_DOXYGEN_CXX
 
   ~Segment() override = default;
 

--- a/maliput/include/maliput/test_utilities/rules_test_utilities.h
+++ b/maliput/include/maliput/test_utilities/rules_test_utilities.h
@@ -12,8 +12,7 @@ namespace rules {
 namespace test {
 
 // TODO(maddog@tri.global) Make the general-purpose assertion collection
-//                         machinery available (and used) by maliput in general,
-//                         or even drake.
+//                         machinery available (and used) by maliput in general.
 
 /// AssertionResultCollector helps with the creation of concise and well-traced
 /// testing subroutines when using googletest.

--- a/maliput/package.xml
+++ b/maliput/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>ament_cmake_doxygen</build_depend>
 
-  <depend>drake_vendor</depend>
   <depend>fmt</depend>
   <depend>pybind11</depend>
   <depend>yaml-cpp</depend>

--- a/maliput/src/api/CMakeLists.txt
+++ b/maliput/src/api/CMakeLists.txt
@@ -30,7 +30,6 @@ target_include_directories(api
 target_link_libraries(api
   PUBLIC
     common
-    drake::drake
     math
 )
 

--- a/maliput/src/base/CMakeLists.txt
+++ b/maliput/src/base/CMakeLists.txt
@@ -37,7 +37,6 @@ target_link_libraries(base
   PUBLIC
     api
     common
-    drake::drake
     yaml-cpp)
 
 ##############################################################################

--- a/maliput/src/base/manual_right_of_way_rule_state_provider.cc
+++ b/maliput/src/base/manual_right_of_way_rule_state_provider.cc
@@ -3,8 +3,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "drake/common/drake_throw.h"
-
 namespace maliput {
 
 using api::rules::RightOfWayRule;

--- a/maliput/src/bindings/api_py.cc
+++ b/maliput/src/bindings/api_py.cc
@@ -1,7 +1,4 @@
-#include "pybind11/eigen.h"
 #include "pybind11/pybind11.h"
-
-#include "drake/math/roll_pitch_yaw.h"
 
 #include "maliput/api/junction.h"
 #include "maliput/api/lane.h"

--- a/maliput/src/geometry_base/CMakeLists.txt
+++ b/maliput/src/geometry_base/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(geometry_base
 target_link_libraries(geometry_base
   PUBLIC
     api
-    drake::drake)
+)
 
 ##############################################################################
 # Tests

--- a/maliput/src/geometry_base/segment.cc
+++ b/maliput/src/geometry_base/segment.cc
@@ -1,7 +1,5 @@
 #include "maliput/geometry_base/segment.h"
 
-#include "drake/common/drake_throw.h"
-
 namespace maliput {
 namespace geometry_base {
 

--- a/maliput/src/math/CMakeLists.txt
+++ b/maliput/src/math/CMakeLists.txt
@@ -19,7 +19,6 @@ target_include_directories(math
 target_link_libraries(math
   PUBLIC
     common
-    drake::drake
 )
 
 ##############################################################################

--- a/maliput/src/routing/CMakeLists.txt
+++ b/maliput/src/routing/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(routing
   PUBLIC
     api
     common
-    drake::drake)
+)
 
 ##############################################################################
 # Export

--- a/maliput/src/test_utilities/CMakeLists.txt
+++ b/maliput/src/test_utilities/CMakeLists.txt
@@ -24,16 +24,12 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_target_dependencies(maliput_test_utilities
-  "drake"
-)
-
 target_link_libraries(maliput_test_utilities
   api
   common
   math
   geometry_base
-  drake::drake)
+)
 
 install(
     TARGETS maliput_test_utilities EXPORT ${PROJECT_NAME}-targets

--- a/maliput/test/api/CMakeLists.txt
+++ b/maliput/test/api/CMakeLists.txt
@@ -29,16 +29,12 @@ macro(add_dependencies_to_test target)
           ${PROJECT_SOURCE_DIR}/test
       )
 
-      ament_target_dependencies(${target}
-          "drake"
-      )
-
       target_link_libraries(${target}
           api
           common
           maliput_test_utilities
           math
-          drake::drake)
+      )
 
     endif()
 endmacro()

--- a/maliput/test/api/rules_road_rulebook_test.cc
+++ b/maliput/test/api/rules_road_rulebook_test.cc
@@ -5,8 +5,6 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/drake_throw.h"
-
 #include "maliput/api/regions.h"
 #include "maliput/api/rules/direction_usage_rule.h"
 #include "maliput/api/rules/right_of_way_rule.h"

--- a/maliput/test/base/CMakeLists.txt
+++ b/maliput/test/base/CMakeLists.txt
@@ -24,15 +24,12 @@ macro(add_dependencies_to_test target)
           ${PROJECT_SOURCE_DIR}/test
       )
 
-      ament_target_dependencies(${target}
-          "drake"
-      )
-
       target_link_libraries(${target}
           api
           base
+          fmt::fmt
           maliput_test_utilities
-          drake::drake)
+      )
 
     endif()
 endmacro()

--- a/maliput/test/common/CMakeLists.txt
+++ b/maliput/test/common/CMakeLists.txt
@@ -15,10 +15,6 @@ macro(add_dependencies_to_test target)
           ${PROJECT_SOURCE_DIR}/test
       )
 
-      ament_target_dependencies(${target}
-          "drake"
-      )
-
       target_link_libraries(${target}
           common)
 

--- a/maliput/test/common/maliput_never_destroyed_test.cc
+++ b/maliput/test/common/maliput_never_destroyed_test.cc
@@ -43,7 +43,7 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/drake_copyable.h"
+#include "maliput/common/maliput_copyable.h"
 
 namespace maliput {
 namespace common {
@@ -78,7 +78,7 @@ GTEST_TEST(NeverDestroyedTest, NoBoomTest) {
 // ensure it remains valid.
 class Singleton {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Singleton)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(Singleton)
   static Singleton& getInstance() {
     static never_destroyed<Singleton> instance;
     return instance.access();

--- a/maliput/test/geometry_base/CMakeLists.txt
+++ b/maliput/test/geometry_base/CMakeLists.txt
@@ -12,14 +12,10 @@ macro(add_dependencies_to_test target)
           ${PROJECT_SOURCE_DIR}/test
       )
 
-      ament_target_dependencies(${target}
-          "drake"
-      )
-
       target_link_libraries(${target}
           api
           maliput_test_utilities
-          drake::drake)
+      )
 
     endif()
 endmacro()

--- a/maliput/test/math/CMakeLists.txt
+++ b/maliput/test/math/CMakeLists.txt
@@ -17,13 +17,8 @@ macro(add_dependencies_to_test target)
           ${PROJECT_SOURCE_DIR}/test
       )
 
-      ament_target_dependencies(${target}
-          "drake"
-      )
-
       target_link_libraries(${target}
           common
-          drake::drake
           math
           maliput_test_utilities
       )

--- a/maliput_utilities/src/maliput-utilities/CMakeLists.txt
+++ b/maliput_utilities/src/maliput-utilities/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(maliput-utilities
 
 ament_target_dependencies(maliput-utilities
   PUBLIC
+    "drake"
     "maliput"
 )
 


### PR DESCRIPTION
> Solves #236 

Depends on :
- [x] Quaternion #264 
- [x] Remove Hyperplane dependency #270 
- [x] Remove ParametrizedLine dependency #273 
- [x] Remove dependency on multilane from maliput-utilities #272 
- [x] Solves packages dependencies after `drake` removal #283  

This PR:
- Finishes with the dependencies on `drake`. Removing all the links libraries carried out in the `CMakeLists` files.
- Removes `#include`s that were forgotten of being removed.