### PR TITLE
Moves dragway_to_urdf to maiput_integration.

### DIFF
--- a/dragway/CMakeLists.txt
+++ b/dragway/CMakeLists.txt
@@ -14,7 +14,6 @@ message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 find_package(ament_cmake REQUIRED)
 
 find_package(maliput REQUIRED)
-find_package(maliput-utilities REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 
 ##############################################################################
@@ -76,7 +75,6 @@ ament_export_include_directories(include)
 
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(maliput)
-ament_export_dependencies(maliput-utilities)
 ament_export_interfaces(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 
 ament_package()

--- a/dragway/README.md
+++ b/dragway/README.md
@@ -8,30 +8,3 @@ teleporting from one end of the lane to the opposite end of the lane.
 
 The number of lanes and their lengths, widths, and shoulder widths are all user
 specifiable.
-
-# How to Run `dragway_to_urdf`
-
-The executable `dragway_to_urdf` allows one create a URDF representation of a
-dragway. To run `dragway_to_urdf`, execute:
-
-    dragway_to_urdf \
-          --dirpath=[dirpath] \
-          --file_name_root=[file name root] \
-          --lane_width=[lane width] \
-          --length=[length of road in meters] \
-          --num_lanes=[number of lanes] \
-          --shoulder_width=[width of shoulder in meters]
-
-For an explanation on what the above-mentioned parameters mean, execute:
-
-    dragway_to_urdf --help
-
-One the above command is executed, the following files should exist:
-
-  1. `[dirpath]/[file name root].urdf` -- a [URDF](http://wiki.ros.org/urdf)
-     description of the dragway.
-  2. `[dirpath]/[file name root].obj` -- a
-     [Wavefront OBJ](https://en.wikipedia.org/wiki/Wavefront_.obj_file) mesh of
-     the dragway.
-  3. `[dirpath]/[file name root].mtl` -- a material file that applies textures
-     and colors to the above Wavefront OBJ file.

--- a/dragway/package.xml
+++ b/dragway/package.xml
@@ -11,7 +11,6 @@
   <build_depend>ament_cmake_doxygen</build_depend>
 
   <depend>maliput</depend>
-  <depend>maliput-utilities</depend>
   <depend>pybind11-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/dragway/src/dragway/CMakeLists.txt
+++ b/dragway/src/dragway/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(dragway
 )
 
 ament_target_dependencies(dragway
-    "maliput-utilities"
     "maliput"
 )
 
@@ -37,28 +36,6 @@ install(
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
-)
-
-add_executable(dragway_to_urdf
-  dragway_to_urdf.cc
-)
-
-ament_target_dependencies(dragway_to_urdf
-  "maliput"
-)
-
-target_link_libraries(dragway_to_urdf
-    dragway
-    gflags
-    maliput-utilities::maliput-utilities
-    maliput::common
-    maliput::geometry_base
-)
-
-install(TARGETS dragway_to_urdf
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
 )
 
 ament_export_libraries(dragway)

--- a/maliput_integration/CMakeLists.txt
+++ b/maliput_integration/CMakeLists.txt
@@ -12,6 +12,10 @@ project(maliput-integration LANGUAGES C CXX VERSION 3.0.0)
 message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
+find_package(dragway REQUIRED)
+find_package(gflags REQUIRED)
+find_package(maliput REQUIRED)
+find_package(maliput-utilities REQUIRED)
 
 ##############################################################################
 # Project Configuration
@@ -39,8 +43,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_clang_format REQUIRED)
   enable_testing()
   add_subdirectory(test)
-  # TODO: when adding code, this should be re-enabled.
-  # ament_clang_format(CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format)
+  ament_clang_format(CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format)
 endif()
 
 ##############################################################################
@@ -55,6 +58,7 @@ if(BUILD_DOCS)
   find_package(ament_cmake_doxygen REQUIRED)
   ament_doxygen_generate(doxygen_maliput_integration
     CONFIG_OVERLAY doc/Doxyfile.overlay.in
+    DEPENDENCIES dragway maliput maliput-utilities
   )
 endif()
 
@@ -68,5 +72,10 @@ install(
 )
 
 ament_export_include_directories(include)
+
 ament_export_dependencies(ament_cmake)
+ament_export_dependencies(dragway)
+ament_export_dependencies(maliput)
+ament_export_dependencies(maliput-utilities)
+
 ament_package()

--- a/maliput_integration/package.xml
+++ b/maliput_integration/package.xml
@@ -9,6 +9,11 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>maliput</depend>
+  <depend>maliput-utilities</depend>
+  <depend>dragway</depend>
+  <depend>libgflags-dev</depend>
+
   <build_depend>ament_cmake_doxygen</build_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/maliput_integration/src/maliput-integration/CMakeLists.txt
+++ b/maliput_integration/src/maliput-integration/CMakeLists.txt
@@ -1,0 +1,30 @@
+##############################################################################
+# Sources
+##############################################################################
+add_executable(dragway_to_urdf
+  dragway_to_urdf.cc
+)
+
+ament_target_dependencies(dragway_to_urdf
+  "dragway"
+  "maliput"
+  "maliput-utilities"
+)
+
+target_link_libraries(dragway_to_urdf
+    dragway::dragway
+    gflags
+    maliput-utilities::maliput-utilities
+    maliput::common
+    maliput::geometry_base
+)
+
+##############################################################################
+# Exports
+##############################################################################
+
+install(TARGETS dragway_to_urdf
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/maliput_integration/src/maliput-integration/dragway_to_urdf.cc
+++ b/maliput_integration/src/maliput-integration/dragway_to_urdf.cc
@@ -3,15 +3,17 @@
  * Instantiates a dragway with a user-specified number of lanes and outputs
  * a URDF model of it.
  */
+#include <limits>
+#include <string>
 
 #include <gflags/gflags.h>
 
+#include "dragway/road_geometry.h"
 #include "maliput-utilities/generate_urdf.h"
+#include "maliput/api/road_geometry.h"
 #include "maliput/common/filesystem.h"
 #include "maliput/common/logger.h"
 #include "maliput/common/maliput_abort.h"
-
-#include "dragway/road_geometry.h"
 
 DEFINE_int32(num_lanes, 2, "The number of lanes.");
 DEFINE_double(length, 10, "The length of the dragway in meters.");
@@ -44,40 +46,40 @@ DEFINE_string(spdlog_level, "unchanged",
               "'off'");
 
 namespace maliput {
-namespace dragway {
+namespace integration {
 namespace {
 
 int exec(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
-  maliput::common::set_log_level(FLAGS_spdlog_level);
+  common::set_log_level(FLAGS_spdlog_level);
 
-  RoadGeometry road_geometry(api::RoadGeometryId{"Dragway with " + std::to_string(FLAGS_num_lanes) + " lanes."},
-                             FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width,
-                             FLAGS_maximum_height, std::numeric_limits<double>::epsilon(),
-                             std::numeric_limits<double>::epsilon());
+  const dragway::RoadGeometry road_geometry(
+      api::RoadGeometryId{"Dragway with " + std::to_string(FLAGS_num_lanes) + " lanes."}, FLAGS_num_lanes, FLAGS_length,
+      FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height, std::numeric_limits<double>::epsilon(),
+      std::numeric_limits<double>::epsilon());
 
   utility::ObjFeatures features;
 
   // Creates the destination directory if it does not already exist.
-  maliput::common::Path directory;
+  common::Path directory;
   directory.set_path(FLAGS_dirpath);
   if (!directory.exists()) {
-    maliput::common::Filesystem::create_directory_recursive(directory);
+    common::Filesystem::create_directory_recursive(directory);
   }
   MALIPUT_DEMAND(directory.exists());
 
   // The following is necessary for users to know where to find the resulting
   // files when this program is executed in a sandbox. This occurs, for example
   // when using `dragway_to_urdf`.
-  const maliput::common::Path my_path = maliput::common::Filesystem::get_cwd();
+  const common::Path my_path = maliput::common::Filesystem::get_cwd();
 
-  maliput::log()->info("Creating Dragway URDF in {}.", my_path.get_path());
+  log()->info("Creating Dragway URDF in {}.", my_path.get_path());
   utility::GenerateUrdfFile(&road_geometry, directory.get_path(), FLAGS_file_name_root, features);
   return 0;
 }
 
 }  // namespace
-}  // namespace dragway
+}  // namespace integration
 }  // namespace maliput
 
-int main(int argc, char* argv[]) { return maliput::dragway::exec(argc, argv); }
+int main(int argc, char* argv[]) { return maliput::integration::exec(argc, argv); }

--- a/maliput_integration_tests/README.md
+++ b/maliput_integration_tests/README.md
@@ -1,0 +1,35 @@
+# `maliput-integration`
+
+This package contains integration examples and tools that unify `maliput` core
+and its possible backends.
+
+# Applications
+
+## `dragway_to_urdf`
+
+## How to run it?
+
+The executable `dragway_to_urdf` allows one create a URDF representation of a
+dragway. To run `dragway_to_urdf`, execute:
+
+    dragway_to_urdf \
+          --dirpath=[dirpath] \
+          --file_name_root=[file name root] \
+          --lane_width=[lane width] \
+          --length=[length of road in meters] \
+          --num_lanes=[number of lanes] \
+          --shoulder_width=[width of shoulder in meters]
+
+For an explanation on what the above-mentioned parameters mean, execute:
+
+    dragway_to_urdf --help
+
+One the above command is executed, the following files should exist:
+
+  1. `[dirpath]/[file name root].urdf` -- a [URDF](http://wiki.ros.org/urdf)
+     description of the dragway.
+  2. `[dirpath]/[file name root].obj` -- a
+     [Wavefront OBJ](https://en.wikipedia.org/wiki/Wavefront_.obj_file) mesh of
+     the dragway.
+  3. `[dirpath]/[file name root].mtl` -- a material file that applies textures
+     and colors to the above Wavefront OBJ file.


### PR DESCRIPTION
Part of #182.

It also modifies namespaces to better reflect the new package and fixes some style guide misuses.