### PR TITLE
Removes const in RoadNetworkLoader functor interface.

### DIFF
--- a/maliput/include/maliput/plugin/road_network_loader.h
+++ b/maliput/include/maliput/plugin/road_network_loader.h
@@ -31,7 +31,7 @@ class RoadNetworkLoader {
 
   /// Returns a maliput::api::RoadNetwork.
   /// @param properties Dictionary containing the arguments needed for creating the RoadNetwork.
-  virtual std::unique_ptr<const maliput::api::RoadNetwork> operator()(
+  virtual std::unique_ptr<maliput::api::RoadNetwork> operator()(
       const std::map<std::string, std::string>& properties) const = 0;
   virtual ~RoadNetworkLoader() = default;
 };


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/maliput/issues/443