### PR TITLE
Adds CreateLane method to mock.h file.

### DIFF
--- a/maliput/include/maliput/test_utilities/mock.h
+++ b/maliput/include/maliput/test_utilities/mock.h
@@ -494,6 +494,9 @@ std::unique_ptr<RoadGeometry> CreateOneLaneRoadGeometry();
 /// Returns an arbitrary two-lane RoadGeometry.
 std::unique_ptr<RoadGeometry> CreateTwoLanesRoadGeometry();
 
+/// Returns an aribtrary lane with @p id .
+std::unique_ptr<Lane> CreateLane(const LaneId& id);
+
 /// Returns an arbitrary rules::RoadRulebook.
 ///
 /// Forwards the call to CreateRoadRulebook() passing a default-constructed


### PR DESCRIPTION
Simply make CreateLane() a public method to be used by downstream packages.

Required from https://github.com/ToyotaResearchInstitute/maliput_object/pull/13/files#diff-1290a6dc7d9ce31cd34b6a10f9608246ccb564b0479b0c14430a31292012e20d