### PR TITLE
Uses ros-action-ci in build.yaml workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: gcc
 
 on:
+  push:
   pull_request:
     branches:
       - main
@@ -9,7 +10,6 @@ on:
 env:
   PACKAGE_NAME: maliput
   ROS_DISTRO: foxy
-  ROS_WS: maliput_ws
 
 jobs:
   compile_and_test:
@@ -18,55 +18,34 @@ jobs:
     container:
       image: ubuntu:20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/action-ros-ci@v0.2
+      id: action_ros_ci_step
       with:
-        path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
-    # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@0.2.1
-    - name: vcs import
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
-    - run: colcon graph
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-    - name: rosdep install
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        rosdep update --include-eol-distros;
-        rosdep install  -i -y --rosdistro ${ROS_DISTRO} --from-paths src
-    - name: colcon build
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-up-to ${PACKAGE_NAME} \
-          --event-handlers=console_direct+
-    - name: colcon test
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon test --packages-select ${PACKAGE_NAME} --event-handlers=console_direct+;
-        colcon test-result --verbose;
+        package-name: ${{ env.PACKAGE_NAME }}
+        target-ros2-distro: ${{ env.ROS_DISTRO }}
+        vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/dependencies.repos
+
     # create tarball to push to github artifacts
     # Note that a file with the name of the bundle is created to pass the value
     # step to step.
     - name: Create tarball to store in Github Artifacts.
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
       shell: bash
-      working-directory: ${{ env.ROS_WS }}
+      working-directory: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}
       env:
         BUNDLE_NAME: maliput_underlay
       run: |
         echo "Moving install space to ${BUNDLE_NAME}";
         mv install ${BUNDLE_NAME};
-        CURRENT_BUNDLE_TARBALL_NAME="${BUNDLE_NAME}_$(date +%Y%m%d)_${{ matrix.ubuntu_name }}.tar.gz"
+        CURRENT_BUNDLE_TARBALL_NAME="${BUNDLE_NAME}_$(date +%Y%m%d)_20.04.tar.gz"
         echo $CURRENT_BUNDLE_TARBALL_NAME > bundle_file_name
         echo "bundle_file_name=${CURRENT_BUNDLE_TARBALL_NAME}" >> $GITHUB_ENV
         echo "Compressing tarball ${CURRENT_BUNDLE_TARBALL_NAME}";
         tar -czvf ${CURRENT_BUNDLE_TARBALL_NAME} ${BUNDLE_NAME};
     - uses: actions/upload-artifact@v2
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
       with:
         name: binary_underlay
-        path: ${{ env.ROS_WS }}/${{ env.bundle_file_name }}
+        path: ${{ steps.action_ros_ci_with_docs.outputs.ros-workspace-directory-name }}/${{ env.bundle_file_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
       with:
         name: binary_underlay
-        path: ${{ steps.action_ros_ci_with_docs.outputs.ros-workspace-directory-name }}/${{ env.bundle_file_name }}
+        path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/${{ env.bundle_file_name }}


### PR DESCRIPTION
Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>

Part of https://github.com/maliput/maliput_infrastructure/issues/268#issuecomment-1148712661

### Summary
 - Rely on `ros-action-ci` for the `build.yaml` workflow
 - Adds workflow to push event 