### PR TITLE
Changed values() and ranges() method from Rules to states()

### DIFF
--- a/maliput/include/maliput/api/rules/discrete_value_rule.h
+++ b/maliput/include/maliput/api/rules/discrete_value_rule.h
@@ -60,10 +60,10 @@ class DiscreteValueRule : public Rule {
   DiscreteValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                     const std::vector<DiscreteValue>& values);
 
-  const std::vector<DiscreteValue>& values() const { return values_; }
+  const std::vector<DiscreteValue>& states() const { return states_; }
 
  private:
-  std::vector<DiscreteValue> values_;
+  std::vector<DiscreteValue> states_;
 };
 
 }  // namespace rules

--- a/maliput/include/maliput/api/rules/range_value_rule.h
+++ b/maliput/include/maliput/api/rules/range_value_rule.h
@@ -76,10 +76,10 @@ class RangeValueRule : public Rule {
   RangeValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                  const std::vector<Range>& ranges);
 
-  const std::vector<Range>& ranges() const { return ranges_; }
+  const std::vector<Range>& states() const { return states_; }
 
  private:
-  std::vector<Range> ranges_;
+  std::vector<Range> states_;
 };
 
 }  // namespace rules

--- a/maliput/include/maliput/base/manual_discrete_value_rule_state_provider.h
+++ b/maliput/include/maliput/base/manual_discrete_value_rule_state_provider.h
@@ -46,9 +46,9 @@ class ManualDiscreteValueRuleStateProvider : public api::rules::DiscreteValueRul
   /// @param id DiscreteValueRule's ID. It must be recognized by the `rulebook`
   ///        specified at time of construction.
   /// @param state The state of the rule. It must be one in
-  ///        DiscreteValueRule::values().
+  ///        DiscreteValueRule::states().
   /// @param next_state The optional next state of the rule. It must be one in
-  ///        DiscreteValueRule::values().
+  ///        DiscreteValueRule::states().
   /// @param duration_until If known, the estimated time until the transition to
   ///        the next state, relative to when this method is called. When
   ///        provided, it must be positive and @p next_state must not be nullopt.
@@ -56,9 +56,9 @@ class ManualDiscreteValueRuleStateProvider : public api::rules::DiscreteValueRul
   /// @throws std::out_of_range When @p id is unrecognized by the `rulebook`
   ///         specified at time of construction.
   /// @throws common::assertion_error When @p state does not match any state
-  ///         in DiscreteValueRule::values().
+  ///         in DiscreteValueRule::states().
   /// @throws common::assertion_error When @p next_state does not match any
-  ///         state in DiscreteValueRule::values().
+  ///         state in DiscreteValueRule::states().
   /// @throws common::assertion_error When @p duration_until is not positive or
   ///         it is provided when @p next_state is nullopt.
   void SetState(const api::rules::Rule::Id& id, const api::rules::DiscreteValueRule::DiscreteValue& state,

--- a/maliput/include/maliput/base/manual_range_value_rule_state_provider.h
+++ b/maliput/include/maliput/base/manual_range_value_rule_state_provider.h
@@ -44,9 +44,9 @@ class ManualRangeValueRuleStateProvider : public api::rules::RangeValueRuleState
   /// @param id RangeValueRule's ID. It must be recognized by the `rulebook`
   ///        specified at time of construction.
   /// @param state The state of the rule. It must be one in
-  ///        RangeValueRule::ranges().
+  ///        RangeValueRule::states().
   /// @param next_state The optional next state of the rule. It must be one in
-  ///        RangeValueRule::ranges().
+  ///        RangeValueRule::states().
   /// @param duration_until If known, the estimated time until the transition to
   ///        the next state, relative to when this method is called. When
   ///        provided, it must be positive and @p next_state must not be nullopt.
@@ -54,9 +54,9 @@ class ManualRangeValueRuleStateProvider : public api::rules::RangeValueRuleState
   /// @throws std::out_of_range When @p id is unrecognized by the `rulebook`
   ///         specified at time of construction.
   /// @throws common::assertion_error When @p state does not match any state
-  ///         in RangeValueRule::ranges().
+  ///         in RangeValueRule::states().
   /// @throws common::assertion_error When @p next_state does not match any state
-  ///         in RangeValueRule::ranges().
+  ///         in RangeValueRule::states().
   /// @throws common::assertion_error When @p duration_until is not positive or
   ///         it is provided when @p next_state is nullopt.
   void SetState(const api::rules::Rule::Id& id, const api::rules::RangeValueRule::Range& state,

--- a/maliput/src/api/road_network_validator.cc
+++ b/maliput/src/api/road_network_validator.cc
@@ -162,7 +162,7 @@ void CheckPhaseDiscreteValueRuleStates(const RoadNetwork& road_network) {
   auto evaluate_phase = [rulebook = road_network.rulebook()](const rules::Phase& phase) {
     for (const auto& rule_id_value : phase.discrete_value_rule_states()) {
       const rules::DiscreteValueRule rule = rulebook->GetDiscreteValueRule(rule_id_value.first);
-      if (std::find(rule.values().begin(), rule.values().end(), rule_id_value.second) == rule.values().end()) {
+      if (std::find(rule.states().begin(), rule.states().end(), rule_id_value.second) == rule.states().end()) {
         MALIPUT_THROW_MESSAGE("DiscreteValueRuleStates have an unknown DiscreteValue referenced by Rule(id: " +
                               rule.id().string() + ") in Phase(id: " + phase.id().string() + ")");
       }
@@ -223,7 +223,7 @@ void CheckRelatedRues(const RoadNetwork& road_network) {
   const rules::RoadRulebook::QueryResults rules = road_network.rulebook()->Rules();
 
   for (const auto& kv : rules.discrete_value_rules) {
-    for (const auto& value : kv.second.values()) {
+    for (const auto& value : kv.second.states()) {
       for (const auto& group_related_rule_ids : value.related_rules) {
         for (const auto& related_rule_id : group_related_rule_ids.second) {
           if (!IsRuleIdIn(related_rule_id, rules.discrete_value_rules, rules.range_value_rules)) {
@@ -240,7 +240,7 @@ void CheckRelatedRues(const RoadNetwork& road_network) {
   }
 
   for (const auto& kv : rules.range_value_rules) {
-    for (const auto& range : kv.second.ranges()) {
+    for (const auto& range : kv.second.states()) {
       for (const auto& group_related_rule_ids : range.related_rules) {
         for (const auto& related_rule_id : group_related_rule_ids.second) {
           if (!IsRuleIdIn(related_rule_id, rules.discrete_value_rules, rules.range_value_rules)) {

--- a/maliput/src/api/rules/discrete_value_rule.cc
+++ b/maliput/src/api/rules/discrete_value_rule.cc
@@ -10,14 +10,14 @@ namespace rules {
 
 DiscreteValueRule::DiscreteValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                      const std::vector<DiscreteValue>& values)
-    : Rule(id, type_id, zone), values_(values) {
-  MALIPUT_VALIDATE(!values_.empty(),
+    : Rule(id, type_id, zone), states_(values) {
+  MALIPUT_VALIDATE(!states_.empty(),
                    "DiscreteValueRule(" + id.string() + ") has no DiscreteValueRule::DiscreteValues.");
-  for (const DiscreteValue& value : values_) {
+  for (const DiscreteValue& value : states_) {
     ValidateRelatedRules(value.related_rules);
     ValidateRelatedUniqueIds(value.related_unique_ids);
     ValidateSeverity(value.severity);
-    MALIPUT_VALIDATE(std::count(values_.begin(), values_.end(), value) == 1,
+    MALIPUT_VALIDATE(std::count(states_.begin(), states_.end(), value) == 1,
                      "DiscreteValueRule(" + id.string() + ") has duplicated DiscreteValueRule::DiscreteValues.");
   }
 }

--- a/maliput/src/api/rules/range_value_rule.cc
+++ b/maliput/src/api/rules/range_value_rule.cc
@@ -10,15 +10,15 @@ namespace rules {
 
 RangeValueRule::RangeValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                const std::vector<Range>& ranges)
-    : Rule(id, type_id, zone), ranges_(ranges) {
-  MALIPUT_VALIDATE(!ranges_.empty(), "RangeValueRule(" + id.string() + ") has no RangeValueRule::Ranges.");
-  for (const Range& range : ranges_) {
+    : Rule(id, type_id, zone), states_(ranges) {
+  MALIPUT_VALIDATE(!states_.empty(), "RangeValueRule(" + id.string() + ") has no RangeValueRule::Ranges.");
+  for (const Range& range : states_) {
     ValidateRelatedRules(range.related_rules);
     ValidateRelatedUniqueIds(range.related_unique_ids);
     ValidateSeverity(range.severity);
     MALIPUT_VALIDATE(range.min <= range.max,
                      "RangeValueRule(" + id.string() + ") has a RangeValueRule::Ranges whose min > max.");
-    MALIPUT_VALIDATE(std::count(ranges_.begin(), ranges_.end(), range) == 1,
+    MALIPUT_VALIDATE(std::count(states_.begin(), states_.end(), range) == 1,
                      "RangeValueRule(" + id.string() + ") has duplicated RangeValueRule::Ranges.");
   }
 }

--- a/maliput/src/base/manual_discrete_value_rule_state_provider.cc
+++ b/maliput/src/base/manual_discrete_value_rule_state_provider.cc
@@ -12,10 +12,10 @@ namespace maliput {
 void ManualDiscreteValueRuleStateProvider::ValidateRuleState(
     const api::rules::DiscreteValueRule& discrete_value_rule,
     const api::rules::DiscreteValueRule::DiscreteValue& state) const {
-  if (std::find(discrete_value_rule.values().begin(), discrete_value_rule.values().end(), state) ==
-      discrete_value_rule.values().end()) {
+  if (std::find(discrete_value_rule.states().begin(), discrete_value_rule.states().end(), state) ==
+      discrete_value_rule.states().end()) {
     MALIPUT_THROW_MESSAGE("DiscreteValue is not in DiscreteValueRule " + discrete_value_rule.id().string() +
-                          "'s' values().");
+                          "'s' states().");
   }
 }
 

--- a/maliput/src/base/manual_range_value_rule_state_provider.cc
+++ b/maliput/src/base/manual_range_value_rule_state_provider.cc
@@ -11,9 +11,9 @@ namespace maliput {
 
 void ManualRangeValueRuleStateProvider::ValidateRuleState(const api::rules::RangeValueRule& range_value_rule,
                                                           const api::rules::RangeValueRule::Range& state) const {
-  if (std::find(range_value_rule.ranges().begin(), range_value_rule.ranges().end(), state) ==
-      range_value_rule.ranges().end()) {
-    MALIPUT_THROW_MESSAGE("Range is not in RangeValueRule " + range_value_rule.id().string() + "'s' ranges().");
+  if (std::find(range_value_rule.states().begin(), range_value_rule.states().end(), state) ==
+      range_value_rule.states().end()) {
+    MALIPUT_THROW_MESSAGE("Range is not in RangeValueRule " + range_value_rule.id().string() + "'s' states().");
   }
 }
 

--- a/maliput/src/base/phase_ring_book_loader.cc
+++ b/maliput/src/base/phase_ring_book_loader.cc
@@ -97,7 +97,7 @@ DiscreteValueRule::DiscreteValue GetDefaultState(const std::vector<DiscreteValue
 DiscreteValueRuleStates CreateDefaultRuleStates(const std::unordered_map<Rule::Id, DiscreteValueRule> rules) {
   DiscreteValueRuleStates result;
   for (const auto& rule : rules) {
-    result.emplace(rule.first, GetDefaultState(rule.second.values()));
+    result.emplace(rule.first, GetDefaultState(rule.second.states()));
   }
   return result;
 }
@@ -213,9 +213,9 @@ PhaseRing BuildPhaseRing(const RoadRulebook* rulebook, const TrafficLightBook* t
       std::string value(rule_state_it.second.as<std::string>());
       MALIPUT_THROW_UNLESS(discrete_rules.find(rule_id) != discrete_rules.end());
       const auto discrete_value_itr = std::find_if(
-          discrete_rules.at(rule_id).values().begin(), discrete_rules.at(rule_id).values().end(),
+          discrete_rules.at(rule_id).states().begin(), discrete_rules.at(rule_id).states().end(),
           [&value](const DiscreteValueRule::DiscreteValue& discrete_value) { return discrete_value.value == value; });
-      MALIPUT_THROW_UNLESS(discrete_value_itr != discrete_rules.at(rule_id).values().end());
+      MALIPUT_THROW_UNLESS(discrete_value_itr != discrete_rules.at(rule_id).states().end());
       MALIPUT_THROW_UNLESS(discrete_rule_states.find(rule_id) != discrete_rule_states.end());
       discrete_rule_states.at(rule_id) = *discrete_value_itr;
     }

--- a/maliput/src/base/phase_ring_book_loader_old_rules.cc
+++ b/maliput/src/base/phase_ring_book_loader_old_rules.cc
@@ -194,7 +194,7 @@ DiscreteValueRule::DiscreteValue FindDiscreteValueFromRightOfWayRuleState(
 
   const DiscreteValueRule::DiscreteValue discrete_value{Rule::State::kStrict, related_rules, related_unique_ids,
                                                         kRightOfWayStateToString.at(row_state.type())};
-  MALIPUT_THROW_UNLESS(std::find(rule.values().begin(), rule.values().end(), discrete_value) != rule.values().end());
+  MALIPUT_THROW_UNLESS(std::find(rule.states().begin(), rule.states().end(), discrete_value) != rule.states().end());
   return discrete_value;
 }
 

--- a/maliput/src/test_utilities/rules_compare.cc
+++ b/maliput/src/test_utilities/rules_compare.cc
@@ -40,7 +40,7 @@ namespace test {
   MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.id(), b.id()));
   MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.type_id(), b.type_id()));
   MALIPUT_ADD_RESULT(c, MALIPUT_REGIONS_IS_EQUAL(a.zone(), b.zone()));
-  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.values(), b.values()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.states(), b.states()));
   return c.result();
 }
 
@@ -73,7 +73,7 @@ namespace test {
   MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.id(), b.id()));
   MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.type_id(), b.type_id()));
   MALIPUT_ADD_RESULT(c, MALIPUT_REGIONS_IS_EQUAL(a.zone(), b.zone()));
-  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.ranges(), b.ranges()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.states(), b.states()));
   return c.result();
 }
 

--- a/maliput/test/api/rule_registry_test.cc
+++ b/maliput/test/api/rule_registry_test.cc
@@ -234,14 +234,14 @@ GTEST_TEST(RegisterAndBuildTest, RegisterAndBuild) {
   EXPECT_EQ(range_value_rule.id(), kRangeRuleId);
   EXPECT_EQ(range_value_rule.type_id(), kRangeValueRuleType);
   EXPECT_TRUE(MALIPUT_REGIONS_IS_EQUAL(range_value_rule.zone(), kZone));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(range_value_rule.ranges(), {kRangeA}));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(range_value_rule.states(), {kRangeA}));
 
   // Builds and evaluates a RangeValueRule of the same type but with non-empty RelatedRules.
   range_value_rule = dut.BuildRangeValueRule(kRangeRuleId, kRangeValueRuleType, kZone, {kRangeB});
   EXPECT_EQ(range_value_rule.id(), kRangeRuleId);
   EXPECT_EQ(range_value_rule.type_id(), kRangeValueRuleType);
   EXPECT_TRUE(MALIPUT_REGIONS_IS_EQUAL(range_value_rule.zone(), kZone));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(range_value_rule.ranges(), {kRangeB}));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(range_value_rule.states(), {kRangeB}));
 
   // Unregistered type.
   EXPECT_THROW(dut.BuildRangeValueRule(Rule::Id("RuleId"), kUnregisteredRuleType, kZone, {kRangeA}),
@@ -261,7 +261,7 @@ GTEST_TEST(RegisterAndBuildTest, RegisterAndBuild) {
   EXPECT_EQ(discrete_value_rule.id(), kDiscreteValueRuleId);
   EXPECT_EQ(discrete_value_rule.type_id(), kDiscreteValueRuleType);
   EXPECT_TRUE(MALIPUT_REGIONS_IS_EQUAL(discrete_value_rule.zone(), kZone));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(discrete_value_rule.values(), kExpectedDiscreteValues));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(discrete_value_rule.states(), kExpectedDiscreteValues));
 
   // Unregistered type.
   EXPECT_THROW(dut.BuildDiscreteValueRule(Rule::Id("RuleId"), kUnregisteredRuleType, kZone, kExpectedDiscreteValues),

--- a/maliput/test/api/rule_test.cc
+++ b/maliput/test/api/rule_test.cc
@@ -142,7 +142,7 @@ TEST_F(RuleTest, RangeValueRuleAccessors) {
   EXPECT_EQ(dut.id(), kId);
   EXPECT_EQ(dut.type_id(), kTypeId);
   EXPECT_TRUE(MALIPUT_REGIONS_IS_EQUAL(dut.zone(), kZone));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.ranges(), kRanges));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.states(), kRanges));
 }
 
 // Evaluates the equal and not equal operator overloads for
@@ -346,7 +346,7 @@ TEST_F(RuleTest, DiscreteValueRuleAccessors) {
   EXPECT_EQ(dut.id(), kId);
   EXPECT_EQ(dut.type_id(), kTypeId);
   EXPECT_TRUE(MALIPUT_REGIONS_IS_EQUAL(dut.zone(), kZone));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.values(), kDiscreteValues));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.states(), kDiscreteValues));
 }
 
 // Evaluates the equal and not equal operator overloads for

--- a/maliput/test/base/phase_ring_book_loader_test.cc
+++ b/maliput/test/base/phase_ring_book_loader_test.cc
@@ -214,8 +214,8 @@ class PhaseRingBookLoaderFromFileTest : public ::testing::Test {
       StraightRoadNetworkHelpers::CreateEastFacingTrafficLight()};
 
   const DiscreteValueRuleStates expected_discrete_value_rule_states_all_go_phase{
-      {kEastWestDiscreteRule.id(), kEastWestDiscreteRule.values()[0]},
-      {kWestEastDiscreteRule.id(), kWestEastDiscreteRule.values()[0]}};
+      {kEastWestDiscreteRule.id(), kEastWestDiscreteRule.states()[0]},
+      {kWestEastDiscreteRule.id(), kWestEastDiscreteRule.states()[0]}};
 
   const BulbStates expected_bulb_states_all_go_phase{
       // West facing bulbs.
@@ -229,8 +229,8 @@ class PhaseRingBookLoaderFromFileTest : public ::testing::Test {
   };
 
   const DiscreteValueRuleStates expected_discrete_value_rule_states_all_stop_phase{
-      {kEastWestDiscreteRule.id(), kEastWestDiscreteRule.values()[1]},
-      {kWestEastDiscreteRule.id(), kWestEastDiscreteRule.values()[1]}};
+      {kEastWestDiscreteRule.id(), kEastWestDiscreteRule.states()[1]},
+      {kWestEastDiscreteRule.id(), kWestEastDiscreteRule.states()[1]}};
 
   const BulbStates expected_bulb_states_all_stop_phase{
       // West facing bulbs.


### PR DESCRIPTION
This PR addresses the issue #472 

This PR changes the method name of `DiscreteValueRule::values()` to `DiscreteValueRule::states()` and  `RangeValueRule::ranges()` to `RangeValueRule::states()`.

Follow up PR on downstream repositories wil be created after this one is reviewed and accepted.