### PR TITLE
Adds convenient method for comparing `RoadPositionResult`

### DIFF
--- a/include/maliput/test_utilities/maliput_types_compare.h
+++ b/include/maliput/test_utilities/maliput_types_compare.h
@@ -44,6 +44,13 @@ namespace test {
 ::testing::AssertionResult IsLanePositionResultClose(const LanePositionResult& lpr_a, const LanePositionResult& lpr_b,
                                                      double tolerance);
 
+/// Compares equality within @p tolerance deviation of the maliput::api::RoadPositionResult @p rpr_a and @p rpr_B.
+/// @param rpr_a The first RoadPositionResult to compare.
+/// @param rpr_b The second RoadPositionResult to compare.
+/// @param tolerance The tolerance to use for the comparison.
+testing::AssertionResult IsRoadPositionResultClose(const maliput::api::RoadPositionResult& rpr_a,
+                                                   const maliput::api::RoadPositionResult& rpr_b, double tolerance);
+
 /// Compares equality within @p tolerance deviation of two InertialPosition objects.
 /// @param pos1 A InertialPosition object to compare.
 /// @param pos2 A InertialPosition object to compare.

--- a/src/test_utilities/maliput_types_compare.cc
+++ b/src/test_utilities/maliput_types_compare.cc
@@ -213,6 +213,17 @@ namespace test {
   return ::testing::AssertionSuccess();
 }
 
+testing::AssertionResult IsRoadPositionResultClose(const maliput::api::RoadPositionResult& rpr_a,
+                                                   const maliput::api::RoadPositionResult& rpr_b, double tolerance) {
+  if (rpr_a.road_position.lane != rpr_b.road_position.lane) {
+    return testing::AssertionFailure()
+           << "RoadPositionResult are different at road_position.lane: rpr_a.road_position.lane: "
+           << rpr_a.road_position.lane << " vs. rpr_b.road_position.lane: " << rpr_b.road_position.lane;
+  }
+  return IsLanePositionResultClose({rpr_a.road_position.pos, rpr_a.nearest_position, rpr_a.distance},
+                                   {rpr_b.road_position.pos, rpr_b.nearest_position, rpr_b.distance}, tolerance);
+}
+
 ::testing::AssertionResult IsLaneEndEqual(const LaneEnd& lane_end1, const LaneEnd& lane_end2) {
   auto which_to_string = [](const LaneEnd::Which end) {
     return end == LaneEnd::Which::kStart ? std::string("kStart") : std::string("kFinish");

--- a/test/test_utilities/maliput_types_compare_test.cc
+++ b/test/test_utilities/maliput_types_compare_test.cc
@@ -112,6 +112,33 @@ TEST(IsLanePositionResultCloseTest, Test) {
   EXPECT_EQ(testing::AssertionFailure(), IsLanePositionResultClose(test_value, non_distance_close, kTolerance));
 }
 
+TEST(IsRoadPositionResultCloseTest, Test) {
+  const InertialPosition inertial_pos{0., 10., 10.};
+  const LanePosition lane_pos{0., 10., 10.};
+  const RoadPosition road_pos{reinterpret_cast<const Lane*>(0xDeadBeef), lane_pos};
+  const double distance{10.};
+  const RoadPositionResult test_value{road_pos, inertial_pos, distance};
+  const RoadPositionResult close_value{road_pos, inertial_pos, distance};
+  EXPECT_EQ(testing::AssertionSuccess(), IsRoadPositionResultClose(test_value, close_value, kTolerance));
+
+  // Non close per non lane matching.
+  const RoadPositionResult non_lane_matching{
+      {reinterpret_cast<const Lane*>(0xDeadD00d), lane_pos}, inertial_pos, distance};
+  EXPECT_EQ(testing::AssertionFailure(), IsRoadPositionResultClose(test_value, non_lane_matching, kTolerance));
+
+  // Non close per lane position.
+  const RoadPositionResult non_lane_pos_close{{road_pos.lane, {10., 10., 10.}}, inertial_pos, distance};
+  EXPECT_EQ(testing::AssertionFailure(), IsRoadPositionResultClose(test_value, non_lane_pos_close, kTolerance));
+
+  // Non close per nearest position.
+  const RoadPositionResult non_inertial_pos_close{road_pos, {10., 10., 10.}, distance};
+  EXPECT_EQ(testing::AssertionFailure(), IsRoadPositionResultClose(test_value, non_inertial_pos_close, kTolerance));
+
+  // Non close per distance.
+  const RoadPositionResult non_distance_close{road_pos, inertial_pos, 85.};
+  EXPECT_EQ(testing::AssertionFailure(), IsRoadPositionResultClose(test_value, non_distance_close, kTolerance));
+}
+
 TEST(IsLaneEndEqualTest, Test) {
   const LaneEnd lane_end1(reinterpret_cast<const Lane*>(0xDeadBeef), maliput::api::LaneEnd::Which::kStart);
   const LaneEnd lane_end2(reinterpret_cast<const Lane*>(0xDeadD00d), maliput::api::LaneEnd::Which::kStart);


### PR DESCRIPTION
# 🎉 New feature

Adds convenient method for comparing `RoadPositionResult`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
