### PR TITLE
move ament_cmake_doxygen to doc_depend

### DIFF
--- a/maliput/package.xml
+++ b/maliput/package.xml
@@ -8,7 +8,7 @@
   <license file="../LICENSE">BSD Clause 3</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>ament_cmake_doxygen</build_depend>
+  <doc_depend>ament_cmake_doxygen</doc_depend>
 
   <depend>fmt</depend>
   <depend>libgflags-dev</depend>

--- a/maliput/src/test_utilities/CMakeLists.txt
+++ b/maliput/src/test_utilities/CMakeLists.txt
@@ -1,6 +1,8 @@
 ##############################################################################
 # Sources
 ##############################################################################
+if(BUILD_TESTING)
+
 
 set(TEST_UTILS_SOURCES
   check_id_indexing.cc
@@ -45,3 +47,5 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+
+endif()


### PR DESCRIPTION
It's only necessary when building the docs