### PR TITLE
Maliput Plugin: Adds interface for providing default parameters from …

### DIFF
--- a/include/maliput/plugin/create_road_network.h
+++ b/include/maliput/plugin/create_road_network.h
@@ -33,6 +33,7 @@
 #include <string>
 
 #include "maliput/api/road_network.h"
+#include "maliput/plugin/road_network_loader.h"
 
 namespace maliput {
 namespace plugin {
@@ -47,6 +48,14 @@ namespace plugin {
 /// @throws maliput::common::assertion_error When the `maliput::api::RoadNetwork` can't be loaded.
 std::unique_ptr<maliput::api::RoadNetwork> CreateRoadNetwork(const std::string& road_network_loader_id,
                                                              const std::map<std::string, std::string>& properties);
+
+/// Creates a maliput::plugin::RoadNetworkLoader using the specified plugin id.
+/// @param road_network_loader_id RoadNetworkLoader plugin id to be used.
+/// @returns A maliput::plugin::RoadNetworkLoader.
+///
+/// @throws maliput::common::assertion_error When `road_network_loader_id` is not found.
+/// @throws maliput::common::assertion_error When the plugin isn't a RoadNetworkLoader plugin type.
+std::unique_ptr<maliput::plugin::RoadNetworkLoader> CreateRoadNetworkLoader(const std::string& road_network_loader_id);
 
 }  // namespace plugin
 }  // namespace maliput

--- a/include/maliput/plugin/maliput_plugin_manager.h
+++ b/include/maliput/plugin/maliput_plugin_manager.h
@@ -63,7 +63,7 @@ class MaliputPluginManager {
   void AddPlugin(const std::string& path_to_plugin);
 
   /// @returns A vector with the MaliputPlugin::Id of the loaded plugins.
-  std::vector<MaliputPlugin::Id> ListPlugins();
+  std::unordered_map<MaliputPlugin::Id, MaliputPluginType> ListPlugins();
 
  private:
   // Environment variable name that holds the path to look for plugins.

--- a/include/maliput/plugin/road_network_loader.h
+++ b/include/maliput/plugin/road_network_loader.h
@@ -33,7 +33,7 @@
 #include "maliput/plugin/maliput_plugin_type.h"
 
 /// @def REGISTER_ROAD_NETWORK_LOADER_PLUGIN(PluginName, RoadNetworkLoaderClass)
-/// Macro for automating the creation of the correspondant functions for the correct
+/// Macro for automating the creation of the correspondent functions for the correct
 /// implementation of a RoadNetworkLoader plugin.
 ///
 /// @param PluginName Is the name of the plugin and must be unique among all the plugins.
@@ -57,11 +57,18 @@ class RoadNetworkLoader {
   /// @returns The entry point method name for getting an instance of the class.
   static std::string GetEntryPoint() { return "MakeRoadNetworkLoader"; }
 
+  virtual ~RoadNetworkLoader() = default;
+
   /// Returns a maliput::api::RoadNetwork.
   /// @param properties Dictionary containing the arguments needed for creating the RoadNetwork.
   virtual std::unique_ptr<maliput::api::RoadNetwork> operator()(
       const std::map<std::string, std::string>& properties) const = 0;
-  virtual ~RoadNetworkLoader() = default;
+
+  /// Returns a map of the default properties that are required for creating the RoadNetwork.
+  /// It is expected to be overriden by the derived class if such properties are wanted to be provided.
+  virtual std::map<std::string, std::string> GetDefaultParameters() const {
+    return std::map<std::string, std::string>();
+  }
 };
 
 }  // namespace plugin

--- a/src/plugin/create_road_network.cc
+++ b/src/plugin/create_road_network.cc
@@ -31,13 +31,11 @@
 #include "maliput/common/logger.h"
 #include "maliput/plugin/maliput_plugin.h"
 #include "maliput/plugin/maliput_plugin_manager.h"
-#include "maliput/plugin/road_network_loader.h"
 
 namespace maliput {
 namespace plugin {
 
-std::unique_ptr<maliput::api::RoadNetwork> CreateRoadNetwork(const std::string& road_network_loader_id,
-                                                             const std::map<std::string, std::string>& properties) {
+std::unique_ptr<maliput::plugin::RoadNetworkLoader> CreateRoadNetworkLoader(const std::string& road_network_loader_id) {
   // 'manager' is static for two main reasons:
   // 1 - The manager should keep loaded the correspondent plugin until the program is finished.
   // 2 - There is no need to reload the libraries every time this function is called.
@@ -55,8 +53,14 @@ std::unique_ptr<maliput::api::RoadNetwork> CreateRoadNetwork(const std::string& 
       maliput_plugin->ExecuteSymbol<maliput::plugin::RoadNetworkLoaderPtr>(
           maliput::plugin::RoadNetworkLoader::GetEntryPoint());
   // Use smart pointers to gracefully manage heap allocation.
-  std::unique_ptr<maliput::plugin::RoadNetworkLoader> road_network_loader{
+  return std::unique_ptr<maliput::plugin::RoadNetworkLoader>{
       reinterpret_cast<maliput::plugin::RoadNetworkLoader*>(rn_loader_ptr)};
+}
+
+std::unique_ptr<maliput::api::RoadNetwork> CreateRoadNetwork(const std::string& road_network_loader_id,
+                                                             const std::map<std::string, std::string>& properties) {
+  std::unique_ptr<maliput::plugin::RoadNetworkLoader> road_network_loader =
+      CreateRoadNetworkLoader(road_network_loader_id);
   // Generates the maliput::api::RoadNetwork.
   return (*road_network_loader)(properties);
 }

--- a/src/plugin/maliput_plugin_manager.cc
+++ b/src/plugin/maliput_plugin_manager.cc
@@ -84,12 +84,12 @@ void MaliputPluginManager::AddPlugin(const std::string& path_to_plugin) {
       (is_repeated ? "A new version of Plugin Id: {} was loaded." : "Plugin Id: {} was correctly loaded."), id);
 }
 
-std::vector<MaliputPlugin::Id> MaliputPluginManager::ListPlugins() {
-  std::vector<MaliputPlugin::Id> keys{};
+std::unordered_map<MaliputPlugin::Id, MaliputPluginType> MaliputPluginManager::ListPlugins() {
+  std::unordered_map<MaliputPlugin::Id, MaliputPluginType> id_type{};
   for (const auto& plugin : plugins_) {
-    keys.push_back(plugin.first);
+    id_type.emplace(plugin.first, plugin.second->GetType());
   }
-  return keys;
+  return id_type;
 }
 
 }  // namespace plugin

--- a/test/plugin/create_road_network_test.cc
+++ b/test/plugin/create_road_network_test.cc
@@ -44,7 +44,7 @@ namespace maliput {
 namespace plugin {
 namespace {
 
-class CreateRoadNetworkTest : public ::testing::Test {
+class CreateRoadNetworkLoaderTest : public ::testing::Test {
  public:
   // Creates a back up of the current environment variable value to be restored in the tear down process.
   // Adds a temporary path where the test plugins are already install.
@@ -64,10 +64,26 @@ class CreateRoadNetworkTest : public ::testing::Test {
   std::string back_up_env_;
 };
 
-TEST_F(CreateRoadNetworkTest, Throws) {
+TEST_F(CreateRoadNetworkLoaderTest, Throws) {
   // No matching plugin id.
-  EXPECT_THROW(CreateRoadNetwork("wrong_id", {}), maliput::common::assertion_error);
+  EXPECT_THROW(CreateRoadNetworkLoader("wrong_id"), maliput::common::assertion_error);
 }
+
+TEST_F(CreateRoadNetworkLoaderTest, CreateRoadNetworkLoader) {
+  std::unique_ptr<maliput::plugin::RoadNetworkLoader> dut;
+  ASSERT_NO_THROW(dut = CreateRoadNetworkLoader(kTestMaliputPlugin));
+  EXPECT_NE(dut, nullptr);
+}
+
+TEST_F(CreateRoadNetworkLoaderTest, DefaultParameters) {
+  const std::map<std::string, std::string> kDefaultParameters{{"configuration_1", "value_1"},
+                                                              {"configuration_2", "value_2"}};
+  std::unique_ptr<maliput::plugin::RoadNetworkLoader> dut = CreateRoadNetworkLoader(kTestMaliputPlugin);
+  ASSERT_NE(dut, nullptr);
+  EXPECT_EQ(kDefaultParameters, dut->GetDefaultParameters());
+}
+
+class CreateRoadNetworkTest : public CreateRoadNetworkLoaderTest {};
 
 TEST_F(CreateRoadNetworkTest, CreateRoadNetwork) { ASSERT_NO_THROW(CreateRoadNetwork(kTestMaliputPlugin, {})); }
 

--- a/test/plugin/maliput_plugin_manager_test.cc
+++ b/test/plugin/maliput_plugin_manager_test.cc
@@ -55,6 +55,7 @@ class MaliputPluginManagerTest : public ::testing::Test {
   struct PluginFeatures {
     MaliputPlugin::Id id{"none"};
     std::string custom_method{};
+    MaliputPluginType type{MaliputPluginType::kRoadNetworkLoader};
   };
 
   // Creates a back of the current environment variable value to be restored in the tear down process.
@@ -88,8 +89,16 @@ TEST_F(MaliputPluginManagerTest, ConstructorGetAndListPlugin) {
 
   const auto plugin_names = dut.ListPlugins();
   EXPECT_EQ(3, static_cast<int>(plugin_names.size()));
-  EXPECT_NE(plugin_names.end(), std::find(plugin_names.begin(), plugin_names.end(), kPlugin1.id));
-  EXPECT_NE(plugin_names.end(), std::find(plugin_names.begin(), plugin_names.end(), kPlugin2.id));
+
+  auto it = plugin_names.find(kPlugin1.id);
+  ASSERT_NE(plugin_names.end(), it);
+  EXPECT_EQ(kPlugin1.type, it->second);
+  it = plugin_names.find(kPlugin2.id);
+  ASSERT_NE(plugin_names.end(), it);
+  EXPECT_EQ(kPlugin2.type, it->second);
+  it = plugin_names.find(kPlugin3.id);
+  ASSERT_NE(plugin_names.end(), it);
+  EXPECT_EQ(kPlugin3.type, it->second);
 
   // multiply_integers_test_plugin plugin.
   auto plugin = dut.GetPlugin(kPlugin1.id);

--- a/test/plugin/tools/road_network_loader_test_plugin.cc
+++ b/test/plugin/tools/road_network_loader_test_plugin.cc
@@ -51,6 +51,10 @@ class MyRoadNetworkLoader : public maliput::plugin::RoadNetworkLoader {
     // For the purpose of this test, we return a nullptr RoadNetwork.
     return nullptr;
   }
+
+  std::map<std::string, std::string> GetDefaultParameters() const override {
+    return {{"configuration_1", "value_1"}, {"configuration_2", "value_2"}};
+  }
 };
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

Closes #531 

## Summary
 - A virtual method is added to the RoadNetworkLoader interface so backends can override it for providing default parameters information. It is useful for implementing https://github.com/maliput/delphyne_gui/issues/427
 - The `MaliputPluginManager::ListPlugins` method is modified to return a map of plugin id / plugin type instead of just a list of ids.
 - A CreateRoadNetworkLoader method was added as now makes sense to get the instance of the loader to get the parameters before actually calling the CreateRoadNetwork method.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

