### PR TITLE
Modifies ToLanePosition and adds ToSegmentPosition.

### DIFF
--- a/include/maliput/api/lane.h
+++ b/include/maliput/api/lane.h
@@ -129,12 +129,25 @@ class Lane {
   InertialPosition ToInertialPosition(const LanePosition& lane_pos) const { return DoToInertialPosition(lane_pos); }
 
   /// Determines the LanePosition corresponding to InertialPosition @p inertial_pos.
+  /// The LanePosition is expected to be contained within the lane's boundaries.
+  /// @see ToSegmentPosition method.
   ///
   /// This method guarantees that its result satisfies the condition that
   /// `ToInertialPosition(result.lane_position)` is within `linear_tolerance()`
   ///  of `result.nearest_position`.
   LanePositionResult ToLanePosition(const InertialPosition& inertial_pos) const {
     return DoToLanePosition(inertial_pos);
+  }
+
+  /// Determines the LanePosition corresponding to InertialPosition @p inertial_pos.
+  /// The LanePosition is expected to be contained within the segment's boundaries.
+  /// @see ToLanePosition method.
+  ///
+  /// This method guarantees that its result satisfies the condition that
+  /// `ToInertialPosition(result.lane_position)` is within `linear_tolerance()`
+  ///  of `result.nearest_position`.
+  LanePositionResult ToSegmentPosition(const InertialPosition& inertial_pos) const {
+    return DoToSegmentPosition(inertial_pos);
   }
 
   // TODO(maddog@tri.global) Method to convert LanePosition to that of
@@ -213,6 +226,8 @@ class Lane {
   virtual InertialPosition DoToInertialPosition(const LanePosition& lane_pos) const = 0;
 
   virtual LanePositionResult DoToLanePosition(const InertialPosition& inertial_pos) const = 0;
+
+  virtual LanePositionResult DoToSegmentPosition(const InertialPosition& inertial_pos) const = 0;
 
   virtual Rotation DoGetOrientation(const LanePosition& lane_pos) const = 0;
 

--- a/include/maliput/api/lane_data.h
+++ b/include/maliput/api/lane_data.h
@@ -281,14 +281,15 @@ class LanePosition {
 
 /// Included in the return result of Lane::ToLanePosition().
 struct LanePositionResult {
-  /// The candidate LanePosition within the Lane' segment-bounds which
-  /// is closest to a `inertial_position` supplied to Lane::ToLanePosition()
+  /// The candidate LanePosition within the Lane' lane-bounds or segment-bounds
+  /// depending if ToLanePosition or ToSegmentPosition respectively, was called.
+  /// The LanePosition is closest to a `inertial_position` supplied to Lane::ToLanePosition()
   /// (measured by the Cartesian metric in the `Inertial`-frame).
   LanePosition lane_position;
   /// The position that exactly corresponds to `lane_position`.
   InertialPosition nearest_position;
   /// The Cartesian distance between `nearest_position` and the
-  /// `inertial_position` supplied to Lane::ToLanePosition().
+  /// `inertial_position` supplied to Lane::ToLanePosition() / Lane::ToSegmentPosition.
   double distance{};
 };
 

--- a/include/maliput/test_utilities/mock.h
+++ b/include/maliput/test_utilities/mock.h
@@ -226,6 +226,7 @@ class MockLane final : public Lane {
     return lane_pos.s() ? end_ip_ : start_ip_;
   }
   LanePositionResult DoToLanePosition(const InertialPosition&) const override { return lane_position_result_; }
+  LanePositionResult DoToSegmentPosition(const InertialPosition&) const override { return lane_position_result_; }
   Rotation DoGetOrientation(const LanePosition& lane_pos) const override {
     return lane_pos.s() ? end_rot_ : start_rot_;
   }


### PR DESCRIPTION
Related to #492 #496 

### Summary

- Adds Lane::ToSegmentPosition method to replace current ToLanePosition behavior.
- Lane::ToLanePosition now expects to return a lane position that is located within Lane boundaries.