### PR TITLE
Don't pass self to ament_target_dependencies

### DIFF
--- a/maliput/test/utilities/CMakeLists.txt
+++ b/maliput/test/utilities/CMakeLists.txt
@@ -20,10 +20,6 @@ macro(add_dependencies_to_test target)
           ${CMAKE_CURRENT_SOURCE_DIR}
       )
 
-      ament_target_dependencies(${target}
-          "maliput"
-      )
-
       target_link_libraries(${target}
           maliput::api
           maliput::common


### PR DESCRIPTION
In preparation of supporting Ubuntu 20.04 and ROS Foxy, I've made the [eloquent branch](https://github.com/ToyotaResearchInstitute/maliput/compare/eloquent) for testing with ROS Eloquent. There is a cmake error that this branch fixes (see the failure on 8ce435a0d9c807c4dc3e2a9075031dcc89f3549f fixed by 23ec7e726fb8278cd48ab14b0f55cb4600a4714f).