### PR TITLE
Adds link to rosdep to further inform why prereqs is needed.

### DIFF
--- a/maliput/prereqs
+++ b/maliput/prereqs
@@ -4,7 +4,8 @@
 # This file allows to install prerequisites that cannot be handled via `rosdep`
 # (@see http://wiki.ros.org/rosdep for further reference). In particular,
 # `libpython3-dev` is available in `ubuntu:bionic` but not for `rosdep` which
-# is why it is provided via this script.
+# is why it is provided via this script. See the following link:
+# https://github.com/ros/rosdistro/blob/48e5975c756582415c50c06bd5ee0f61d780c21d/rosdep/python.yaml#L373-L395
 
 set -e pipefail
 


### PR DESCRIPTION
Related to #351 

It provides more information about why we require prereqs.
