### PR TITLE
Points to maliput-documentation instead of dsim-repos-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Road network runtime interface.
 
 ## Build
 
-1. Setup a development workspace as described [here](https://github.com/ToyotaResearchInstitute/dsim-repos-index/tree/master/README.md).
+1. Setup a development workspace as described [here](https://github.com/ToyotaResearchInstitute/maliput-documentation/blob/main/docs/installation_quickstart.rst).
 
 2. Bring up your development workspace:
 


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/182