### PR TITLE
Adds Undefined Behavior Sanitizer.

### DIFF
--- a/cmake/SanitizersConfig.cmake
+++ b/cmake/SanitizersConfig.cmake
@@ -1,6 +1,34 @@
+##############################################################################
+# Useful Macros
+##############################################################################
+
+# It will throw an error if more than one sanitizer is enabled.
+macro(check_sanitizers_exclusivity)
+  set(SANITIZER_COUNT 0)
+  set(SANITIZER_LIST)
+  foreach(sanitizer IN ITEMS ${ARGN})
+    if(${${sanitizer}})
+      math(EXPR SANITIZER_COUNT "1 + ${SANITIZER_COUNT}")
+      list(APPEND SANITIZER_LIST ${sanitizer})
+    endif()
+  endforeach()
+
+  if(${SANITIZER_COUNT} GREATER 1)
+    message(FATAL_ERROR "Can only enable one of ${SANITIZER_LIST} at a time.")
+  endif()
+endmacro()
+
+##############################################################################
+# Sanitizers Configuration
+##############################################################################
+
 if ("${CMAKE_CXX_COMPILER_ID} " MATCHES "Clang ")
-  # Address Sanitizer Configuration
   option(ADDRESS_SANITIZER "Enable Clang Address Sanitizer" OFF)
+  option(UNDEFINED_SANITIZER "Enable Clang Undefined Behaviour Sanitizer" OFF)
+
+  check_sanitizers_exclusivity(ADDRESS_SANITIZER UNDEFINED_SANITIZER)
+
+  # Address Sanitizer Configuration
   if (ADDRESS_SANITIZER)
       message(STATUS "Address Sanitizer - enabled")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope")
@@ -9,6 +37,17 @@ if ("${CMAKE_CXX_COMPILER_ID} " MATCHES "Clang ")
   else()
       message(STATUS "Address Sanitizer - disabled")
   endif()
+
+  # Undefined Behaviour Sanitizer Configuration
+  if (UNDEFINED_SANITIZER)
+      message(STATUS "Undefined Behaviour Sanitizer - enabled")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+      set(LDFLAGS "${LDFLAGS} -fsanitize=undefined")
+      set(SANITIZERS on)
+  else()
+      message(STATUS "Undefined Behaviour Sanitizer - disabled")
+  endif()
+
 else ()
     message(STATUS "Compiler Id:${CMAKE_CXX_COMPILER_ID} - Sanitizers disabled.")
 endif ()


### PR DESCRIPTION
> One step of [dsim-repos-index#64](https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/64)

It allows to activate the undefined behavior sanitizer by passing an argument to the build command line.

`--cmake-args -DUNDEFINED_SANITIZER=On`

And later on, running the test(the sanitizer finds the errors in run-time). 

This sanitizer doesn't halt the execution when an error is found. To do that an environment variable needs to be passed when test command (or having it `export`ed in the environment.) with the following command:

`UBSAN_OPTIONS=halt_on_error=1`

So, to build with the undefined behavior  sanitizer:
```
CC=clang CXX=clang++ colcon build --packages-select maliput --cmake-args ' -DCMAKE_LINKER=/usr/bin/llvm-ld' ' -DUNDEFINED_SANITIZER=On'
```
And to run the tests:
```
UBSAN_OPTIONS=halt_on_error=1 colcon test --packages-select maliput
```
