### PR TITLE
Migrate docs to doxygen part 2

### DIFF
--- a/maliput/include/maliput/api/maliput_design.h
+++ b/maliput/include/maliput/api/maliput_design.h
@@ -582,7 +582,8 @@
 /// Taking @f$G_{xy} = (G_x, G_y)@f$ and @f$G_z@f$ together,
 ///
 /// > @f[
-/// > \left(\begin{array}{c} G_{xy}\\ l_\text{max}G_z \end{array}\right): p_{SEG} \mapsto \left(\begin{array}{c}x\\y\\z\end{array}\right)
+/// > \left(\begin{array}{c} G_{xy}\\ l_\text{max}G_z \end{array}\right): p_{SEG} \mapsto
+/// >   \left(\begin{array}{c}x\\y\\z\end{array}\right)
 /// > @f]
 ///
 /// @f[


### PR DESCRIPTION
Migration of org-documentation to doxygen. Part 2.

Scope: This PR migrates from the top of the file from "Lanes Joined End-to-End via BranchPoints" to the end of "`multilane`" documentation. This PR will be later migrated to maliput-multilane.

Relates to #278

To build the documentation:

```
colcon build --packages-up-to dsim-docs-bundler
```
And then open in a browser /path/to/workspace/build/maliput/ament_cmake_doxygen/maliput/output/html/group___design.html

Parent PR: #322 

