### PR TITLE
Replaces AMENT_CURRENT_PREFIX by COLCON_PREFIX_PATH

### DIFF
--- a/maliput/setup.sh.in
+++ b/maliput/setup.sh.in
@@ -52,4 +52,4 @@ add_if_not_in_var() {
   fi
 }
 add_if_not_in_var ASAN_OPTIONS $ASAN_OPTIONS:detect_odr_violation=0
-add_if_not_in_var MALIPUT_PLUGIN_PATH $MALIPUT_PLUGIN_PATH $AMENT_CURRENT_PREFIX/lib/maliput/plugins
+add_if_not_in_var MALIPUT_PLUGIN_PATH $MALIPUT_PLUGIN_PATH $COLCON_PREFIX_PATH/maliput/lib/maliput/plugins


### PR DESCRIPTION
AMENT_CURRENT_PREFIX points to /opt/ros/foxy in foxy whereas
it points to the full workspace/install/package_name in dashing.
COLCON_PREFIX_PATH remains to point to the full workspace/install
path

Part of ToyotaResearchInstitute/maliput_infrastructure#196 -- see this [comment](https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196)