### PR TITLE
Uploads the install space after building maliput.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,10 @@ jobs:
         ubuntu: [18.04, 20.04]
         include:
           - ubuntu: 18.04
+            ubuntu_name: bionic
             ROS_DISTRO: dashing
           - ubuntu: 20.04
+            ubuntu_name: focal
             ROS_DISTRO: foxy
     container:
       image: ubuntu:${{ matrix.ubuntu }}


### PR DESCRIPTION
Per slack conversation: https://tri-internal.slack.com/archives/C028K32S4FP/p1638907644058400

Generates an artifact right after finishing the workflow with the install space. See this [actions page](https://github.com/ToyotaResearchInstitute/maliput/actions/runs/1558325704) as an example.