### PR TITLE
Provides new-rule-api compatible RoadNetwork's constructor.

### DIFF
--- a/include/maliput/api/road_network.h
+++ b/include/maliput/api/road_network.h
@@ -61,6 +61,7 @@ class RoadNetwork {
   /// Constructs a RoadNetwork instance. After creation, you are encouraged to
   /// validate it using ValidateRoadNetwork(), which is defined in
   /// maliput/api/road_network_validator.h.
+  /// TODO(#108): Remove this constructor once old rule api is removed.
   RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry, std::unique_ptr<const rules::RoadRulebook> rulebook,
               std::unique_ptr<const rules::TrafficLightBook> traffic_light_book,
               std::unique_ptr<IntersectionBook> intersection_book,
@@ -70,6 +71,17 @@ class RoadNetwork {
               std::unique_ptr<rules::DiscreteValueRuleStateProvider> discrete_value_rule_state_provider,
               std::unique_ptr<rules::RangeValueRuleStateProvider> range_value_rule_state_provider);
 #pragma GCC diagnostic pop
+
+  /// Constructs a RoadNetwork instance. After creation, you are encouraged to
+  /// validate it using ValidateRoadNetwork(), which is defined in
+  /// maliput/api/road_network_validator.h.
+  RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry, std::unique_ptr<const rules::RoadRulebook> rulebook,
+              std::unique_ptr<const rules::TrafficLightBook> traffic_light_book,
+              std::unique_ptr<IntersectionBook> intersection_book,
+              std::unique_ptr<rules::PhaseRingBook> phase_ring_book,
+              std::unique_ptr<rules::PhaseProvider> phase_provider, std::unique_ptr<rules::RuleRegistry> rule_registry,
+              std::unique_ptr<rules::DiscreteValueRuleStateProvider> discrete_value_rule_state_provider,
+              std::unique_ptr<rules::RangeValueRuleStateProvider> range_value_rule_state_provider);
 
   virtual ~RoadNetwork() = default;
 

--- a/src/api/road_network.cc
+++ b/src/api/road_network.cc
@@ -49,12 +49,30 @@ RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
                          std::unique_ptr<rules::RuleRegistry> rule_registry,
                          std::unique_ptr<rules::DiscreteValueRuleStateProvider> discrete_value_rule_state_provider,
                          std::unique_ptr<rules::RangeValueRuleStateProvider> range_value_rule_state_provider)
+    : RoadNetwork(std::move(road_geometry), std::move(rulebook), std::move(traffic_light_book),
+                  std::move(intersection_book), std::move(phase_ring_book), std::move(phase_provider),
+                  std::move(rule_registry), std::move(discrete_value_rule_state_provider),
+                  std::move(range_value_rule_state_provider)) {
+  right_of_way_rule_state_provider_ = std::move(right_of_way_rule_state_provider);
+  MALIPUT_THROW_UNLESS(right_of_way_rule_state_provider_.get() != nullptr);
+}
+
+#pragma GCC diagnostic pop
+
+RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
+                         std::unique_ptr<const rules::RoadRulebook> rulebook,
+                         std::unique_ptr<const rules::TrafficLightBook> traffic_light_book,
+                         std::unique_ptr<IntersectionBook> intersection_book,
+                         std::unique_ptr<rules::PhaseRingBook> phase_ring_book,
+                         std::unique_ptr<rules::PhaseProvider> phase_provider,
+                         std::unique_ptr<rules::RuleRegistry> rule_registry,
+                         std::unique_ptr<rules::DiscreteValueRuleStateProvider> discrete_value_rule_state_provider,
+                         std::unique_ptr<rules::RangeValueRuleStateProvider> range_value_rule_state_provider)
     : road_geometry_(std::move(road_geometry)),
       rulebook_(std::move(rulebook)),
       traffic_light_book_(std::move(traffic_light_book)),
       intersection_book_(std::move(intersection_book)),
       phase_ring_book_(std::move(phase_ring_book)),
-      right_of_way_rule_state_provider_(std::move(right_of_way_rule_state_provider)),
       phase_provider_(std::move(phase_provider)),
       rule_registry_(std::move(rule_registry)),
       discrete_value_rule_state_provider_(std::move(discrete_value_rule_state_provider)),
@@ -64,13 +82,11 @@ RoadNetwork::RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
   MALIPUT_THROW_UNLESS(traffic_light_book_.get() != nullptr);
   MALIPUT_THROW_UNLESS(intersection_book_.get() != nullptr);
   MALIPUT_THROW_UNLESS(phase_ring_book_.get() != nullptr);
-  MALIPUT_THROW_UNLESS(right_of_way_rule_state_provider_.get() != nullptr);
   MALIPUT_THROW_UNLESS(phase_provider_.get() != nullptr);
   MALIPUT_THROW_UNLESS(rule_registry_.get() != nullptr);
   MALIPUT_THROW_UNLESS(discrete_value_rule_state_provider_.get() != nullptr);
   MALIPUT_THROW_UNLESS(range_value_rule_state_provider_.get() != nullptr);
 }
-#pragma GCC diagnostic pop
 
 bool RoadNetwork::Contains(const RoadPosition& road_position) const {
   return road_position.lane->Contains(road_position.pos);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #534 

## Summary
Provides a new-rule-api compatible RoadNetwork's constructor.

Note: Tests weren't added as this constructor is being fully used by the old constructor so it is indirectly tested.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

