### PR TITLE
Move clang to sanitizers workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Compile and test with gcc
+name: gcc
 
 on: [push, pull_request]
 
@@ -9,7 +9,7 @@ env:
 
 jobs:
   compile_and_test:
-    name: Compile and test with gcc
+    name: Compile and test
     runs-on: ubuntu-18.04
     container:
       image: ubuntu:18.04

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,4 +1,4 @@
-name: Compile and test with clang sanitizers
+name: clang
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   compile_and_test:
-    name: Compile and test with clang sanitizer
+    name: Compile and test with sanitizer
     runs-on: ubuntu-18.04
     container:
       image: ubuntu:18.04


### PR DESCRIPTION
This reduces the total size of our workflow configuration by reverting most changes from #352 to gcc workflow, since it's smaller to add a `clang` build without a sanitizer to the other workflow.