### PR TITLE
Adds a default populated ManualPhaseProvider.

### DIFF
--- a/include/maliput/base/manual_phase_provider.h
+++ b/include/maliput/base/manual_phase_provider.h
@@ -35,6 +35,7 @@
 #include "maliput/api/rules/phase.h"
 #include "maliput/api/rules/phase_provider.h"
 #include "maliput/api/rules/phase_ring.h"
+#include "maliput/api/rules/phase_ring_book.h"
 #include "maliput/common/maliput_copyable.h"
 
 namespace maliput {
@@ -44,6 +45,14 @@ namespace maliput {
 class ManualPhaseProvider : public api::rules::PhaseProvider {
  public:
   MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(ManualPhaseProvider);
+
+  /// Constructs a ManualPhaseProvider populated from a given PhaseRingBook.
+  /// @details The initial phase for each ring is the arbitrarily chosen.
+  ///
+  /// @param phase_ring_book The PhaseRingBook to use.
+  /// @throws maliput::common::assertion_error When phase_ring_book is nullptr.
+  static std::unique_ptr<ManualPhaseProvider> GetDefaultPopulatedManualPhaseProvider(
+      const maliput::api::rules::PhaseRingBook* phase_ring_book);
 
   ManualPhaseProvider();
 

--- a/src/base/manual_phase_provider.cc
+++ b/src/base/manual_phase_provider.cc
@@ -41,6 +41,33 @@ using api::rules::Phase;
 using api::rules::PhaseProvider;
 using api::rules::PhaseRing;
 
+std::unique_ptr<ManualPhaseProvider> ManualPhaseProvider::GetDefaultPopulatedManualPhaseProvider(
+    const maliput::api::rules::PhaseRingBook* phase_ring_book) {
+  MALIPUT_THROW_UNLESS(phase_ring_book != nullptr);
+  auto manual_phase_provider = std::make_unique<maliput::ManualPhaseProvider>();
+  for (const auto& phase_ring_id : phase_ring_book->GetPhaseRings()) {
+    const std::optional<PhaseRing> phase_ring = phase_ring_book->GetPhaseRing(phase_ring_id);
+    MALIPUT_THROW_UNLESS(phase_ring != std::nullopt);
+    std::optional<Phase::Id> next_phase_id = std::nullopt;
+    std::optional<double> duration_until = std::nullopt;
+
+    const std::unordered_map<Phase::Id, Phase>& phases = phase_ring->phases();
+    if (phases.empty()) continue;
+    // As `phases` is an unordered map, the initial phase is randomly selected even though always the "begin" value of
+    // the collection is selected.
+    const Phase::Id initial_phase = phases.begin()->first;
+    const std::vector<PhaseRing::NextPhase> next_phases = phase_ring->next_phases().at(initial_phase);
+    if (!next_phases.empty()) {
+      // Arbitrarily selects the first next phase.
+      const PhaseRing::NextPhase& n = next_phases.front();
+      next_phase_id = n.id;
+      duration_until = n.duration_until;
+    }
+    manual_phase_provider->AddPhaseRing(phase_ring_id, initial_phase, next_phase_id, duration_until);
+  }
+  return manual_phase_provider;
+}
+
 class ManualPhaseProvider::Impl {
  public:
   MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(Impl)

--- a/test/base/manual_phase_provider_test.cc
+++ b/test/base/manual_phase_provider_test.cc
@@ -40,6 +40,8 @@
 #include "maliput/api/rules/phase_ring.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/rule.h"
+#include "maliput/base/manual_phase_ring_book.h"
+#include "maliput/test_utilities/mock.h"
 
 namespace maliput {
 namespace {
@@ -138,6 +140,117 @@ GTEST_TEST(PhaseRingTest, InvalidPhases) {
   Phase phase_2(Phase::Id("baz"), rule_states_2, discrete_value_rule_states_2);
   const std::vector<Phase> phases{phase_1, phase_2};
   EXPECT_THROW(PhaseRing(PhaseRing::Id("foo"), phases), std::exception);
+}
+
+// Tests the ManualPhaseProvider::GetDefaultPopulatedManualPhaseProvider method.
+// For this, two phase_rings are added to the phase ring book:
+// 1 - Containing 3 phases with next phases information.
+// 2 - Containing 3 phases without next phases information.
+class DefaultPopulatedManualPhaseProviderTest : public testing::Test {
+ public:
+  static DiscreteValueRule::DiscreteValue CreateDiscreteValue(const std::string& value) {
+    return {Rule::State::kStrict, api::test::CreateEmptyRelatedRules(), api::test::CreateEmptyRelatedUniqueIds(),
+            value};
+  }
+  static constexpr double kDurationUntil = 10.0;
+
+ protected:
+  void SetUp() override {
+    phase_ring_book_.AddPhaseRing(phase_ring_with_next_);
+    phase_ring_book_.AddPhaseRing(phase_ring_without_next_);
+  }
+
+  const Phase::Id kPhaseId1{"phase_1"};
+  const Phase::Id kPhaseId2{"phase_2"};
+  const Phase::Id kPhaseId3{"phase_3"};
+  const Phase::Id kPhaseId4{"phase_4"};
+  const Phase::Id kPhaseId5{"phase_5"};
+  const Phase::Id kPhaseId6{"phase_6"};
+  const Phase phase_1_{kPhaseId1,
+                       {} /* rule_states */,
+                       {
+                           {Rule::Id{"rule_a"}, CreateDiscreteValue("rule_a_value_1")},
+                           {Rule::Id{"rule_b"}, CreateDiscreteValue("rule_b_value_1")},
+                       } /* discrete_value_rule_states */,
+                       std::nullopt /* bulb_states */};
+
+  const Phase phase_2_{kPhaseId2,
+                       {} /* rule_states */,
+                       {
+                           {Rule::Id{"rule_a"}, CreateDiscreteValue("rule_a_value_2")},
+                           {Rule::Id{"rule_b"}, CreateDiscreteValue("rule_b_value_2")},
+                       } /* discrete_value_rule_states */,
+                       std::nullopt /* bulb_states */};
+  const Phase phase_3_{kPhaseId3,
+                       {} /* rule_states */,
+                       {
+                           {Rule::Id{"rule_a"}, CreateDiscreteValue("rule_a_value_3")},
+                           {Rule::Id{"rule_b"}, CreateDiscreteValue("rule_b_value_3")},
+                       } /* discrete_value_rule_states */,
+                       std::nullopt /* bulb_states */};
+  const Phase phase_4_{kPhaseId4,
+                       {} /* rule_states */,
+                       {
+                           {Rule::Id{"rule_c"}, CreateDiscreteValue("rule_c_value_1")},
+                           {Rule::Id{"rule_d"}, CreateDiscreteValue("rule_d_value_1")},
+                       } /* discrete_value_rule_states */,
+                       std::nullopt /* bulb_states */};
+
+  const Phase phase_5_{kPhaseId5,
+                       {} /* rule_states */,
+                       {
+                           {Rule::Id{"rule_c"}, CreateDiscreteValue("rule_c_value_2")},
+                           {Rule::Id{"rule_d"}, CreateDiscreteValue("rule_d_value_2")},
+                       } /* discrete_value_rule_states */,
+                       std::nullopt /* bulb_states */};
+  const Phase phase_6_{kPhaseId6,
+                       {} /* rule_states */,
+                       {
+                           {Rule::Id{"rule_c"}, CreateDiscreteValue("rule_c_value_3")},
+                           {Rule::Id{"rule_d"}, CreateDiscreteValue("rule_d_value_3")},
+                       } /* discrete_value_rule_states */,
+                       std::nullopt /* bulb_states */};
+  const PhaseRing::Id phase_ring_id_1_{"phase_ring_1"};
+  const PhaseRing::Id phase_ring_id_2_{"phase_ring_2"};
+  const PhaseRing phase_ring_with_next_{phase_ring_id_1_,
+                                        {phase_1_, phase_2_, phase_3_},
+                                        {{
+                                            {phase_1_.id(), {{phase_2_.id(), {kDurationUntil}}}},
+                                            {phase_2_.id(), {{phase_3_.id(), {kDurationUntil}}}},
+                                            {phase_3_.id(), {{phase_1_.id(), {kDurationUntil}}}},
+                                        }}};
+  const PhaseRing phase_ring_without_next_{phase_ring_id_2_, {phase_4_, phase_5_, phase_6_}};
+
+  ManualPhaseRingBook phase_ring_book_{};
+};
+
+TEST_F(DefaultPopulatedManualPhaseProviderTest, Test) {
+  const std::unique_ptr<ManualPhaseProvider> dut{
+      ManualPhaseProvider::GetDefaultPopulatedManualPhaseProvider(&phase_ring_book_)};
+
+  // Phase ring book 1.
+  const std::optional<PhaseProvider::Result> phase_from_ring_1 = dut->GetPhase(phase_ring_id_1_);
+  ASSERT_TRUE(phase_from_ring_1.has_value());
+  // As the phases aren't added in order, we need to check if the gotten phase is actually part of the ring.
+  ASSERT_TRUE(phase_ring_with_next_.GetPhase(phase_from_ring_1->state).has_value());
+  ASSERT_TRUE(phase_from_ring_1->next.has_value());
+  // Once that we get the phase we could check the next phase.
+  if (phase_from_ring_1->state == kPhaseId1) {
+    EXPECT_EQ(kPhaseId3, phase_from_ring_1->next->state);
+  } else if (phase_from_ring_1->state == kPhaseId2) {
+    EXPECT_EQ(kPhaseId3, phase_from_ring_1->next->state);
+  } else if (phase_from_ring_1->state == kPhaseId3) {
+    EXPECT_EQ(kPhaseId1, phase_from_ring_1->next->state);
+  } else {
+    FAIL();
+  }
+  EXPECT_EQ(phase_from_ring_1->next->duration_until, kDurationUntil);
+
+  // Phase ring book 2.
+  const std::optional<PhaseProvider::Result> phase_from_ring_2 = dut->GetPhase(phase_ring_id_2_);
+  ASSERT_TRUE(phase_from_ring_2.has_value());
+  ASSERT_TRUE(phase_ring_without_next_.GetPhase(phase_from_ring_2->state).has_value());
+  ASSERT_FALSE(phase_from_ring_2->next.has_value());
 }
 
 }  // namespace

--- a/test/base/manual_phase_provider_test.cc
+++ b/test/base/manual_phase_provider_test.cc
@@ -46,6 +46,7 @@
 namespace maliput {
 namespace {
 
+using api::rules::BulbStates;
 using api::rules::DiscreteValueRule;
 using api::rules::DiscreteValueRuleStates;
 using api::rules::Phase;
@@ -166,50 +167,52 @@ class DefaultPopulatedManualPhaseProviderTest : public testing::Test {
   const Phase::Id kPhaseId4{"phase_4"};
   const Phase::Id kPhaseId5{"phase_5"};
   const Phase::Id kPhaseId6{"phase_6"};
+  const RuleStates kEmptyRuleStates{};
+  const BulbStates kEmptyBulbStates{};
   const Phase phase_1_{kPhaseId1,
-                       {} /* rule_states */,
+                       kEmptyRuleStates,
                        {
                            {Rule::Id{"rule_a"}, CreateDiscreteValue("rule_a_value_1")},
                            {Rule::Id{"rule_b"}, CreateDiscreteValue("rule_b_value_1")},
                        } /* discrete_value_rule_states */,
-                       std::nullopt /* bulb_states */};
+                       kEmptyBulbStates};
 
   const Phase phase_2_{kPhaseId2,
-                       {} /* rule_states */,
+                       kEmptyRuleStates,
                        {
                            {Rule::Id{"rule_a"}, CreateDiscreteValue("rule_a_value_2")},
                            {Rule::Id{"rule_b"}, CreateDiscreteValue("rule_b_value_2")},
                        } /* discrete_value_rule_states */,
-                       std::nullopt /* bulb_states */};
+                       kEmptyBulbStates};
   const Phase phase_3_{kPhaseId3,
-                       {} /* rule_states */,
+                       kEmptyRuleStates,
                        {
                            {Rule::Id{"rule_a"}, CreateDiscreteValue("rule_a_value_3")},
                            {Rule::Id{"rule_b"}, CreateDiscreteValue("rule_b_value_3")},
                        } /* discrete_value_rule_states */,
-                       std::nullopt /* bulb_states */};
+                       kEmptyBulbStates};
   const Phase phase_4_{kPhaseId4,
-                       {} /* rule_states */,
+                       kEmptyRuleStates,
                        {
                            {Rule::Id{"rule_c"}, CreateDiscreteValue("rule_c_value_1")},
                            {Rule::Id{"rule_d"}, CreateDiscreteValue("rule_d_value_1")},
                        } /* discrete_value_rule_states */,
-                       std::nullopt /* bulb_states */};
+                       kEmptyBulbStates};
 
   const Phase phase_5_{kPhaseId5,
-                       {} /* rule_states */,
+                       kEmptyRuleStates,
                        {
                            {Rule::Id{"rule_c"}, CreateDiscreteValue("rule_c_value_2")},
                            {Rule::Id{"rule_d"}, CreateDiscreteValue("rule_d_value_2")},
                        } /* discrete_value_rule_states */,
-                       std::nullopt /* bulb_states */};
+                       kEmptyBulbStates};
   const Phase phase_6_{kPhaseId6,
-                       {} /* rule_states */,
+                       kEmptyRuleStates,
                        {
                            {Rule::Id{"rule_c"}, CreateDiscreteValue("rule_c_value_3")},
                            {Rule::Id{"rule_d"}, CreateDiscreteValue("rule_d_value_3")},
                        } /* discrete_value_rule_states */,
-                       std::nullopt /* bulb_states */};
+                       kEmptyBulbStates};
   const PhaseRing::Id phase_ring_id_1_{"phase_ring_1"};
   const PhaseRing::Id phase_ring_id_2_{"phase_ring_2"};
   const PhaseRing phase_ring_with_next_{phase_ring_id_1_,
@@ -234,7 +237,7 @@ TEST_F(DefaultPopulatedManualPhaseProviderTest, Test) {
   // As the phases aren't added in order, we need to check if the gotten phase is actually part of the ring.
   ASSERT_TRUE(phase_ring_with_next_.GetPhase(phase_from_ring_1->state).has_value());
   ASSERT_TRUE(phase_from_ring_1->next.has_value());
-  // Once that we get the phase we could check the next phase.
+  // Once we get the phase we could check the next phase.
   if (phase_from_ring_1->state == kPhaseId1) {
     EXPECT_EQ(kPhaseId3, phase_from_ring_1->next->state);
   } else if (phase_from_ring_1->state == kPhaseId2) {

--- a/test/base/manual_phase_provider_test.cc
+++ b/test/base/manual_phase_provider_test.cc
@@ -167,7 +167,10 @@ class DefaultPopulatedManualPhaseProviderTest : public testing::Test {
   const Phase::Id kPhaseId4{"phase_4"};
   const Phase::Id kPhaseId5{"phase_5"};
   const Phase::Id kPhaseId6{"phase_6"};
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const RuleStates kEmptyRuleStates{};
+  #pragma GCC diagnostic pop
   const BulbStates kEmptyBulbStates{};
   const Phase phase_1_{kPhaseId1,
                        kEmptyRuleStates,

--- a/test/base/manual_phase_provider_test.cc
+++ b/test/base/manual_phase_provider_test.cc
@@ -167,10 +167,10 @@ class DefaultPopulatedManualPhaseProviderTest : public testing::Test {
   const Phase::Id kPhaseId4{"phase_4"};
   const Phase::Id kPhaseId5{"phase_5"};
   const Phase::Id kPhaseId6{"phase_6"};
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const RuleStates kEmptyRuleStates{};
-  #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   const BulbStates kEmptyBulbStates{};
   const Phase phase_1_{kPhaseId1,
                        kEmptyRuleStates,


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_osm/issues/36

## Summary
Adds a `ManualPhaseProvider::GetDefaultPopulatedPhaseProvider` static method that returns a ManualPhaseProvider
with a default population using the phase ring book.

Implementation is brought from maliput_malidrive


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
