### PR TITLE
Brings range validator from maliput_malidrive.

### DIFF
--- a/include/maliput/common/maliput_throw.h
+++ b/include/maliput/common/maliput_throw.h
@@ -108,3 +108,12 @@ void Throw(const char* condition, const char* func, const char* file, int line);
       ::maliput::common::internal::Throw(std::string(message).c_str(), __func__, __FILE__, __LINE__); \
     }                                                                                                 \
   } while (0)
+
+/// @def MALIPUT_IS_IN_RANGE
+/// Throws if `value` is within [`min_value`; `max_value`]. It forwards the call
+/// to MALIPUT_VALIDATE() with a customized string stating the error.
+#define MALIPUT_IS_IN_RANGE(value, min_value, max_value)                                                           \
+  do {                                                                                                             \
+    MALIPUT_VALIDATE(value >= min_value, std::to_string(value) + " is less than " + std::to_string(min_value));    \
+    MALIPUT_VALIDATE(value <= max_value, std::to_string(value) + " is greater than " + std::to_string(max_value)); \
+  } while (0)

--- a/include/maliput/common/range_validator.h
+++ b/include/maliput/common/range_validator.h
@@ -1,0 +1,112 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2019-2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "maliput/common/maliput_copyable.h"
+
+namespace maliput {
+namespace common {
+
+/// Functor to validate if a number is within [min, max] and considering
+/// assuming a tolerance. This tolerance extends the range to be
+/// [min - tolerance, max + tolerance].
+/// The functor not only validates that number is within the range, but also
+/// adapts it to be in the interval (min, max) where the difference between the
+/// close and open range is epsilon.
+/// This functor is motivated to wrap MALIPUT_VALIDATE() calls plus a std::clamp() to avoid throws for numerical errors.
+class RangeValidator {
+ public:
+  MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RangeValidator)
+
+  /// Creates a RangeValidator instance that uses a relative epsilon to validate the values.
+  /// This relative epsilon is computed by multiplying `epsilon` by the range.
+  /// @param min lower extreme of the range.
+  /// @param max upper extreme of the range.
+  /// @param tolerance is the range extension to be accepted.
+  /// @param epsilon is the relative minimum difference that separates a number within
+  ///                range to be distinct from extremes. It is relative to the range.
+  /// @returns A RangeValidator instance.
+  /// @throws maliput::common::assertion_error When `tolerance` is non positive.
+  /// @throws maliput::common::assertion_error When `epsilon` is not in
+  ///         [0, tolerance].
+  /// @throws maliput::common::assertion_error When `min` + `epsilon` > `max` or
+  ///         `max` - `epsilon` < `min`
+  static RangeValidator GetRelativeEpsilonValidator(double min, double max, double tolerance, double epsilon);
+
+  /// Creates a RangeValidator instance that uses a `epsilon` as the absolute epsilon to validate the values.
+  /// @param min lower extreme of the range.
+  /// @param max upper extreme of the range.
+  /// @param tolerance is the range extension to be accepted.
+  /// @param epsilon is minimum difference that separates a number within the
+  ///        range to be distinct from range extremes (`min` and `max`).
+  /// @returns A RangeValidator instance.
+  /// @throws maliput::common::assertion_error When `tolerance` is non positive.
+  /// @throws maliput::common::assertion_error When `epsilon` is not in
+  ///         [0, tolerance].
+  /// @throws maliput::common::assertion_error When `min` + `epsilon` > `max` or
+  ///         `max` - `epsilon` < `min`
+  static RangeValidator GetAbsoluteEpsilonValidator(double min, double max, double tolerance, double epsilon);
+
+  RangeValidator() = delete;
+
+  /// Evaluates whether `s` is in range or not.
+  /// @returns `s` when it is within the open range. If `s` is equal to either
+  /// range extremes or the difference to them is less or equal to tolerance, it
+  /// returns the closest open range value. Otherwise, it
+  /// @throws maliput::common::assertion_error.
+  double operator()(double s) const;
+
+ private:
+  // The provided epsilon can be used relatively or absolutely.
+  enum class EpsilonUse { kAbsolute = 0, kRelative };
+
+  // Constructs the functor.
+  //
+  // @param min lower extreme of the range.
+  // @param max upper extreme of the range.
+  // @param tolerance is the range extension to be accepted.
+  // @param epsilon is minimum difference that separates a number within the
+  //        range to be distinct from range extremes (`min` and `max`).
+  // @param epsilon_mode selects how `epsilon` will be used: absolute or relative.
+  // @throws maliput::common::assertion_error When `tolerance` is non positive.
+  // @throws maliput::common::assertion_error When `epsilon` is not in
+  //         [0, tolerance].
+  // @throws maliput::common::assertion_error When `min` + `epsilon` > `max` or
+  //         `max` - `epsilon` < `min`
+  RangeValidator(double min, double max, double tolerance, double epsilon, const EpsilonUse& epsilon_mode);
+
+  double min_{};
+  double max_{};
+  double tolerance_{};
+  double epsilon_{};
+};
+
+}  // namespace common
+}  // namespace maliput

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -5,7 +5,9 @@
 set(COMMON_SOURCES
   filesystem.cc
   logger.cc
-  maliput_abort_and_throw.cc)
+  maliput_abort_and_throw.cc
+  range_validator.cc
+)
 
 add_library(common ${COMMON_SOURCES})
 

--- a/src/common/range_validator.cc
+++ b/src/common/range_validator.cc
@@ -1,0 +1,74 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput/common/range_validator.h"
+
+#include <algorithm>
+#include <string>
+
+#include "maliput/common/assertion_error.h"
+#include "maliput/common/maliput_throw.h"
+
+namespace maliput {
+namespace common {
+
+RangeValidator RangeValidator::GetRelativeEpsilonValidator(double min, double max, double tolerance, double epsilon) {
+  return RangeValidator{min, max, tolerance, epsilon, EpsilonUse::kRelative};
+}
+
+RangeValidator RangeValidator::GetAbsoluteEpsilonValidator(double min, double max, double tolerance, double epsilon) {
+  return RangeValidator{min, max, tolerance, epsilon, EpsilonUse::kAbsolute};
+}
+
+RangeValidator::RangeValidator(double min, double max, double tolerance, double epsilon, const EpsilonUse& epsilon_mode)
+    : min_(min), max_(max), tolerance_(tolerance), epsilon_(epsilon) {
+  MALIPUT_THROW_UNLESS(tolerance_ > 0.);
+
+  if (epsilon_mode == EpsilonUse::kRelative) {
+    // Multiplying the range by kEpsilon creates an epsilon value that is relative to the
+    // length of the range. This avoids numerical errors when having a long range and a very small epsilon value
+    // (~1e-14) leads to calculation that goes beyond the minimal useful digit of the double type.
+    epsilon_ = (max_ - min_) * epsilon_;
+  }
+  MALIPUT_IS_IN_RANGE(epsilon_, 0., tolerance_);
+  MALIPUT_VALIDATE((min_ + epsilon_) <= max_, std::string("Open range lower bound <") +
+                                                  std::to_string((min_ + epsilon_)) + "> is greater than <" +
+                                                  std::to_string(max_) + ">");
+  MALIPUT_VALIDATE(min <= (max_ - epsilon_), std::string("Open range upper bound <") +
+                                                 std::to_string((max_ - epsilon_)) + "> is less than <" +
+                                                 std::to_string(min) + ">");
+}
+
+double RangeValidator::operator()(double s) const {
+  MALIPUT_IS_IN_RANGE(s, min_ - tolerance_, max_ + tolerance_);
+  return std::clamp(s, min_ + epsilon_, max_ - epsilon_);
+}
+
+}  // namespace common
+}  // namespace maliput

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -4,6 +4,7 @@ ament_add_gtest(maliput_deprecated_test maliput_deprecated_test.cc)
 ament_add_gtest(maliput_hash_test maliput_hash_test.cc)
 ament_add_gtest(maliput_never_destroyed_test maliput_never_destroyed_test.cc)
 ament_add_gtest(maliput_throw_test maliput_throw_test.cc)
+ament_add_gtest(range_validator_test range_validator_test.cc)
 
 macro(add_dependencies_to_test target)
     if (TARGET ${target})
@@ -28,6 +29,7 @@ add_dependencies_to_test(maliput_deprecated_test)
 add_dependencies_to_test(maliput_hash_test)
 add_dependencies_to_test(maliput_never_destroyed_test)
 add_dependencies_to_test(maliput_throw_test)
+add_dependencies_to_test(range_validator_test)
 
 # TODO(#335): When a sanitizer is enabled, tests where assert are checked are disabled.
 if (NOT ${SANITIZERS})

--- a/test/common/maliput_throw_test.cc
+++ b/test/common/maliput_throw_test.cc
@@ -49,6 +49,18 @@ GTEST_TEST(MaliputThrowMessageTest, ExpectThrowWithMessageTest) {
   EXPECT_THROW({ MALIPUT_THROW_MESSAGE("Exception description"); }, assertion_error);
 }
 
+// Evaluates whether or not MALIPUT_VALIDATE() throws.
+GTEST_TEST(MaliputValidateTest, Test) {
+  EXPECT_THROW({ MALIPUT_VALIDATE(false, "Exception description"); }, assertion_error);
+  EXPECT_NO_THROW({ MALIPUT_VALIDATE(true, "Exception description"); });
+}
+
+// Evaluates whether or not MALIPUT_IS_IN_RANGE() throws.
+GTEST_TEST(MaliputIsInRangeTest, Test) {
+  EXPECT_THROW({ MALIPUT_IS_IN_RANGE(5., 1., 4.); }, assertion_error);
+  EXPECT_NO_THROW({ MALIPUT_IS_IN_RANGE(5., 1., 10.); });
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace common

--- a/test/common/range_validator_test.cc
+++ b/test/common/range_validator_test.cc
@@ -1,0 +1,208 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput/common/range_validator.h"
+
+#include <gtest/gtest.h>
+
+#include "maliput/common/assertion_error.h"
+
+namespace maliput {
+namespace common {
+namespace test {
+
+class RangeValidatorConstructorValidation : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  static constexpr double kMin{0.5};
+  static constexpr double kMax{1034.};
+  static constexpr double kTolerance{1e-3};
+  static constexpr double kEpsilon{1e-5};
+};
+
+// no throw
+TEST_F(RangeValidatorConstructorValidation, WellConstructed) {
+  EXPECT_NO_THROW({ RangeValidator::GetAbsoluteEpsilonValidator(kMin, kMax, kTolerance, kEpsilon); });
+}
+
+// relative epsilon > tolerance
+// kEpsilon * (kMax - kMin) > tolerance
+TEST_F(RangeValidatorConstructorValidation, RelativeEpsilonGreaterThanTolerance) {
+  EXPECT_THROW({ RangeValidator::GetRelativeEpsilonValidator(kMin, kMax, kTolerance, kEpsilon); },
+               maliput::common::assertion_error);
+}
+
+// min > max
+TEST_F(RangeValidatorConstructorValidation, MinGreaterThanMax) {
+  EXPECT_THROW({ RangeValidator::GetAbsoluteEpsilonValidator(kMax, kMin, kTolerance, kEpsilon); },
+               maliput::common::assertion_error);
+}
+
+// epsilon > tolerance
+TEST_F(RangeValidatorConstructorValidation, EpsilonGreaterThanTolerance) {
+  EXPECT_THROW({ RangeValidator::GetAbsoluteEpsilonValidator(kMin, kMax, kEpsilon, kTolerance); },
+               maliput::common::assertion_error);
+}
+
+// min + epsilon > max (applies the other way around, it's specially provided
+// in constructor code to validate numerical error).
+TEST_F(RangeValidatorConstructorValidation, MinPlusEpsilonGreaterThanMax) {
+  EXPECT_THROW({ RangeValidator::GetAbsoluteEpsilonValidator(kMin, kMax, 2 * kMax, kMax); },
+               maliput::common::assertion_error);
+}
+
+class RangeValidatorAbsoluteEpsilonRange : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  static constexpr double kMin{0.5};
+  static constexpr double kMax{3.};
+  static constexpr double kTolerance{1e-3};
+  static constexpr double kEpsilon{1e-5};
+  const RangeValidator dut{RangeValidator::GetAbsoluteEpsilonValidator(kMin, kMax, kTolerance, kEpsilon)};
+};
+
+// In the middle of the range.
+TEST_F(RangeValidatorAbsoluteEpsilonRange, MiddleOfRange) {
+  const double kS{2.};
+  EXPECT_DOUBLE_EQ(dut(kS), kS);
+}
+
+// In the maximum of the range.
+TEST_F(RangeValidatorAbsoluteEpsilonRange, MaxLimitOfRange) {
+  const double kS{kMax};
+  EXPECT_DOUBLE_EQ(dut(kS), kS - kEpsilon);
+}
+
+// In the minimum of the range.
+TEST_F(RangeValidatorAbsoluteEpsilonRange, MinLimitOfRange) {
+  const double kS{kMin};
+  EXPECT_DOUBLE_EQ(dut(kS), kS + kEpsilon);
+}
+
+// Exceeding the maximum but within linear tolerance.
+TEST_F(RangeValidatorAbsoluteEpsilonRange, ExceedsMaximum) {
+  const double kS{kMax + kTolerance / 2.};
+  EXPECT_DOUBLE_EQ(dut(kS), kMax - kEpsilon);
+}
+
+// Exceeding the minimum but within linear tolerance.
+TEST_F(RangeValidatorAbsoluteEpsilonRange, ExceedsMinimum) {
+  const double kS{kMin - kTolerance / 2.};
+  EXPECT_DOUBLE_EQ(dut(kS), kMin + kEpsilon);
+}
+
+// Expects throw because of out of bounds.
+TEST_F(RangeValidatorAbsoluteEpsilonRange, OutOfBounds) {
+  const double kS{kMax + 10 * kTolerance};
+  EXPECT_THROW({ dut(kS); }, maliput::common::assertion_error);
+}
+
+class RangeValidatorRelativeEpsilonRange : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  static constexpr double kMin{0.5};
+  static constexpr double kMax{100.5};
+  static constexpr double kRange{kMax - kMin};
+  static constexpr double kTolerance{1e-3};
+  static constexpr double kEpsilon{1e-8};
+  static constexpr double kRelativeEpsilon{kEpsilon * kRange};
+  const RangeValidator dut{RangeValidator::GetRelativeEpsilonValidator(kMin, kMax, kTolerance, kEpsilon)};
+};
+
+// In the middle of the range.
+TEST_F(RangeValidatorRelativeEpsilonRange, MiddleOfRange) {
+  const double kS{kMax - kMin};
+  EXPECT_DOUBLE_EQ(dut(kS), kS);
+}
+
+// In the maximum of the range.
+TEST_F(RangeValidatorRelativeEpsilonRange, MaxLimitOfRange) {
+  const double kS{kMax};
+  EXPECT_DOUBLE_EQ(dut(kS), kS - kRelativeEpsilon);
+}
+
+// In the minimum of the range.
+TEST_F(RangeValidatorRelativeEpsilonRange, MinLimitOfRange) {
+  const double kS{kMin};
+  EXPECT_DOUBLE_EQ(dut(kS), kS + kRelativeEpsilon);
+}
+
+// Exceeding the maximum but within linear tolerance.
+TEST_F(RangeValidatorRelativeEpsilonRange, ExceedsMaximum) {
+  const double kS{kMax + kTolerance / 2.};
+  EXPECT_DOUBLE_EQ(dut(kS), kMax - kRelativeEpsilon);
+}
+
+// Exceeding the minimum but within linear tolerance.
+TEST_F(RangeValidatorRelativeEpsilonRange, ExceedsMinimum) {
+  const double kS{kMin - kTolerance / 2.};
+  EXPECT_DOUBLE_EQ(dut(kS), kMin + kRelativeEpsilon);
+}
+
+// Expects throw because of out of bounds.
+TEST_F(RangeValidatorRelativeEpsilonRange, OutOfBounds) {
+  const double kS{kMax + 10 * kTolerance};
+  EXPECT_THROW({ dut(kS); }, maliput::common::assertion_error);
+}
+
+// Tests behavior when working close to the limit of the precision for both relative and absolute use of epsilon value.
+// Considering that the number of useful digits for the double type is about 15(or 16) digits.
+class RangeValidatorOutOfPrecisionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  static constexpr double kMin{0.5};
+  static constexpr double kMax{100000.5};
+  static constexpr double kTolerance{1e-3};
+  static constexpr double kEpsilon{1e-14};
+};
+
+TEST_F(RangeValidatorOutOfPrecisionTest, WithAbsoluteEpsilon) {
+  const RangeValidator dut{RangeValidator::GetAbsoluteEpsilonValidator(kMin, kMax, kTolerance, kEpsilon)};
+  // In the maximum of the range.
+  const double kS{kMax};
+  // The value isn't clamped because it is beyond of the double precision.
+  EXPECT_DOUBLE_EQ(dut(kS), kS);
+}
+
+TEST_F(RangeValidatorOutOfPrecisionTest, WithRelativeEpsilon) {
+  const double kRelativeEpsilon{kEpsilon * (kMax - kMin)};
+  const RangeValidator dut{RangeValidator::GetRelativeEpsilonValidator(kMin, kMax, kTolerance, kEpsilon)};
+  // In the maximum of the range.
+  const double kS{kMax};
+  // The value is clamped because the epsilon value is weighten by the length of the range.
+  EXPECT_DOUBLE_EQ(dut(kS), kS - kRelativeEpsilon);
+}
+
+}  // namespace test
+}  // namespace common
+}  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

Closes #528 

## Summary

 - Brings `OpenRangeValidator` from `maliput_malidrive` as `RangeValidator` under `maliput::common`
 - Adds `MALIPUT_IS_IN_RANGE` convenient macro.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
