### PR TITLE
Extend IntersectionBook to enable querying for intersections by the inertial position and road geometry

### DIFF
--- a/maliput/include/maliput/api/intersection_book.h
+++ b/maliput/include/maliput/api/intersection_book.h
@@ -45,7 +45,9 @@ class IntersectionBook {
   /// @param inertial_pose A position in inertial space (TODO TERMINOLOGY space?)
   /// @returns The Intersection that contains `inertial_pose`. When none of the Intersections have overlap with
   /// `inertial_pose`, nullptr is returned.
-  Intersection* FindIntersection(const InertialPosition& inertial_pose, const api::RoadGeometry* road_geometry) { return DoGetFindIntersection(inertial_pose, road_geometry); }
+  Intersection* FindIntersection(const InertialPosition& inertial_pose, const api::RoadGeometry* road_geometry) {
+    return DoGetFindIntersection(inertial_pose, road_geometry);
+  }
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -70,7 +72,8 @@ class IntersectionBook {
 
   virtual Intersection* DoGetFindIntersection(const rules::DiscreteValueRule::Id& id) = 0;
 
-  virtual Intersection* DoGetFindIntersection(const InertialPosition& inertial_pose, const api::RoadGeometry* road_geometry) = 0;
+  virtual Intersection* DoGetFindIntersection(const InertialPosition& inertial_pose,
+                                              const api::RoadGeometry* road_geometry) = 0;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/maliput/include/maliput/base/intersection_book.h
+++ b/maliput/include/maliput/base/intersection_book.h
@@ -39,7 +39,8 @@ class IntersectionBook : public api::IntersectionBook {
   api::Intersection* DoGetFindIntersection(const api::rules::DiscreteValueRule::Id& id) override;
 
   // api::Intersection* DoGetFindIntersection(const api::InertialPosition& inetial_pose) override;
-  api::Intersection* DoGetFindIntersection(const api::InertialPosition& inetial_pose, const api::RoadGeometry* road_geometry) override;
+  api::Intersection* DoGetFindIntersection(const api::InertialPosition& inetial_pose,
+                                           const api::RoadGeometry* road_geometry) override;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/maliput/src/base/intersection_book.cc
+++ b/maliput/src/base/intersection_book.cc
@@ -45,18 +45,19 @@ class IntersectionBook::Impl {
     return it->second.get();
   }
 
-  Intersection* DoGetFindIntersection(const api::InertialPosition& inertial_pose, const api::RoadGeometry* road_geometry) {
-  //TODO add maliputpy binding layer
-  // TODO add to maliput implementations (maliput_malidrive maliput_multilane, maliput_dragway?, test others too)
-  // TODO add_road_network_* method
-  // auto road_geometry = road_network_->road_geometry()
-  for (const auto& intersection : DoGetIntersections()) {
-    if (intersection->Includes(inertial_pose, road_geometry)) {
-      return intersection;
+  Intersection* DoGetFindIntersection(const api::InertialPosition& inertial_pose,
+                                      const api::RoadGeometry* road_geometry) {
+    // TODO add maliputpy binding layer
+    // TODO add to maliput implementations (maliput_malidrive maliput_multilane, maliput_dragway?, test others too)
+    // TODO add_road_network_* method
+    // auto road_geometry = road_network_->road_geometry()
+    for (const auto& intersection : DoGetIntersections()) {
+      if (intersection->Includes(inertial_pose, road_geometry)) {
+        return intersection;
+      }
     }
+    return nullptr;
   }
-  return nullptr;
-}
 
  private:
   std::unordered_map<Intersection::Id, std::unique_ptr<Intersection>> book_;
@@ -112,8 +113,9 @@ api::Intersection* IntersectionBook::DoGetFindIntersection(const api::rules::Dis
   return nullptr;
 }
 
-Intersection* IntersectionBook::DoGetFindIntersection(const api::InertialPosition& inertial_pose, const api::RoadGeometry* road_geometry) { 
-    return impl_->DoGetFindIntersection(inertial_pose, road_geometry);
+Intersection* IntersectionBook::DoGetFindIntersection(const api::InertialPosition& inertial_pose,
+                                                      const api::RoadGeometry* road_geometry) {
+  return impl_->DoGetFindIntersection(inertial_pose, road_geometry);
 }
 
 #pragma GCC diagnostic push

--- a/maliput/src/test_utilities/mock.cc
+++ b/maliput/src/test_utilities/mock.cc
@@ -291,7 +291,10 @@ class MockIntersectionBook final : public IntersectionBook {
 
   api::Intersection* DoGetFindIntersection(const api::rules::DiscreteValueRule::Id& id) override { return nullptr; };
 
-  api::Intersection* DoGetFindIntersection(const api::InertialPosition& inetial_pose, const api::RoadGeometry* road_geometry) override { return nullptr; };
+  api::Intersection* DoGetFindIntersection(const api::InertialPosition& inetial_pose,
+                                           const api::RoadGeometry* road_geometry) override {
+    return nullptr;
+  };
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
This is a first stage towards resolving #479

Looking forward I expect to:
* [ ] provide the ability to attach the road_network or road_geometry to the IntersectionBook as either a constructor or `add` method.
* [ ] Add an error if there's no road geometry available yet.
* [ ] Validate lifecycle documentation
* [ ] Add unit tests