### PR TITLE
Links maliput::test_utilities against gtest.

### DIFF
--- a/maliput/src/test_utilities/CMakeLists.txt
+++ b/maliput/src/test_utilities/CMakeLists.txt
@@ -1,3 +1,7 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+ament_find_gtest()
+
 ##############################################################################
 # Sources
 ##############################################################################
@@ -29,13 +33,17 @@ target_include_directories(
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
+    ${GTEST_INCLUDE_DIRS}
 )
 
 target_link_libraries(test_utilities
+ PUBLIC
   maliput::api
   maliput::common
   maliput::math
   maliput::geometry_base
+ PRIVATE
+  ${GTEST_LIBRARIES}
 )
 
 install(


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196

Found while debugging https://github.com/ToyotaResearchInstitute/malidrive/pull/767 . `maliput::test_utilities` is not linked against gtest and it seems to be solved most of the times in bionic with both gtest. I think it is because we are not using exactly the same version in bionic than in focal:

| Linker | bionic | focal |
| -------- | -------- | ------ |
| ld        | 2.30    | 2.34 |
| lld-8    | 8.0      | 8.0.1 |

The problem is seen when compiling `maliput_malidrive` in focal with clang8.