### PR TITLE
Implements RoadPosition::ToInertialPosition and acoording test

### DIFF
--- a/maliput/include/maliput/api/lane_data.h
+++ b/maliput/include/maliput/api/lane_data.h
@@ -299,6 +299,7 @@ struct RoadPosition {
 
   /// Indirection to #api::Lane::ToInertialPosition() method.
   /// @returns The InertialPosition that corresponds to `lane` and `pos`.
+  /// @throws When member `lane` is nullptr.
   InertialPosition ToInertialPosition() const;
 
   const Lane* lane{};

--- a/maliput/src/api/lane_data.cc
+++ b/maliput/src/api/lane_data.cc
@@ -35,7 +35,10 @@ InertialPosition Rotation::Apply(const InertialPosition& inertial_position) cons
   return InertialPosition::FromXyz(quaternion_ * inertial_position.xyz());
 }
 
-InertialPosition RoadPosition::ToInertialPosition() const { return lane->ToInertialPosition(pos); };
+InertialPosition RoadPosition::ToInertialPosition() const {
+  MALIPUT_THROW_UNLESS(lane != nullptr);
+  return lane->ToInertialPosition(pos);
+};
 
 math::Matrix3 Rotation::matrix() const { return quaternion_.ToRotationMatrix(); }
 

--- a/maliput/test/api/lane_data_test.cc
+++ b/maliput/test/api/lane_data_test.cc
@@ -182,17 +182,18 @@ GTEST_TEST(RoadPosition, ToInertialPositionTest) {
   const LanePosition pos_1(0.0, kX1, kX2);
   const LanePosition pos_2(1.0, kX1, kX2);
 
-  InertialPosition start_ip(1, 0, 0);
-  InertialPosition end_ip(2, 0, 0);
+  const InertialPosition start_ip(1, 0, 0);
+  const InertialPosition end_ip(2, 0, 0);
 
-  maliput::api::test::MockLane test_lane{maliput::api::LaneId{"mock"}, start_ip, {}, end_ip, {}};
-  maliput::api::test::MockLane* test_lane_ptr = &test_lane;
+  const maliput::api::test::MockLane lane{maliput::api::LaneId{"mock"}, start_ip, {}, end_ip, {}};
 
-  RoadPosition dut1(test_lane_ptr, pos_1);
-  RoadPosition dut2(test_lane_ptr, pos_2);
+  RoadPosition dut(&lane, pos_1);
 
-  EXPECT_EQ(dut1.ToInertialPosition(), start_ip);
-  EXPECT_EQ(dut2.ToInertialPosition(), end_ip);
+  EXPECT_EQ(start_ip, dut.ToInertialPosition());
+
+  dut.pos = pos_2;
+
+  EXPECT_EQ(end_ip, dut.ToInertialPosition());
 }
 
 // An arbitrary very small number (that passes the tests).


### PR DESCRIPTION
This PR addresses the issue #452.

Basically this PR provides a method that calls another method provided by the ``lane`` class in order to obtain the inertial position from a lane position.