### PR TITLE
Workflow: use setup-ros@0.0.26 without workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,7 @@ jobs:
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
     # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@0.0.25
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    - uses: ros-tooling/setup-ros@0.0.26
     - name: vcs import
       shell: bash
       working-directory: ${{ env.ROS_WS }}


### PR DESCRIPTION
Remove the ACTIONS_ALLOW_UNSECURE_COMMANDS workaround.