### PR TITLE
Replace drake::saturate by std::clamp in dragway.

### DIFF
--- a/dragway/CMakeLists.txt
+++ b/dragway/CMakeLists.txt
@@ -13,7 +13,6 @@ message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
 
-find_package(drake_vendor REQUIRED)
 find_package(maliput REQUIRED)
 find_package(maliput-utilities REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
@@ -76,7 +75,6 @@ install(
 ament_export_include_directories(include)
 
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(drake)
 ament_export_dependencies(maliput)
 ament_export_dependencies(maliput-utilities)
 ament_export_interfaces(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)

--- a/dragway/package.xml
+++ b/dragway/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>ament_cmake_doxygen</build_depend>
 
-  <depend>drake_vendor</depend>
   <depend>maliput</depend>
   <depend>maliput-utilities</depend>
   <depend>pybind11-dev</depend>

--- a/dragway/src/dragway/CMakeLists.txt
+++ b/dragway/src/dragway/CMakeLists.txt
@@ -20,13 +20,11 @@ target_link_libraries(dragway
   maliput::api
   maliput::common
   maliput::geometry_base
-  drake::drake
 )
 
 ament_target_dependencies(dragway
     "maliput-utilities"
     "maliput"
-    "drake"
 )
 
 ##############################################################################

--- a/dragway/src/dragway/road_geometry.cc
+++ b/dragway/src/dragway/road_geometry.cc
@@ -3,8 +3,6 @@
 #include <cmath>
 #include <memory>
 
-#include "drake/math/saturate.h"
-
 #include "maliput/common/logger.h"
 #include "maliput/common/maliput_abort.h"
 #include "maliput/common/maliput_throw.h"
@@ -170,9 +168,9 @@ api::RoadPositionResult RoadGeometry::DoToRoadPosition(const api::GeoPosition& g
       follows.
   */
   api::GeoPosition closest_position;
-  closest_position.set_x(drake::math::saturate(geo_pos.x(), min_x, max_x));
-  closest_position.set_y(drake::math::saturate(geo_pos.y(), min_y, max_y));
-  closest_position.set_z(drake::math::saturate(geo_pos.z(), min_z, max_z));
+  closest_position.set_x(std::clamp(geo_pos.x(), min_x, max_x));
+  closest_position.set_y(std::clamp(geo_pos.y(), min_y, max_y));
+  closest_position.set_z(std::clamp(geo_pos.z(), min_z, max_z));
 
   const int closest_lane_index = GetLaneIndex(closest_position);
   const Lane* closest_lane = dynamic_cast<const Lane*>(junction_.segment(0)->lane(closest_lane_index));

--- a/dragway/src/dragway_test_utilities/CMakeLists.txt
+++ b/dragway/src/dragway_test_utilities/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(
 target_link_libraries(dragway_test_utilities
   dragway
   maliput::api
-  drake::drake)
+)
 
 install(
     TARGETS dragway_test_utilities

--- a/dragway/test/CMakeLists.txt
+++ b/dragway/test/CMakeLists.txt
@@ -13,7 +13,6 @@ macro(add_dependencies_to_test target)
 
       ament_target_dependencies(${target}
         "maliput"
-        "drake"
       )
 
       target_link_libraries(${target}


### PR DESCRIPTION
- Remove `drake::saturate` and use `std::clamp` instead. (In `dragway`)
- Remove dependency on `dragway` to `drake` given that `saturate` is the only thing left of `drake` in `dragway`.