### PR TITLE
Disables maliput_abort_test when running sanitizers.

### DIFF
--- a/maliput/test/common/CMakeLists.txt
+++ b/maliput/test/common/CMakeLists.txt
@@ -26,7 +26,7 @@ add_dependencies_to_test(maliput_never_destroyed_test)
 add_dependencies_to_test(maliput_passkey_test)
 add_dependencies_to_test(maliput_throw_test)
 
-# When a sanitizer is enabled, tests where assert are checked are disabled.
+# TODO(#335): When a sanitizer is enabled, tests where assert are checked are disabled.
 if (NOT ${SANITIZERS})
   ament_add_gtest(maliput_abort_test maliput_abort_test.cc)
   add_dependencies_to_test(maliput_abort_test)


### PR DESCRIPTION
> One step of [dsim-repos-index#64](https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/64)

When running `asan` `maliput_abort_tests` leads to a `stack overflow error` caused by the gtest macro `EXPECT_DEATH` in combination with `asan`. The test was disabled when running sanitizers.