### PR TITLE
Use container for GitHub action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   PACKAGE_NAME: maliput
   ROS_DISTRO: dashing
-  ROS_WS: ros_ws
+  ROS_WS: maliput_ws
 
 jobs:
   compile_and_test:


### PR DESCRIPTION
I had to switch to using a container to get actions working with malidrive in https://github.com/ToyotaResearchInstitute/malidrive/pull/607, and it's a little cleaner this way, so I'll update the other workflows to use it as well.

* Use `ubuntu:18.04` container
* Working directories are now simpler to specify
* Use newer version of setup-ros action