### PR TITLE
Adds maliput-integrations to CI checks.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,8 @@ node('delphyne-linux-bionic-unprovisioned') {
         stage('checkout_index') {
           sh 'src/maliput/ci/jenkins/checkout_index'
         }
-        withEnv(['COLCON_BUILD_EXTRA_ARGS=--packages-up-to dragway maliput-integration-tests',
-                 'COLCON_TEST_EXTRA_ARGS=--packages-up-to dragway maliput-integration-tests']) {
+        withEnv(['COLCON_BUILD_EXTRA_ARGS=--packages-up-to dragway maliput-integration-tests maliput-integration',
+                 'COLCON_TEST_EXTRA_ARGS=--packages-up-to dragway maliput-integration-tests maliput-integration']) {
           load './index/ci/jenkins/pipeline.groovy'
         }
       } finally {


### PR DESCRIPTION
I missed to include maliput-integration to CI checks in #299. This PR covers the missing functionality.