### PR TITLE
Modifies PhaseBasedRightOfWayDiscreteValueRuleStateProvider

### DIFF
--- a/maliput/include/maliput/base/manual_discrete_value_rule_state_provider.h
+++ b/maliput/include/maliput/base/manual_discrete_value_rule_state_provider.h
@@ -63,10 +63,14 @@ class ManualDiscreteValueRuleStateProvider : public api::rules::DiscreteValueRul
                 const std::optional<api::rules::DiscreteValueRule::DiscreteValue>& next_state,
                 const std::optional<double>& duration_until);
 
- private:
-  std::optional<api::rules::DiscreteValueRuleStateProvider::StateResult> DoGetState(
-      const api::rules::Rule::Id& id) const final;
+ protected:
+  // This function has been marked as virtual because other providers might
+  // benefit from injecting their own getter and then forwarding calls to this
+  // function.
+  virtual std::optional<api::rules::DiscreteValueRuleStateProvider::StateResult> DoGetState(
+      const api::rules::Rule::Id& id) const;
 
+ private:
   // @throws common::assertion_error When @p state is unrecognized in
   //         @p discrete_value_rule's values.
   void ValidateRuleState(const api::rules::DiscreteValueRule& discrete_value_rule,

--- a/maliput/src/base/phase_based_right_of_way_discrete_value_rule_state_provider.cc
+++ b/maliput/src/base/phase_based_right_of_way_discrete_value_rule_state_provider.cc
@@ -16,9 +16,12 @@ using api::rules::PhaseRingBook;
 using api::rules::Rule;
 
 PhaseBasedRightOfWayDiscreteValueRuleStateProvider::PhaseBasedRightOfWayDiscreteValueRuleStateProvider(
-    const PhaseRingBook* phase_ring_book, const PhaseProvider* phase_provider)
-    : phase_ring_book_(phase_ring_book), phase_provider_(phase_provider) {
-  MALIPUT_DEMAND(phase_ring_book_ != nullptr && phase_provider != nullptr);
+    const api::rules::RoadRulebook* rulebook, const PhaseRingBook* phase_ring_book, const PhaseProvider* phase_provider)
+    : ManualDiscreteValueRuleStateProvider(rulebook),
+      phase_ring_book_(phase_ring_book),
+      phase_provider_(phase_provider) {
+  MALIPUT_THROW_UNLESS(phase_ring_book_ != nullptr);
+  MALIPUT_THROW_UNLESS(phase_provider_ != nullptr);
 }
 
 std::optional<DiscreteValueRuleStateProvider::StateResult>
@@ -40,7 +43,7 @@ PhaseBasedRightOfWayDiscreteValueRuleStateProvider::DoGetState(const Rule::Id& r
       return DiscreteValueRuleStateProvider::StateResult{value, next};
     }
   }
-  return std::nullopt;
+  return ManualDiscreteValueRuleStateProvider::DoGetState(rule_id);
 }
 
 }  // namespace maliput

--- a/maliput/test/base/phase_based_right_of_way_discrete_value_rule_state_provider_test.cc
+++ b/maliput/test/base/phase_based_right_of_way_discrete_value_rule_state_provider_test.cc
@@ -1,60 +1,117 @@
 #include "maliput/base/phase_based_right_of_way_discrete_value_rule_state_provider.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
+#include "maliput/api/lane.h"
+#include "maliput/api/regions.h"
+#include "maliput/api/rules/right_of_way_rule.h"
+#include "maliput/api/rules/road_rulebook.h"
 #include "maliput/base/manual_phase_provider.h"
 #include "maliput/base/manual_phase_ring_book.h"
+#include "maliput/base/manual_rulebook.h"
+#include "maliput/common/assertion_error.h"
+#include "maliput/test_utilities/mock.h"
+#include "maliput/test_utilities/rules_compare.h"
+#include "maliput/test_utilities/rules_test_utilities.h"
 
 namespace maliput {
 namespace {
 
+using maliput::api::LaneId;
+using maliput::api::LaneSRange;
+using maliput::api::LaneSRoute;
 using maliput::api::rules::DiscreteValueRule;
 using maliput::api::rules::DiscreteValueRuleStateProvider;
 using maliput::api::rules::Phase;
 using maliput::api::rules::PhaseRing;
 using maliput::api::rules::RightOfWayRule;
+using maliput::api::rules::RoadRulebook;
 using maliput::api::rules::Rule;
 
-GTEST_TEST(PhaseBasedRightOfWayDiscreteValueRuleStateProviderTest, BasicTest) {
-  const RightOfWayRule::Id row_rule_id_a("rule a");
-  const RightOfWayRule::Id row_rule_id_b("rule b");
-  const RightOfWayRule::State::Id row_state_id_go("GO");
-  const RightOfWayRule::State::Id row_state_id_stop("STOP");
+// Evaluates constructor constraints.
+GTEST_TEST(PhaseBasedRightOfWayDiscreteValueRuleStateProviderTest, ConstructorConstraints) {
+  const ManualRulebook rulebook;
+  const ManualPhaseRingBook phase_ring_book;
+  const ManualPhaseProvider phase_provider;
 
-  const Rule::Id rule_id_a("Right-Of-Way/rule a");
-  const Rule::Id rule_id_b("Right-Of-Way/rule b");
-  const DiscreteValueRule::DiscreteValue state_go =
-      DiscreteValueRule::DiscreteValue{Rule::State::kStrict, Rule::RelatedRules{}, Rule::RelatedUniqueIds{}, "Go"};
-  const DiscreteValueRule::DiscreteValue state_stop =
-      DiscreteValueRule::DiscreteValue{Rule::State::kStrict, Rule::RelatedRules{}, Rule::RelatedUniqueIds{}, "Stop"};
+  EXPECT_THROW(PhaseBasedRightOfWayDiscreteValueRuleStateProvider(nullptr, &phase_ring_book, &phase_provider),
+               maliput::common::assertion_error);
+  EXPECT_THROW(PhaseBasedRightOfWayDiscreteValueRuleStateProvider(&rulebook, nullptr, &phase_provider),
+               maliput::common::assertion_error);
+  EXPECT_THROW(PhaseBasedRightOfWayDiscreteValueRuleStateProvider(&rulebook, &phase_ring_book, nullptr),
+               maliput::common::assertion_error);
+  EXPECT_NO_THROW(PhaseBasedRightOfWayDiscreteValueRuleStateProvider(&rulebook, &phase_ring_book, &phase_provider));
+}
 
-  const Phase::Id phase_id_1("phase1");
-  const Phase phase1(phase_id_1, {{row_rule_id_a, row_state_id_go}, {row_rule_id_b, row_state_id_stop}},
-                     {{rule_id_a, state_go}, {rule_id_b, state_stop}});
-  const Phase::Id phase_id_2("phase2");
-  const Phase phase2(phase_id_2, {{row_rule_id_a, row_state_id_stop}, {row_rule_id_b, row_state_id_go}},
-                     {{rule_id_a, state_stop}, {rule_id_b, state_go}});
-
-  const PhaseRing::Id ring_id("ring");
-  const PhaseRing ring(ring_id, {phase1, phase2});
-
-  ManualPhaseRingBook phase_ring_book;
-  phase_ring_book.AddPhaseRing(ring);
-
-  ManualPhaseProvider phase_provider;
-  phase_provider.AddPhaseRing(ring_id, phase_id_1);
-
-  PhaseBasedRightOfWayDiscreteValueRuleStateProvider dut(&phase_ring_book, &phase_provider);
-
-  EXPECT_EQ(&dut.phase_ring_book(), &phase_ring_book);
-  EXPECT_EQ(&dut.phase_provider(), &phase_provider);
-
+// Evaluates the phase based behavior of the state provider.
+class PhaseBasedBehaviorTest : public ::testing::Test {
+ protected:
   struct ExpectedState {
     const Rule::Id rule;
     const DiscreteValueRuleStateProvider::StateResult result;
   };
 
-  auto compare_expected = [&](const std::vector<ExpectedState>& test_cases) {
+  const LaneSRange kZone{LaneId{"a"}, {10., 20.}};
+
+  const RightOfWayRule::Id row_rule_id_a{"rule a"};
+  const RightOfWayRule::Id row_rule_id_b{"rule b"};
+  const RightOfWayRule::State::Id row_state_id_go{"GO"};
+  const RightOfWayRule::State::Id row_state_id_stop{"STOP"};
+  const RightOfWayRule right_of_way_rule_a{
+      row_rule_id_a,
+      LaneSRoute({kZone}),
+      RightOfWayRule::ZoneType::kStopExcluded,
+      {RightOfWayRule::State{row_state_id_go, RightOfWayRule::State::Type::kGo, {}},
+       RightOfWayRule::State{row_state_id_stop, RightOfWayRule::State::Type::kStop, {}}},
+      {} /* related_bulb_groups */
+  };
+  const RightOfWayRule right_of_way_rule_b{
+      row_rule_id_b,
+      LaneSRoute({kZone}),
+      RightOfWayRule::ZoneType::kStopExcluded,
+      {RightOfWayRule::State{row_state_id_go, RightOfWayRule::State::Type::kGo, {}},
+       RightOfWayRule::State{row_state_id_stop, RightOfWayRule::State::Type::kStop, {}}},
+      {} /* related_bulb_groups */
+  };
+
+  const Rule::Id rule_id_a{"Right-Of-Way/rule a"};
+  const Rule::Id rule_id_b{"Right-Of-Way/rule b"};
+  const DiscreteValueRule::DiscreteValue state_go{Rule::State::kStrict, Rule::RelatedRules{}, Rule::RelatedUniqueIds{},
+                                                  "Go"};
+  const DiscreteValueRule::DiscreteValue state_stop{Rule::State::kStrict, Rule::RelatedRules{},
+                                                    Rule::RelatedUniqueIds{}, "Stop"};
+  const DiscreteValueRule right_of_way_discrete_value_rule_a{
+      rule_id_a, Rule::TypeId("Right-Of-Way"), LaneSRoute({kZone}), {state_go, state_stop}};
+  const DiscreteValueRule right_of_way_discrete_value_rule_b{
+      rule_id_b, Rule::TypeId("Right-Of-Way"), LaneSRoute({kZone}), {state_go, state_stop}};
+
+  const Phase::Id phase_id_1{"phase1"};
+  const Phase phase1{phase_id_1,
+                     {{row_rule_id_a, row_state_id_go}, {row_rule_id_b, row_state_id_stop}},
+                     {{rule_id_a, state_go}, {rule_id_b, state_stop}}};
+  const Phase::Id phase_id_2{"phase2"};
+  const Phase phase2{phase_id_2,
+                     {{row_rule_id_a, row_state_id_stop}, {row_rule_id_b, row_state_id_go}},
+                     {{rule_id_a, state_stop}, {rule_id_b, state_go}}};
+
+  const PhaseRing::Id ring_id{"ring"};
+  const PhaseRing ring{ring_id, {phase1, phase2}};
+
+  void SetUp() override {
+    rulebook_.AddRule(right_of_way_rule_a);
+    rulebook_.AddRule(right_of_way_rule_b);
+    rulebook_.AddRule(right_of_way_discrete_value_rule_a);
+    rulebook_.AddRule(right_of_way_discrete_value_rule_b);
+
+    phase_ring_book_.AddPhaseRing(ring);
+
+    phase_provider_.AddPhaseRing(ring_id, phase_id_1);
+  }
+
+  void CompareExpectedTestCases(const DiscreteValueRuleStateProvider& dut,
+                                const std::vector<ExpectedState>& test_cases) const {
     for (const auto& test : test_cases) {
       const std::optional<DiscreteValueRuleStateProvider::StateResult> result = dut.GetState(test.rule);
       EXPECT_TRUE(result.has_value());
@@ -70,17 +127,79 @@ GTEST_TEST(PhaseBasedRightOfWayDiscreteValueRuleStateProviderTest, BasicTest) {
         EXPECT_EQ(result->next, std::nullopt);
       }
     }
-  };
+  }
+
+  ManualRulebook rulebook_;
+  ManualPhaseRingBook phase_ring_book_;
+  ManualPhaseProvider phase_provider_;
+};
+
+TEST_F(PhaseBasedBehaviorTest, PhaseBasedBehavior) {
+  PhaseBasedRightOfWayDiscreteValueRuleStateProvider dut(&rulebook_, &phase_ring_book_, &phase_provider_);
+
+  EXPECT_EQ(&dut.phase_ring_book(), &phase_ring_book_);
+  EXPECT_EQ(&dut.phase_provider(), &phase_provider_);
 
   // TODO(liang.fok) Add tests for "next state" in returned results once #9993
   // is resolved.
   const std::vector<ExpectedState> phase_1_test_cases{{rule_id_a, {state_go, std::nullopt}},
                                                       {rule_id_b, {state_stop, std::nullopt}}};
-  compare_expected(phase_1_test_cases);
-  phase_provider.SetPhase(ring_id, phase_id_2);
+  CompareExpectedTestCases(dut, phase_1_test_cases);
+  phase_provider_.SetPhase(ring_id, phase_id_2);
   const std::vector<ExpectedState> phase_2_test_cases{{rule_id_a, {state_stop}}, {rule_id_b, {state_go}}};
-  compare_expected(phase_2_test_cases);
+  CompareExpectedTestCases(dut, phase_2_test_cases);
   EXPECT_FALSE(dut.GetState(Rule::Id("unknown rule")).has_value());
+}
+
+// Evaluates the manual behavior of the state provider.
+class ManualBasedBehaviorTest : public ::testing::Test {
+ protected:
+  const Rule::Id kRuleId{"dvrt/dvr_id"};
+  const Rule::Id kUnknownRuleId{"dvrt/unknown_id"};
+  const DiscreteValueRule::DiscreteValue kStateA{DiscreteValueRule::DiscreteValue{
+      Rule::State::kStrict, api::test::CreateEmptyRelatedRules(), api::test::CreateEmptyRelatedUniqueIds(), "value1"}};
+  const DiscreteValueRule::DiscreteValue kStateB{DiscreteValueRule::DiscreteValue{
+      Rule::State::kStrict, api::test::CreateEmptyRelatedRules(), api::test::CreateEmptyRelatedUniqueIds(), "value2"}};
+  const DiscreteValueRule::DiscreteValue kInvalidState{
+      DiscreteValueRule::DiscreteValue{Rule::State::kStrict, api::test::CreateEmptyRelatedRules(),
+                                       api::test::CreateEmptyRelatedUniqueIds(), "invalid_state"}};
+  const double kDurationUntil{10.};
+
+  void SetUp() override {
+    const maliput::api::test::RoadRulebookBuildFlags kRulebookBuildFlags{
+        false /* add_right_of_way */, {} /* right_of_way_build_flags */,  false /* add_direction_usage */,
+        false /* add_speed_limit */,  true /* add_discrete_value_rule */, false /* add_range_value_rule */};
+    road_rulebook_ = api::test::CreateRoadRulebook(kRulebookBuildFlags);
+  }
+
+  std::unique_ptr<RoadRulebook> road_rulebook_;
+  ManualPhaseRingBook phase_ring_book_;
+  ManualPhaseProvider phase_provider_;
+};
+
+TEST_F(ManualBasedBehaviorTest, SetStateTest) {
+  PhaseBasedRightOfWayDiscreteValueRuleStateProvider dut(road_rulebook_.get(), &phase_ring_book_, &phase_provider_);
+
+  // Tries to set the state to an unknown Rule::Id in `rulebook_`.
+  EXPECT_THROW(dut.SetState(kUnknownRuleId, kStateA, {}, {}), std::out_of_range);
+  // Tries to set an invalid state to the rule.
+  EXPECT_THROW(dut.SetState(kRuleId, kInvalidState, {}, {}), maliput::common::assertion_error);
+  // Tries to set an invalid next state to the rule.
+  EXPECT_THROW(dut.SetState(kRuleId, kStateA, {kInvalidState}, {}), maliput::common::assertion_error);
+  // Tries to set a valid next state with a negative duration.
+  EXPECT_THROW(dut.SetState(kRuleId, kStateA, {kStateA}, {-kDurationUntil}), maliput::common::assertion_error);
+  // Tries to set a nullopt next state with duration.
+  EXPECT_THROW(dut.SetState(kRuleId, kStateA, {}, {kDurationUntil}), maliput::common::assertion_error);
+
+  // Sets a valid state, next state and duration until.
+  EXPECT_NO_THROW(dut.SetState(kRuleId, kStateA, {kStateB}, {kDurationUntil}));
+  const std::optional<DiscreteValueRuleStateProvider::StateResult> result = dut.GetState(kRuleId);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(result->state, kStateA));
+  EXPECT_TRUE(result->next.has_value());
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(result->next->state, kStateB));
+  EXPECT_TRUE(result->next->duration_until.has_value());
+  EXPECT_EQ(result->next->duration_until.value(), kDurationUntil);
 }
 
 }  // namespace


### PR DESCRIPTION
Includes the manual behavior for none Right-Of-Way rule types into `PhaseBasedRightOfWayDiscreteValueRuleStateProvider`.

See https://github.com/ToyotaResearchInstitute/malidrive/issues/738 and this [comment](https://github.com/ToyotaResearchInstitute/malidrive/issues/738#issuecomment-755435270) in particular for context.

A set of follow up PRs will land in malidrive and maliput_malidrive to use this class from now on.