### PR TITLE
Adds a test function for LaneEnds.

### DIFF
--- a/include/maliput/test_utilities/maliput_types_compare.h
+++ b/include/maliput/test_utilities/maliput_types_compare.h
@@ -99,7 +99,7 @@ namespace test {
 
 /// Compares equality of two LaneEnd objects.
 /// @param lane_end1 A LaneEnd object to compare.
-/// @param lane_end1 A LaneEnd object to compare.
+/// @param lane_end2 A LaneEnd object to compare.
 /// @return ::testing::AssertionFailure() When LaneEnd objects are different.
 /// @return ::testing::AssertionSuccess() When LaneEnd objects are equal.
 ::testing::AssertionResult IsLaneEndEqual(const LaneEnd& lane_end1, const LaneEnd& lane_end2);

--- a/include/maliput/test_utilities/maliput_types_compare.h
+++ b/include/maliput/test_utilities/maliput_types_compare.h
@@ -97,6 +97,13 @@ namespace test {
 /// within the @p tolerance deviation.
 ::testing::AssertionResult IsHBoundsClose(const HBounds& hbounds1, const HBounds& hbounds2, double tolerance);
 
+/// Compares equality of two LaneEnd objects.
+/// @param lane_end1 A LaneEnd object to compare.
+/// @param lane_end1 A LaneEnd object to compare.
+/// @return ::testing::AssertionFailure() When LaneEnd objects are different.
+/// @return ::testing::AssertionSuccess() When LaneEnd objects are equal.
+::testing::AssertionResult IsLaneEndEqual(const LaneEnd& lane_end1, const LaneEnd& lane_end2);
+
 }  // namespace test
 }  // namespace api
 }  // namespace maliput

--- a/src/test_utilities/maliput_types_compare.cc
+++ b/src/test_utilities/maliput_types_compare.cc
@@ -213,6 +213,22 @@ namespace test {
   return ::testing::AssertionSuccess();
 }
 
+::testing::AssertionResult IsLaneEndEqual(const LaneEnd& lane_end1, const LaneEnd& lane_end2) {
+  auto which_to_string = [](const LaneEnd::Which end) {
+    return end == LaneEnd::Which::kStart ? std::string("kStart") : std::string("kFinish");
+  };
+  if (lane_end1.lane != lane_end2.lane) {
+    return ::testing::AssertionFailure() << "lane_end1.lane is different from lane_end2.lane. lane_end1.lane: "
+                                         << lane_end1.lane << " vs. lane_end2.lane: " << lane_end2.lane << "\n";
+  }
+  if (lane_end1.end != lane_end2.end) {
+    return ::testing::AssertionFailure() << "lane_end1.end is different from lane_end2.end. lane_end1.end: "
+                                         << which_to_string(lane_end1.end)
+                                         << " vs. lane_end2.end: " << which_to_string(lane_end2.end) << "\n";
+  }
+  return ::testing::AssertionSuccess();
+}
+
 }  // namespace test
 }  // namespace api
 }  // namespace maliput

--- a/test/test_utilities/maliput_types_compare_test.cc
+++ b/test/test_utilities/maliput_types_compare_test.cc
@@ -112,6 +112,16 @@ TEST(IsLanePositionResultCloseTest, Test) {
   EXPECT_EQ(testing::AssertionFailure(), IsLanePositionResultClose(test_value, non_distance_close, kTolerance));
 }
 
+TEST(IsLaneEndEqualTest, Test) {
+  const LaneEnd lane_end1(reinterpret_cast<const Lane*>(0xDeadBeef), maliput::api::LaneEnd::Which::kStart);
+  const LaneEnd lane_end2(reinterpret_cast<const Lane*>(0xDeadD00d), maliput::api::LaneEnd::Which::kStart);
+  const LaneEnd lane_end3(reinterpret_cast<const Lane*>(0xDeadBeef), maliput::api::LaneEnd::Which::kFinish);
+
+  EXPECT_EQ(testing::AssertionSuccess(), IsLaneEndEqual(lane_end1, lane_end1));
+  EXPECT_EQ(testing::AssertionFailure(), IsLaneEndEqual(lane_end1, lane_end2));
+  EXPECT_EQ(testing::AssertionFailure(), IsLaneEndEqual(lane_end1, lane_end3));
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace api


### PR DESCRIPTION
# 🎉 Adds a new function to simplify the testing of LaneEnds

See https://github.com/maliput/maliput_sparse/pull/24 for reference.

## Summary

Adds a function to assert equality between two LaneEnds in tests.

## Test it

Unit tests are provided.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
