### PR TITLE
Prefix library names with `maliput_`

### DIFF
--- a/maliput/src/api/CMakeLists.txt
+++ b/maliput/src/api/CMakeLists.txt
@@ -22,6 +22,11 @@ set(API_SOURCES
 
 add_library(api ${API_SOURCES})
 
+set_target_properties(api
+  PROPERTIES
+    OUTPUT_NAME maliput_api
+)
+
 target_include_directories(api
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/maliput/src/base/CMakeLists.txt
+++ b/maliput/src/base/CMakeLists.txt
@@ -28,6 +28,11 @@ set(BASE_SOURCES
 
 add_library(base ${BASE_SOURCES})
 
+set_target_properties(base
+  PROPERTIES
+    OUTPUT_NAME maliput_base
+)
+
 target_include_directories(base
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/maliput/src/common/CMakeLists.txt
+++ b/maliput/src/common/CMakeLists.txt
@@ -9,6 +9,11 @@ set(COMMON_SOURCES
 
 add_library(common ${COMMON_SOURCES})
 
+set_target_properties(common
+  PROPERTIES
+    OUTPUT_NAME maliput_common
+)
+
 target_include_directories(common
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/maliput/src/geometry_base/CMakeLists.txt
+++ b/maliput/src/geometry_base/CMakeLists.txt
@@ -12,6 +12,11 @@ set(SOURCES
 
 add_library(geometry_base ${SOURCES})
 
+set_target_properties(geometry_base
+  PROPERTIES
+    OUTPUT_NAME maliput_geometry_base
+)
+
 target_include_directories(geometry_base
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/maliput/src/math/CMakeLists.txt
+++ b/maliput/src/math/CMakeLists.txt
@@ -11,6 +11,11 @@ set(MATH_SOURCES
 
 add_library(math ${MATH_SOURCES})
 
+set_target_properties(math
+  PROPERTIES
+    OUTPUT_NAME maliput_math
+)
+
 target_include_directories(math
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/maliput/src/routing/CMakeLists.txt
+++ b/maliput/src/routing/CMakeLists.txt
@@ -8,6 +8,11 @@ set(ROUTING_SOURCES
 
 add_library(routing ${ROUTING_SOURCES})
 
+set_target_properties(routing
+  PROPERTIES
+    OUTPUT_NAME maliput_routing
+)
+
 target_include_directories(routing
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/maliput/src/utilities/CMakeLists.txt
+++ b/maliput/src/utilities/CMakeLists.txt
@@ -11,6 +11,11 @@ set(SOURCES
 
 add_library(utilities ${SOURCES})
 
+set_target_properties(utilities
+  PROPERTIES
+    OUTPUT_NAME maliput_utilities
+)
+
 target_include_directories(utilities
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>


### PR DESCRIPTION
Closes #366.

I think this won't require changes to any downstream packages.