### PR TITLE
Standarize Rule Types Ids.

### DIFF
--- a/maliput/include/maliput/base/rule_registry.h
+++ b/maliput/include/maliput/base/rule_registry.h
@@ -9,7 +9,7 @@
 namespace maliput {
 
 /// Returns a Rule::TypeId whose string representation is
-/// "Direction Usage Rule Type".
+/// "Direction-Usage Rule Type".
 api::rules::Rule::TypeId DirectionUsageRuleTypeId();
 
 /// Returns a direction usage rule type and its possible discrete values.
@@ -55,7 +55,7 @@ api::rules::Rule::TypeId RightOfWayRuleTypeId();
 api::rules::DiscreteValueRuleTypeAndValues BuildRightOfWayRuleType();
 
 /// Returns a Rule::TypeId whose string representation is
-/// "Vehicle Stop In Zone Behavior Rule Type".
+/// "Vehicle-Stop-In-Zone-Behavior Rule Type".
 api::rules::Rule::TypeId VehicleStopInZoneBehaviorRuleTypeId();
 
 /// Returns a vehicle stop in zone behavior rule type and its possible discrete
@@ -84,7 +84,7 @@ api::rules::Rule::TypeId VehicleStopInZoneBehaviorRuleTypeId();
 api::rules::DiscreteValueRuleTypeAndValues BuildVehicleStopInZoneBehaviorRuleType();
 
 /// Returns a maliput::api::rules::Rule::TypeId initialized with
-/// "Speed Limit Rule Type".
+/// "Speed-Limit Rule Type".
 api::rules::Rule::TypeId SpeedLimitRuleTypeId();
 
 /// Defines keys used in api::rules::Rule::RelatedRules.

--- a/maliput/src/base/rule_registry.cc
+++ b/maliput/src/base/rule_registry.cc
@@ -25,7 +25,7 @@ std::vector<api::rules::DiscreteValueRule::DiscreteValue> GenerateEveryCombinati
 
 }  // namespace
 
-api::rules::Rule::TypeId DirectionUsageRuleTypeId() { return api::rules::Rule::TypeId("Direction Usage Rule Type"); }
+api::rules::Rule::TypeId DirectionUsageRuleTypeId() { return api::rules::Rule::TypeId("Direction-Usage Rule Type"); }
 
 api::rules::DiscreteValueRuleTypeAndValues BuildDirectionUsageRuleType() {
   const std::vector<std::string> state_values{"WithS", "AgainstS", "Bidirectional", "BidirectionalTurnOnly",
@@ -44,7 +44,7 @@ api::rules::DiscreteValueRuleTypeAndValues BuildRightOfWayRuleType() {
 }
 
 api::rules::Rule::TypeId VehicleStopInZoneBehaviorRuleTypeId() {
-  return api::rules::Rule::TypeId("Vehicle Stop In Zone Behavior Rule Type");
+  return api::rules::Rule::TypeId("Vehicle-Stop-In-Zone-Behavior Rule Type");
 }
 
 api::rules::DiscreteValueRuleTypeAndValues BuildVehicleStopInZoneBehaviorRuleType() {
@@ -56,7 +56,7 @@ api::rules::DiscreteValueRuleTypeAndValues BuildVehicleStopInZoneBehaviorRuleTyp
       GenerateEveryCombination({api::rules::Rule::State::kStrict}, state_values));
 }
 
-api::rules::Rule::TypeId SpeedLimitRuleTypeId() { return api::rules::Rule::TypeId{"Speed Limit Rule Type"}; }
+api::rules::Rule::TypeId SpeedLimitRuleTypeId() { return api::rules::Rule::TypeId{"Speed-Limit Rule Type"}; }
 
 const char* RelatedRulesKeys::kYieldGroup{"Yield Group"};
 

--- a/maliput/test/base/rule_registry_test.cc
+++ b/maliput/test/base/rule_registry_test.cc
@@ -16,7 +16,7 @@ namespace test {
 namespace {
 
 GTEST_TEST(DirectionUsageRuleTypeIdTest, Initialization) {
-  EXPECT_EQ(DirectionUsageRuleTypeId().string(), "Direction Usage Rule Type");
+  EXPECT_EQ(DirectionUsageRuleTypeId().string(), "Direction-Usage Rule Type");
 }
 
 GTEST_TEST(RightOfWayRuleTypeIdTest, Initialization) {
@@ -24,11 +24,11 @@ GTEST_TEST(RightOfWayRuleTypeIdTest, Initialization) {
 }
 
 GTEST_TEST(VehicleStopInZoneBehaviorRuleTypeIdTest, Initialization) {
-  EXPECT_EQ(VehicleStopInZoneBehaviorRuleTypeId().string(), "Vehicle Stop In Zone Behavior Rule Type");
+  EXPECT_EQ(VehicleStopInZoneBehaviorRuleTypeId().string(), "Vehicle-Stop-In-Zone-Behavior Rule Type");
 }
 
 GTEST_TEST(SpeedLimitRuleTypeIdTest, Initialization) {
-  EXPECT_EQ(SpeedLimitRuleTypeId().string(), "Speed Limit Rule Type");
+  EXPECT_EQ(SpeedLimitRuleTypeId().string(), "Speed-Limit Rule Type");
 }
 
 // Holds the information to evaluate the rule type built by `builder` function.


### PR DESCRIPTION
Some rule types ids are provided in maliput base however they weren't following the same format.