### PR TITLE
Adds colours to the logging messages

### DIFF
--- a/maliput/include/maliput/common/logger.h
+++ b/maliput/include/maliput/common/logger.h
@@ -118,7 +118,7 @@ class SinkBase {
 
   /// Log the message
   /// @param msg Is the message to be logged.
-  virtual void log(const std::string& msg) = 0;
+  virtual void log(const std::string& msg, logger::level lev) = 0;
 
   /// Empty the buffer.
   virtual void flush() = 0;
@@ -131,7 +131,7 @@ class Sink : public SinkBase {
   Sink() = default;
   ~Sink() = default;
 
-  void log(const std::string& msg) override;
+  void log(const std::string& msg, logger::level lev) override;
 
   void flush() override{};
 };
@@ -266,7 +266,7 @@ void Logger::log(logger::level lev, Args&&... args) {
     // Performing type-erasure in the header file.
     msg += format(std::vector<std::string>{Serialize()(std::forward<Args>(args))...});
     msg += "\n";
-    sink_->log(msg);
+    sink_->log(msg, lev);
   }
 }
 

--- a/maliput/include/maliput/common/logger.h
+++ b/maliput/include/maliput/common/logger.h
@@ -128,12 +128,15 @@ class SinkBase {
 class Sink : public SinkBase {
  public:
   MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(Sink);
-  Sink() = default;
+  Sink(bool color);
   ~Sink() = default;
 
   void log(const std::string& msg, logger::level lev) override;
 
   void flush() override{};
+
+ private:
+  std::function<void(const std::string&, logger::level)> print_{};
 };
 
 /// A logger class implementation.
@@ -224,7 +227,17 @@ class Logger {
   /// @return The string value of the previous log level. @see logger::kLevelToString.
   std::string set_level(logger::level log_level);
 
+  /// Sets flag to whether print using colors or not.
+  /// @param color True to enable color printing. False otherwise.
+  /// @return Previous value of the color flag.
+  bool set_color(bool color);
+
  private:
+  // Create a string from a list of strings.
+  // @param v Is a list of strings of fmt type. See https://github.com/fmtlib/fmt.
+  // @return A string created from the list `v` using fmt library.
+  const std::string format(const std::vector<std::string>& v) const;
+
   // Send the message to the sink.
   // @param log_level Level of the message.
   // @param args Is an argument list representing objects to be formatted using fmt library. See
@@ -232,16 +245,14 @@ class Logger {
   template <typename... Args>
   void log(logger::level log_level, Args&&... args);
 
+  // Flag to enable color printing.
+  bool color_{false};
+
   // Sink where the messages will be dumped to.
-  std::unique_ptr<common::SinkBase> sink_{std::make_unique<common::Sink>()};
+  std::unique_ptr<common::SinkBase> sink_{std::make_unique<common::Sink>(color_)};
 
   // Minimum level of messages to be log.
   logger::level level_{logger::level::info};
-
-  // Create a string from a list of strings.
-  // @param v Is a list of strings of fmt type. See https://github.com/fmtlib/fmt.
-  // @return A string created from the list `v` using fmt library.
-  const std::string format(const std::vector<std::string>& v) const;
 };
 
 /// Convenient functor for getting a string from a object that has serialization operator defined.
@@ -280,6 +291,13 @@ void Logger::log(logger::level lev, Args&&... args) {
 ///         predefined values.
 /// @relatesalso Logger.
 std::string set_log_level(const std::string& level);
+
+/// Invokes `maliput::log()->set_color(color)`.
+///
+/// @param level True to enable color printing. False otherwise.
+/// @return Previous value of the color flag.
+/// @relatesalso Logger.
+bool set_log_color(bool color);
 
 }  // namespace common
 

--- a/maliput/src/common/CMakeLists.txt
+++ b/maliput/src/common/CMakeLists.txt
@@ -16,6 +16,11 @@ set_target_properties(common
     OUTPUT_NAME maliput_common
 )
 
+target_compile_definitions(common
+  PRIVATE
+    MALIPUT_FMT_VERSION=${fmt_VERSION_MAJOR}
+)
+
 target_include_directories(common
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/maliput/src/common/logger.cc
+++ b/maliput/src/common/logger.cc
@@ -45,42 +45,80 @@
 
 #include "maliput/common/maliput_never_destroyed.h"
 
+// fmt major version for focal: 6.
+// fmt major version for bionic: 4.
+#if MALIPUT_FMT_VERSION == 6
+#include <fmt/color.h>
+#endif
+
 namespace maliput {
 namespace common {
 
 namespace {
-// Color is from fmt V4. From V6 a color.h must be include and a color enum is created.
-fmt::Color FromLogLevelToColor(const logger::level& lev){
-  switch (lev)
-  {
-  case logger::level::trace:
-    return fmt::Color::WHITE;
-  break;
 
-  case logger::level::debug:
-    return fmt::Color::BLUE;
-  break;
+#if MALIPUT_FMT_VERSION == 4
+fmt::Color FromLogLevelToColor(const logger::level& lev) {
+  switch (lev) {
+    case logger::level::trace:
+      return fmt::Color::WHITE;
+      break;
 
-  case logger::level::info:
-    return fmt::Color::GREEN;
-  break;
+    case logger::level::debug:
+      return fmt::Color::BLUE;
+      break;
 
-  case logger::level::error:
-    return fmt::Color::RED;
-  break;
+    case logger::level::info:
+      return fmt::Color::GREEN;
+      break;
 
-  case logger::level::warn:
-    return fmt::Color::YELLOW;
-  break;
+    case logger::level::error:
+      return fmt::Color::RED;
+      break;
 
-  case logger::level::critical:
-    return fmt::Color::RED;
-  break;
-  
-  default:
-    return fmt::Color::WHITE;
+    case logger::level::warn:
+      return fmt::Color::YELLOW;
+      break;
+
+    case logger::level::critical:
+      return fmt::Color::RED;
+      break;
+
+    default:
+      return fmt::Color::WHITE;
   }
 }
+#elif MALIPUT_FMT_VERSION == 6
+fmt::color FromLogLevelToColor(const logger::level& lev) {
+  switch (lev) {
+    case logger::level::trace:
+      return fmt::color::white;
+      break;
+
+    case logger::level::debug:
+      return fmt::color::blue;
+      break;
+
+    case logger::level::info:
+      return fmt::color::green;
+      break;
+
+    case logger::level::error:
+      return fmt::color::red;
+      break;
+
+    case logger::level::warn:
+      return fmt::color::yellow;
+      break;
+
+    case logger::level::critical:
+      return fmt::color::red;
+      break;
+
+    default:
+      return fmt::color::white;
+  }
+}
+#endif
 
 // Apply fmt::format to a list of arguments defined by an array `v`.
 // @tparam N Is the size of the array.
@@ -134,7 +172,11 @@ const std::string Logger::format(const std::vector<std::string>& v) const {
   return call_fmt_format(args);
 }
 
+#if MALIPUT_FMT_VERSION == 6
+void Sink::log(const std::string& msg, logger::level lev) { fmt::print(fg(FromLogLevelToColor(lev)), msg); }
+#elif MALIPUT_FMT_VERSION == 4
 void Sink::log(const std::string& msg, logger::level lev) { fmt::print_colored(FromLogLevelToColor(lev), msg); }
+#endif
 
 }  // namespace common
 

--- a/maliput/src/common/logger.cc
+++ b/maliput/src/common/logger.cc
@@ -49,6 +49,38 @@ namespace maliput {
 namespace common {
 
 namespace {
+// Color is from fmt V4. From V6 a color.h must be include and a color enum is created.
+fmt::Color FromLogLevelToColor(const logger::level& lev){
+  switch (lev)
+  {
+  case logger::level::trace:
+    return fmt::Color::WHITE;
+  break;
+
+  case logger::level::debug:
+    return fmt::Color::BLUE;
+  break;
+
+  case logger::level::info:
+    return fmt::Color::GREEN;
+  break;
+
+  case logger::level::error:
+    return fmt::Color::RED;
+  break;
+
+  case logger::level::warn:
+    return fmt::Color::YELLOW;
+  break;
+
+  case logger::level::critical:
+    return fmt::Color::RED;
+  break;
+  
+  default:
+    return fmt::Color::WHITE;
+  }
+}
 
 // Apply fmt::format to a list of arguments defined by an array `v`.
 // @tparam N Is the size of the array.
@@ -102,7 +134,7 @@ const std::string Logger::format(const std::vector<std::string>& v) const {
   return call_fmt_format(args);
 }
 
-void Sink::log(const std::string& msg) { fmt::printf(msg); }
+void Sink::log(const std::string& msg, logger::level lev) { fmt::print_colored(FromLogLevelToColor(lev), msg); }
 
 }  // namespace common
 

--- a/maliput/test/common/logger_test.cc
+++ b/maliput/test/common/logger_test.cc
@@ -23,7 +23,7 @@ class MockSink : public SinkBase {
   ~MockSink() = default;
 
   const std::string& get_log_message() const { return log_message_; }
-  void log(const std::string& msg) override { log_message_ = msg; }
+  void log(const std::string& msg, logger::level lev) override { log_message_ = msg; }
   void flush() override{};
 
  private:

--- a/maliput/test/common/logger_test.cc
+++ b/maliput/test/common/logger_test.cc
@@ -33,7 +33,7 @@ class MockSink : public SinkBase {
 GTEST_TEST(LoggerTest, GetInstance) { EXPECT_NE(log(), nullptr); }
 
 GTEST_TEST(LoggerTest, SetSink) {
-  std::unique_ptr<SinkBase> dut = std::make_unique<Sink>();
+  std::unique_ptr<SinkBase> dut = std::make_unique<MockSink>();
   SinkBase* dut_ptr = dut.get();
   log()->set_sink(std::move(dut));
   EXPECT_EQ(log()->get_sink(), dut_ptr);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/53065142/128575988-5cc63a31-b11a-4bbd-ad35-f4c7f7b6c1cd.png)

Next steps before removing draft label:
 - [ ] Agree about the picked colors for each level of logging.
 -  [ ] Verify behavior for bionic
  - [ ] Verify behavior for focal
