### PR TITLE
Adds maliput profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,18 @@ else()
 endif()
 
 ##############################################################################
+# Profiling
+##############################################################################
+
+if(MALIPUT_PROFILER_ENABLE)
+  message(STATUS "Maliput Profiler - Enabled")
+  find_package(ignition-common3 REQUIRED COMPONENTS profiler)
+  add_definitions(-DMALIPUT_PROFILER_ENABLE)
+  else()
+  message(STATUS "Maliput Profiler - Disabled")
+endif()
+
+##############################################################################
 # Sources
 ##############################################################################
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,35 @@ For further info refer to [Source Installation on Ubuntu](https://maliput.readth
 
 It is recommended to follow the guidelines for setting up a development workspace as described [here](https://maliput.readthedocs.io/en/latest/developer_setup.html).
 
+## Profiling maliput
+
+`maliput` is able to run a profiler for evaluating performance.
+It is implemented via `ign-common3`'s `profiler` component.
+
+In order to avoid any performance drop, this is disabled by default and the binaries aren't distributed with the profiler set up.
+
+For having the profiler enabled when using `maliput`, it is mandatory to install `maliput` from source.
+
+### Steps
+
+1. Install prerequisites. `ign-common3` is not installed via `rosdep` as the profiler is only run on demand:
+
+    ```
+    sudo apt install libignition-common3-dev
+    ```
+
+2. Build `maliput` package using `MALIPUT_PROFILER_ENABLE` cmake argument:
+Continue the [Source-Installation-on-Ubuntu](#Source-Installation-on-Ubuntu) instructions. The only difference is:
+    ```
+    colcon build --packages-select maliput --cmake-args " -DMALIPUT_PROFILER_ENABLE=On"
+    ```
+
+3. Run an application with your preferred `maliput` backend. In another terminal, open the visualizer for the profiler:
+    ```
+    ign_remotery_vis
+    ```
+    _Note: As it opens a browser using `xdg-open`, it is recommended to have installed `xdg-utils` and a browser: (e.g: `sudo apt install -y xdg-utils firefox`)_.
+
 ## Contributing
 
 Please see [CONTRIBUTING](https://maliput.readthedocs.io/en/latest/contributing.html) page.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For having the profiler enabled when using `maliput`, it is mandatory to install
 1. Install prerequisites. `ign-common3` is not installed via `rosdep` as the profiler is only run on demand:
 
     ```
-    sudo apt install libignition-common3-dev
+    sudo apt install libignition-common3-profiler-dev
     ```
 
 2. Build `maliput` package using `MALIPUT_PROFILER_ENABLE` cmake argument:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It is recommended to follow the guidelines for setting up a development workspac
 `maliput` is able to run a profiler for evaluating performance.
 It is implemented via `ign-common3`'s `profiler` component.
 
-In order to avoid any performance drop, this is disabled by default and the binaries aren't distributed with the profiler set up.
+In order to avoid any performance drop and to keep maliput dependency chain clean, this is disabled by default and the binaries aren't distributed with the profiler enabled.
 
 For having the profiler enabled when using `maliput`, it is mandatory to install `maliput` from source.
 

--- a/include/maliput/api/lane.h
+++ b/include/maliput/api/lane.h
@@ -64,13 +64,13 @@ class Lane {
   virtual ~Lane() = default;
 
   /// Returns the persistent identifier.
-  LaneId id() const { return do_id(); }
+  LaneId id() const;
 
   /// Returns the Segment to which this Lane belongs.
-  const Segment* segment() const { return do_segment(); }
+  const Segment* segment() const;
 
   /// Returns the index of this Lane within the Segment which owns it.
-  int index() const { return do_index(); }
+  int index() const;
 
   /// Returns a pointer to the adjacent Lane to the left of this Lane.
   ///
@@ -78,7 +78,7 @@ class Lane {
   /// e.g., "to the left along the +s direction".
   ///
   /// @returns nullptr iff parent Segment has no Lane to the left.
-  const Lane* to_left() const { return do_to_left(); }
+  const Lane* to_left() const;
 
   /// Returns a pointer to the adjacent Lane to the right of this Lane.
   ///
@@ -86,13 +86,13 @@ class Lane {
   /// e.g., "to the right along the +s direction".
   ///
   /// @returns nullptr iff parent Segment has no Lane to the right.
-  const Lane* to_right() const { return do_to_right(); }
+  const Lane* to_right() const;
 
   /// Returns the arc-length of the Lane along its reference curve.
   ///
   /// The value of length() is also the maximum s-coordinate for this Lane;
   /// i.e., the domain of s is [0, length()].
-  double length() const { return do_length(); }
+  double length() const;
 
   /// Returns the nominal lateral (r) bounds for the lane as a function of s.
   ///
@@ -100,7 +100,7 @@ class Lane {
   /// "staying in the lane".
   ///
   /// @see segment_bounds(double s) that defines the whole surface.
-  RBounds lane_bounds(double s) const { return do_lane_bounds(s); }
+  RBounds lane_bounds(double s) const;
 
   /// Returns the lateral segment (r) bounds of the lane as a function of s.
   ///
@@ -110,7 +110,7 @@ class Lane {
   ///
   /// @see lane_bounds(double s) that defines what's considered to be "staying
   /// in the lane".
-  RBounds segment_bounds(double s) const { return do_segment_bounds(s); }
+  RBounds segment_bounds(double s) const;
 
   /// Returns the elevation (`h`) bounds of the lane as a function of `(s, r)`.
   ///
@@ -119,14 +119,14 @@ class Lane {
   ///
   /// `s` is within [0, `length()`] of this Lane and `r` is within
   /// `lane_bounds(s)`.
-  HBounds elevation_bounds(double s, double r) const { return do_elevation_bounds(s, r); }
+  HBounds elevation_bounds(double s, double r) const;
 
   /// Returns the InertialPosition corresponding to the given LanePosition.
   ///
   /// @pre The s component of @p lane_pos must be in domain [0, Lane::length()].
   /// @pre The r component of @p lane_pos must be in domain [Rmin, Rmax]
   ///      derived from Lane::segment_bounds().
-  InertialPosition ToInertialPosition(const LanePosition& lane_pos) const { return DoToInertialPosition(lane_pos); }
+  InertialPosition ToInertialPosition(const LanePosition& lane_pos) const;
 
   /// Determines the LanePosition corresponding to InertialPosition @p inertial_pos.
   /// The LanePosition is expected to be contained within the lane's boundaries.
@@ -135,9 +135,7 @@ class Lane {
   /// This method guarantees that its result satisfies the condition that
   /// `ToInertialPosition(result.lane_position)` is within `linear_tolerance()`
   ///  of `result.nearest_position`.
-  LanePositionResult ToLanePosition(const InertialPosition& inertial_pos) const {
-    return DoToLanePosition(inertial_pos);
-  }
+  LanePositionResult ToLanePosition(const InertialPosition& inertial_pos) const;
 
   /// Determines the LanePosition corresponding to InertialPosition @p inertial_pos.
   /// The LanePosition is expected to be contained within the segment's boundaries.
@@ -146,9 +144,7 @@ class Lane {
   /// This method guarantees that its result satisfies the condition that
   /// `ToInertialPosition(result.lane_position)` is within `linear_tolerance()`
   ///  of `result.nearest_position`.
-  LanePositionResult ToSegmentPosition(const InertialPosition& inertial_pos) const {
-    return DoToSegmentPosition(inertial_pos);
-  }
+  LanePositionResult ToSegmentPosition(const InertialPosition& inertial_pos) const;
 
   // TODO(maddog@tri.global) Method to convert LanePosition to that of
   //                         another Lane.  (Should assert that both
@@ -160,39 +156,33 @@ class Lane {
   /// Returns the rotation which expresses the orientation of the
   /// `Lane`-frame basis at @p lane_pos with respect to the
   /// `Inertial`-frame basis.
-  Rotation GetOrientation(const LanePosition& lane_pos) const { return DoGetOrientation(lane_pos); }
+  Rotation GetOrientation(const LanePosition& lane_pos) const;
 
   /// Computes derivatives of LanePosition given a velocity vector @p velocity.
   /// @p velocity is a isometric velocity vector oriented in the `Lane`-frame
   /// at @p position.
   ///
   /// @returns `Lane`-frame derivatives packed into a LanePosition struct.
-  LanePosition EvalMotionDerivatives(const LanePosition& position, const IsoLaneVelocity& velocity) const {
-    return DoEvalMotionDerivatives(position, velocity);
-  }
+  LanePosition EvalMotionDerivatives(const LanePosition& position, const IsoLaneVelocity& velocity) const;
 
   // TODO(maddog@tri.global)  Design/implement this.
   // void EvalSurfaceDerivatives(...) const { return do_(); }
 
   /// Returns the lane's BranchPoint for the end specified by @p which_end.
-  const BranchPoint* GetBranchPoint(const LaneEnd::Which which_end) const { return DoGetBranchPoint(which_end); }
+  const BranchPoint* GetBranchPoint(const LaneEnd::Which which_end) const;
 
   /// Returns the set of LaneEnd's which connect with this lane on the
   /// same side of the BranchPoint at @p which_end.  At a minimum,
   /// this set will include this Lane.
-  const LaneEndSet* GetConfluentBranches(const LaneEnd::Which which_end) const {
-    return DoGetConfluentBranches(which_end);
-  }
+  const LaneEndSet* GetConfluentBranches(const LaneEnd::Which which_end) const;
 
   /// Returns the set of LaneEnd's which continue onward from this lane at the
   /// BranchPoint at @p which_end.
-  const LaneEndSet* GetOngoingBranches(const LaneEnd::Which which_end) const { return DoGetOngoingBranches(which_end); }
+  const LaneEndSet* GetOngoingBranches(const LaneEnd::Which which_end) const;
 
   /// Returns the default ongoing LaneEnd connected at @p which_end,
   /// or std::nullopt if no default branch has been established at @p which_end.
-  std::optional<LaneEnd> GetDefaultBranch(const LaneEnd::Which which_end) const {
-    return DoGetDefaultBranch(which_end);
-  }
+  std::optional<LaneEnd> GetDefaultBranch(const LaneEnd::Which which_end) const;
 
   /// Returns if this lane contains @p lane_position.
   bool Contains(const LanePosition& lane_position) const;

--- a/include/maliput/api/road_geometry.h
+++ b/include/maliput/api/road_geometry.h
@@ -138,9 +138,7 @@ class RoadGeometry {
   //                          might expect an updated RoadPosition which is
   //                          nearby (e.g., on the same Lane).
   RoadPositionResult ToRoadPosition(const InertialPosition& inertial_position,
-                                    const std::optional<RoadPosition>& hint = std::nullopt) const {
-    return DoToRoadPosition(inertial_position, hint);
-  }
+                                    const std::optional<RoadPosition>& hint = std::nullopt) const;
 
   /// Obtains all RoadPositions within @p radius of @p inertial_position. Only Lanes
   /// whose segment regions include points that are within @p radius of
@@ -163,10 +161,7 @@ class RoadGeometry {
   /// Note that derivative implementations may choose to violate the above
   /// semantics for performance reasons. See docstrings of derivative
   /// implementations for details.
-  std::vector<RoadPositionResult> FindRoadPositions(const InertialPosition& inertial_position, double radius) const {
-    MALIPUT_THROW_UNLESS(radius >= 0.);
-    return DoFindRoadPositions(inertial_position, radius);
-  }
+  std::vector<RoadPositionResult> FindRoadPositions(const InertialPosition& inertial_position, double radius) const;
 
   /// Returns the tolerance guaranteed for linear measurements (positions).
   double linear_tolerance() const { return do_linear_tolerance(); }
@@ -202,9 +197,7 @@ class RoadGeometry {
   /// @throws maliput::assertion_error When any LaneSRange in `lane_s_route.ranges()` refers to
   ///                an unknown Lane.
   std::vector<InertialPosition> SampleAheadWaypoints(const LaneSRoute& lane_s_route,
-                                                     double path_length_sampling_rate) const {
-    return DoSampleAheadWaypoints(lane_s_route, path_length_sampling_rate);
-  }
+                                                     double path_length_sampling_rate) const;
 
   /// The Backend Frame is an inertial frame similar to the Inertial Frame that
   /// differ one from another by an isometric transformation. This method
@@ -214,7 +207,7 @@ class RoadGeometry {
   /// maliput_design.h.
   ///
   /// @return maliput's Inertial Frame to Backend Frame translation vector.
-  math::Vector3 inertial_to_backend_frame_translation() const { return do_inertial_to_backend_frame_translation(); }
+  math::Vector3 inertial_to_backend_frame_translation() const;
 
   // TODO(#400): Add RollPitchYaw inertial_to_backend_frame_rotation() const.
 
@@ -266,22 +259,22 @@ class RoadGeometry::IdIndex {
   virtual ~IdIndex() = default;
 
   /// Returns the Lane identified by @p id, or `nullptr` if @p id is unknown.
-  const Lane* GetLane(const LaneId& id) const { return DoGetLane(id); }
+  const Lane* GetLane(const LaneId& id) const;
 
   // Returns all of the Lane instances.
-  const std::unordered_map<LaneId, const Lane*>& GetLanes() const { return DoGetLanes(); }
+  const std::unordered_map<LaneId, const Lane*>& GetLanes() const;
 
   /// Returns the Segment identified by @p id, or `nullptr` if @p id is
   /// unknown.
-  const Segment* GetSegment(const SegmentId& id) const { return DoGetSegment(id); }
+  const Segment* GetSegment(const SegmentId& id) const;
 
   /// Returns the Junction identified by @p id, or `nullptr` if @p id is
   /// unknown.
-  const Junction* GetJunction(const JunctionId& id) const { return DoGetJunction(id); }
+  const Junction* GetJunction(const JunctionId& id) const;
 
   /// Returns the BranchPoint identified by @p id, or `nullptr` if @p id is
   /// unknown.
-  const BranchPoint* GetBranchPoint(const BranchPointId& id) const { return DoGetBranchPoint(id); }
+  const BranchPoint* GetBranchPoint(const BranchPointId& id) const;
 
  protected:
   IdIndex() = default;

--- a/include/maliput/common/profiler.h
+++ b/include/maliput/common/profiler.h
@@ -56,8 +56,11 @@
 /// \brief Scoped profiling sample. Sample will stop at end of scope.
 #define MALIPUT_PROFILE(name) IGN_PROFILE(name)
 /// \brief Scoped profiling sample as MALIPUT_PROFILE.
-///        The function name is used as the sample name.
+///        __FUNCTION__ is used as the sample name.
 #define MALIPUT_PROFILE_FUNC() IGN_PROFILE(__FUNCTION__)
+/// \brief Scoped profiling sample as MALIPUT_PROFILE.
+///        __PRETTY_FUNCTION__ is used as the sample name.
+#define MALIPUT_PROFILE_PRETTY_FUNC() IGN_PROFILE(__PRETTY_FUNCTION__)
 
 /// \brief Macro to determine if profiler is enabled and has an implementation.
 #define MALIPUT_PROFILER_VALID IGN_PROFILER_VALID
@@ -69,6 +72,8 @@
 #define MALIPUT_PROFILE_END() ((void)0)
 #define MALIPUT_PROFILE_L(name, line) ((void)name)
 #define MALIPUT_PROFILE(name) ((void)name)
+#define MALIPUT_PROFILE_FUNC() ((void)0)
+#define MALIPUT_PROFILE_PRETTY_FUNC() ((void)0)
 #define MALIPUT_PROFILER_VALID MALIPUT_PROFILER_ENABLE
 
 #endif  // MALIPUT_PROFILER_ENABLE

--- a/include/maliput/common/profiler.h
+++ b/include/maliput/common/profiler.h
@@ -1,0 +1,71 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+/// @file Wraps ignition common's profiler behind maliput macros.
+///       This allows us to enable/disable profiling at compile time and avoid adding a dependency on ignition common.
+
+#ifndef MALIPUT_PROFILER_ENABLE
+/// Always set this variable to some value
+#define MALIPUT_PROFILER_ENABLE 0
+#endif
+
+#if MALIPUT_PROFILER_ENABLE
+
+#define IGN_PROFILER_ENABLE 1
+#include <ignition/common/Profiler.hh>
+
+/// \brief Set name of profiled thread
+#define MALIPUT_PROFILE_THREAD_NAME(name) IGN_PROFILE_THREAD_NAME(name)
+/// \brief Log profiling text, if supported by implementation
+#define MALIPUT_PROFILE_LOG_TEXT(name) IGN_PROFILE_LOG_TEXT(name)
+/// \brief Being profiling sample
+#define MALIPUT_PROFILE_BEGIN(name) IGN_PROFILE_BEGIN(name)
+/// \brief End profiling sample
+#define MALIPUT_PROFILE_END() IGN_PROFILE_END()
+
+/// \brief Convenience wrapper for scoped profiling sample. Use MALIPUT_PROFILE
+#define MALIPUT_PROFILE_L(name, line) IGN_PROFILE_L(name, line)
+/// \brief Scoped profiling sample. Sample will stop at end of scope.
+#define MALIPUT_PROFILE(name) IGN_PROFILE(name)
+
+/// \brief Macro to determine if profiler is enabled and has an implementation.
+#define MALIPUT_PROFILER_VALID IGN_PROFILER_VALID
+#else
+
+#define MALIPUT_PROFILE_THREAD_NAME(name) ((void)name)
+#define MALIPUT_PROFILE_LOG_TEXT(name) ((void)name)
+#define MALIPUT_PROFILE_BEGIN(name) ((void)name)
+#define MALIPUT_PROFILE_END() ((void)0)
+#define MALIPUT_PROFILE_L(name, line) ((void)name)
+#define MALIPUT_PROFILE(name) ((void)name)
+#define MALIPUT_PROFILER_VALID MALIPUT_PROFILER_ENABLE
+
+#endif  // MALIPUT_PROFILER_ENABLE

--- a/include/maliput/common/profiler.h
+++ b/include/maliput/common/profiler.h
@@ -55,6 +55,9 @@
 #define MALIPUT_PROFILE_L(name, line) IGN_PROFILE_L(name, line)
 /// \brief Scoped profiling sample. Sample will stop at end of scope.
 #define MALIPUT_PROFILE(name) IGN_PROFILE(name)
+/// \brief Scoped profiling sample as MALIPUT_PROFILE.
+///        The function name is used as the sample name.
+#define MALIPUT_PROFILE_FUNC() IGN_PROFILE(__FUNCTION__)
 
 /// \brief Macro to determine if profiler is enabled and has an implementation.
 #define MALIPUT_PROFILER_VALID IGN_PROFILER_VALID

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -40,6 +40,13 @@ target_link_libraries(api
     maliput::math
 )
 
+if(MALIPUT_PROFILER_ENABLE)
+  target_link_libraries(api
+    PRIVATE
+      ignition-common3::profiler
+  )
+endif()
+
 ##############################################################################
 # Export
 ##############################################################################

--- a/src/api/lane.cc
+++ b/src/api/lane.cc
@@ -45,98 +45,98 @@ bool IsWithinRange(double x, double min, double max, double tolerance) {
 }  // namespace
 
 LaneId Lane::id() const {
-  MALIPUT_PROFILE("maliput::api::Lane::id");
+  MALIPUT_PROFILE_FUNC();
   return do_id();
 }
 
 const Segment* Lane::segment() const {
-  MALIPUT_PROFILE("maliput::api::Lane::segment");
+  MALIPUT_PROFILE_FUNC();
   return do_segment();
 }
 
 int Lane::index() const {
-  MALIPUT_PROFILE("maliput::api::Lane::index");
+  MALIPUT_PROFILE_FUNC();
   return do_index();
 }
 
 const Lane* Lane::to_left() const {
-  MALIPUT_PROFILE("maliput::api::Lane::to_left");
+  MALIPUT_PROFILE_FUNC();
   return do_to_left();
 }
 
 const Lane* Lane::to_right() const {
-  MALIPUT_PROFILE("maliput::api::Lane::to_right");
+  MALIPUT_PROFILE_FUNC();
   return do_to_right();
 }
 
 double Lane::length() const {
-  MALIPUT_PROFILE("maliput::api::Lane::length");
+  MALIPUT_PROFILE_FUNC();
   return do_length();
 }
 
 RBounds Lane::lane_bounds(double s) const {
-  MALIPUT_PROFILE("maliput::api::Lane::lane_bounds");
+  MALIPUT_PROFILE_FUNC();
 
   return do_lane_bounds(s);
 }
 
 RBounds Lane::segment_bounds(double s) const {
-  MALIPUT_PROFILE("maliput::api::Lane::segment_bounds");
+  MALIPUT_PROFILE_FUNC();
   return do_segment_bounds(s);
 }
 
 HBounds Lane::elevation_bounds(double s, double r) const {
-  MALIPUT_PROFILE("maliput::api::Lane::elevation_bounds");
+  MALIPUT_PROFILE_FUNC();
   return do_elevation_bounds(s, r);
 }
 
 InertialPosition Lane::ToInertialPosition(const LanePosition& lane_pos) const {
-  MALIPUT_PROFILE("maliput::api::Lane::ToInertialPosition");
+  MALIPUT_PROFILE_FUNC();
   return DoToInertialPosition(lane_pos);
 }
 
 LanePositionResult Lane::ToLanePosition(const InertialPosition& inertial_pos) const {
-  MALIPUT_PROFILE("maliput::api::Lane::ToLanePosition");
+  MALIPUT_PROFILE_FUNC();
   return DoToLanePosition(inertial_pos);
 }
 
 LanePositionResult Lane::ToSegmentPosition(const InertialPosition& inertial_pos) const {
-  MALIPUT_PROFILE("maliput::api::Lane::ToSegmentPosition");
+  MALIPUT_PROFILE_FUNC();
   return DoToSegmentPosition(inertial_pos);
 }
 
 Rotation Lane::GetOrientation(const LanePosition& lane_pos) const {
-  MALIPUT_PROFILE("maliput::api::Lane::GetOrientation");
+  MALIPUT_PROFILE_FUNC();
   return DoGetOrientation(lane_pos);
 }
 
 LanePosition Lane::EvalMotionDerivatives(const LanePosition& position, const IsoLaneVelocity& velocity) const {
-  MALIPUT_PROFILE("maliput::api::Lane::EvalMotionDerivatives");
+  MALIPUT_PROFILE_FUNC();
   return DoEvalMotionDerivatives(position, velocity);
 }
 
 const BranchPoint* Lane::GetBranchPoint(const LaneEnd::Which which_end) const {
-  MALIPUT_PROFILE("maliput::api::Lane::GetBranchPoint");
+  MALIPUT_PROFILE_FUNC();
   return DoGetBranchPoint(which_end);
 }
 
 const LaneEndSet* Lane::GetConfluentBranches(const LaneEnd::Which which_end) const {
-  MALIPUT_PROFILE("maliput::api::Lane::GetConfluentBranches");
+  MALIPUT_PROFILE_FUNC();
   return DoGetConfluentBranches(which_end);
 }
 
 const LaneEndSet* Lane::GetOngoingBranches(const LaneEnd::Which which_end) const {
-  MALIPUT_PROFILE("maliput::api::Lane::GetOngoingBranches");
+  MALIPUT_PROFILE_FUNC();
   return DoGetOngoingBranches(which_end);
 }
 
 std::optional<LaneEnd> Lane::GetDefaultBranch(const LaneEnd::Which which_end) const {
-  MALIPUT_PROFILE("maliput::api::Lane::GetDefaultBranch");
+  MALIPUT_PROFILE_FUNC();
   return DoGetDefaultBranch(which_end);
 }
 
 bool Lane::Contains(const LanePosition& lane_position) const {
-  MALIPUT_PROFILE("maliput::api::Lane::Contains");
+  MALIPUT_PROFILE_FUNC();
   const double s = lane_position.s();
   const double r = lane_position.r();
   const double h = lane_position.h();

--- a/src/api/lane.cc
+++ b/src/api/lane.cc
@@ -32,15 +32,111 @@
 #include "maliput/api/junction.h"
 #include "maliput/api/road_geometry.h"
 #include "maliput/api/segment.h"
+#include "maliput/common/profiler.h"
 
 namespace maliput {
 namespace api {
+namespace {
 
 bool IsWithinRange(double x, double min, double max, double tolerance) {
   return ((min - tolerance) <= x) && (x <= (max + tolerance));
 }
 
+}  // namespace
+
+LaneId Lane::id() const {
+  MALIPUT_PROFILE("maliput::api::Lane::id");
+  return do_id();
+}
+
+const Segment* Lane::segment() const {
+  MALIPUT_PROFILE("maliput::api::Lane::segment");
+  return do_segment();
+}
+
+int Lane::index() const {
+  MALIPUT_PROFILE("maliput::api::Lane::index");
+  return do_index();
+}
+
+const Lane* Lane::to_left() const {
+  MALIPUT_PROFILE("maliput::api::Lane::to_left");
+  return do_to_left();
+}
+
+const Lane* Lane::to_right() const {
+  MALIPUT_PROFILE("maliput::api::Lane::to_right");
+  return do_to_right();
+}
+
+double Lane::length() const {
+  MALIPUT_PROFILE("maliput::api::Lane::length");
+  return do_length();
+}
+
+RBounds Lane::lane_bounds(double s) const {
+  MALIPUT_PROFILE("maliput::api::Lane::lane_bounds");
+
+  return do_lane_bounds(s);
+}
+
+RBounds Lane::segment_bounds(double s) const {
+  MALIPUT_PROFILE("maliput::api::Lane::segment_bounds");
+  return do_segment_bounds(s);
+}
+
+HBounds Lane::elevation_bounds(double s, double r) const {
+  MALIPUT_PROFILE("maliput::api::Lane::elevation_bounds");
+  return do_elevation_bounds(s, r);
+}
+
+InertialPosition Lane::ToInertialPosition(const LanePosition& lane_pos) const {
+  MALIPUT_PROFILE("maliput::api::Lane::ToInertialPosition");
+  return DoToInertialPosition(lane_pos);
+}
+
+LanePositionResult Lane::ToLanePosition(const InertialPosition& inertial_pos) const {
+  MALIPUT_PROFILE("maliput::api::Lane::ToLanePosition");
+  return DoToLanePosition(inertial_pos);
+}
+
+LanePositionResult Lane::ToSegmentPosition(const InertialPosition& inertial_pos) const {
+  MALIPUT_PROFILE("maliput::api::Lane::ToSegmentPosition");
+  return DoToSegmentPosition(inertial_pos);
+}
+
+Rotation Lane::GetOrientation(const LanePosition& lane_pos) const {
+  MALIPUT_PROFILE("maliput::api::Lane::GetOrientation");
+  return DoGetOrientation(lane_pos);
+}
+
+LanePosition Lane::EvalMotionDerivatives(const LanePosition& position, const IsoLaneVelocity& velocity) const {
+  MALIPUT_PROFILE("maliput::api::Lane::EvalMotionDerivatives");
+  return DoEvalMotionDerivatives(position, velocity);
+}
+
+const BranchPoint* Lane::GetBranchPoint(const LaneEnd::Which which_end) const {
+  MALIPUT_PROFILE("maliput::api::Lane::GetBranchPoint");
+  return DoGetBranchPoint(which_end);
+}
+
+const LaneEndSet* Lane::GetConfluentBranches(const LaneEnd::Which which_end) const {
+  MALIPUT_PROFILE("maliput::api::Lane::GetConfluentBranches");
+  return DoGetConfluentBranches(which_end);
+}
+
+const LaneEndSet* Lane::GetOngoingBranches(const LaneEnd::Which which_end) const {
+  MALIPUT_PROFILE("maliput::api::Lane::GetOngoingBranches");
+  return DoGetOngoingBranches(which_end);
+}
+
+std::optional<LaneEnd> Lane::GetDefaultBranch(const LaneEnd::Which which_end) const {
+  MALIPUT_PROFILE("maliput::api::Lane::GetDefaultBranch");
+  return DoGetDefaultBranch(which_end);
+}
+
 bool Lane::Contains(const LanePosition& lane_position) const {
+  MALIPUT_PROFILE("maliput::api::Lane::Contains");
   const double s = lane_position.s();
   const double r = lane_position.r();
   const double h = lane_position.h();

--- a/src/api/road_geometry.cc
+++ b/src/api/road_geometry.cc
@@ -42,6 +42,7 @@
 #include "maliput/api/regions.h"
 #include "maliput/api/segment.h"
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/profiler.h"
 
 namespace maliput {
 namespace api {
@@ -69,7 +70,32 @@ Rotation OrientationOutFromLane(const LaneEnd& lane_end) {
 
 }  // namespace
 
+RoadPositionResult RoadGeometry::ToRoadPosition(const InertialPosition& inertial_position,
+                                                const std::optional<RoadPosition>& hint) const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::ToRoadPosition");
+  return DoToRoadPosition(inertial_position, hint);
+}
+
+std::vector<RoadPositionResult> RoadGeometry::FindRoadPositions(const InertialPosition& inertial_position,
+                                                                double radius) const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::FindRoadPositions");
+  MALIPUT_THROW_UNLESS(radius >= 0.);
+  return DoFindRoadPositions(inertial_position, radius);
+}
+
+std::vector<InertialPosition> RoadGeometry::SampleAheadWaypoints(const LaneSRoute& lane_s_route,
+                                                                 double path_length_sampling_rate) const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::SampleAheadWaypoints");
+  return DoSampleAheadWaypoints(lane_s_route, path_length_sampling_rate);
+}
+
+math::Vector3 RoadGeometry::inertial_to_backend_frame_translation() const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::inertial_to_backend_frame_translation");
+  return do_inertial_to_backend_frame_translation();
+}
+
 std::vector<std::string> RoadGeometry::CheckInvariants() const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::CheckInvariants");
   std::vector<std::string> failures;
 
   // Verify correctness of back-pointers/indexing in object hierarchy.
@@ -217,6 +243,32 @@ std::vector<InertialPosition> RoadGeometry::DoSampleAheadWaypoints(const LaneSRo
     waypoints.emplace_back(last_lane->ToInertialPosition(LanePosition(ranges.back().s_range().s1(), 0.0, 0.0)));
   }
   return waypoints;
+}
+
+const Lane* RoadGeometry::IdIndex::GetLane(const LaneId& id) const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetLane");
+  return DoGetLane(id);
+}
+
+const std::unordered_map<LaneId, const Lane*>& RoadGeometry::IdIndex::GetLanes() const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetLanes");
+  return DoGetLanes();
+}
+
+const Segment* RoadGeometry::IdIndex::GetSegment(const SegmentId& id) const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetSegment");
+
+  return DoGetSegment(id);
+}
+
+const Junction* RoadGeometry::IdIndex::GetJunction(const JunctionId& id) const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetJunction");
+  return DoGetJunction(id);
+}
+
+const BranchPoint* RoadGeometry::IdIndex::GetBranchPoint(const BranchPointId& id) const {
+  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetBranchPoint");
+  return DoGetBranchPoint(id);
 }
 
 }  // namespace api

--- a/src/api/road_geometry.cc
+++ b/src/api/road_geometry.cc
@@ -72,30 +72,30 @@ Rotation OrientationOutFromLane(const LaneEnd& lane_end) {
 
 RoadPositionResult RoadGeometry::ToRoadPosition(const InertialPosition& inertial_position,
                                                 const std::optional<RoadPosition>& hint) const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::ToRoadPosition");
+  MALIPUT_PROFILE_FUNC();
   return DoToRoadPosition(inertial_position, hint);
 }
 
 std::vector<RoadPositionResult> RoadGeometry::FindRoadPositions(const InertialPosition& inertial_position,
                                                                 double radius) const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::FindRoadPositions");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_THROW_UNLESS(radius >= 0.);
   return DoFindRoadPositions(inertial_position, radius);
 }
 
 std::vector<InertialPosition> RoadGeometry::SampleAheadWaypoints(const LaneSRoute& lane_s_route,
                                                                  double path_length_sampling_rate) const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::SampleAheadWaypoints");
+  MALIPUT_PROFILE_FUNC();
   return DoSampleAheadWaypoints(lane_s_route, path_length_sampling_rate);
 }
 
 math::Vector3 RoadGeometry::inertial_to_backend_frame_translation() const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::inertial_to_backend_frame_translation");
+  MALIPUT_PROFILE_FUNC();
   return do_inertial_to_backend_frame_translation();
 }
 
 std::vector<std::string> RoadGeometry::CheckInvariants() const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::CheckInvariants");
+  MALIPUT_PROFILE_FUNC();
   std::vector<std::string> failures;
 
   // Verify correctness of back-pointers/indexing in object hierarchy.
@@ -246,28 +246,28 @@ std::vector<InertialPosition> RoadGeometry::DoSampleAheadWaypoints(const LaneSRo
 }
 
 const Lane* RoadGeometry::IdIndex::GetLane(const LaneId& id) const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetLane");
+  MALIPUT_PROFILE_FUNC();
   return DoGetLane(id);
 }
 
 const std::unordered_map<LaneId, const Lane*>& RoadGeometry::IdIndex::GetLanes() const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetLanes");
+  MALIPUT_PROFILE_FUNC();
   return DoGetLanes();
 }
 
 const Segment* RoadGeometry::IdIndex::GetSegment(const SegmentId& id) const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetSegment");
+  MALIPUT_PROFILE_FUNC();
 
   return DoGetSegment(id);
 }
 
 const Junction* RoadGeometry::IdIndex::GetJunction(const JunctionId& id) const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetJunction");
+  MALIPUT_PROFILE_FUNC();
   return DoGetJunction(id);
 }
 
 const BranchPoint* RoadGeometry::IdIndex::GetBranchPoint(const BranchPointId& id) const {
-  MALIPUT_PROFILE("maliput::api::RoadGeometry::IdIndex::GetBranchPoint");
+  MALIPUT_PROFILE_FUNC();
   return DoGetBranchPoint(id);
 }
 

--- a/src/routing/CMakeLists.txt
+++ b/src/routing/CMakeLists.txt
@@ -26,6 +26,13 @@ target_link_libraries(routing
     maliput::common
 )
 
+if(MALIPUT_PROFILER_ENABLE)
+  target_link_libraries(routing
+    PRIVATE
+      ignition-common3::profiler
+  )
+endif()
+
 ##############################################################################
 # Export
 ##############################################################################

--- a/src/routing/derive_lane_s_routes.cc
+++ b/src/routing/derive_lane_s_routes.cc
@@ -34,6 +34,7 @@
 #include "maliput/api/branch_point.h"
 #include "maliput/api/lane.h"
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/profiler.h"
 #include "maliput/routing/find_lane_sequences.h"
 
 namespace maliput {
@@ -68,6 +69,7 @@ std::optional<double> DetermineEdgeS(const api::Lane* lane, const api::Lane* nex
 
 std::vector<api::LaneSRoute> DeriveLaneSRoutes(const api::RoadPosition& start, const api::RoadPosition& end,
                                                double max_length_m) {
+  MALIPUT_PROFILE("maliput::routing::DeriveLaneSRoutes");
   MALIPUT_DEMAND(start.lane != nullptr);
   MALIPUT_DEMAND(end.lane != nullptr);
   const double start_s = start.pos.s();

--- a/src/routing/derive_lane_s_routes.cc
+++ b/src/routing/derive_lane_s_routes.cc
@@ -69,7 +69,7 @@ std::optional<double> DetermineEdgeS(const api::Lane* lane, const api::Lane* nex
 
 std::vector<api::LaneSRoute> DeriveLaneSRoutes(const api::RoadPosition& start, const api::RoadPosition& end,
                                                double max_length_m) {
-  MALIPUT_PROFILE("maliput::routing::DeriveLaneSRoutes");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_DEMAND(start.lane != nullptr);
   MALIPUT_DEMAND(end.lane != nullptr);
   const double start_s = start.pos.s();

--- a/src/routing/find_lane_sequences.cc
+++ b/src/routing/find_lane_sequences.cc
@@ -84,7 +84,7 @@ std::vector<std::vector<const Lane*>> FindLaneSequencesHelper(const Lane* start,
 }  // namespace
 
 std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane* start, const Lane* end, double max_length_m) {
-  MALIPUT_PROFILE("maliput::routing::FindLaneSequences");
+  MALIPUT_PROFILE_FUNC();
   if (start->id() == end->id()) {
     return {{start}};
   }

--- a/src/routing/find_lane_sequences.cc
+++ b/src/routing/find_lane_sequences.cc
@@ -31,6 +31,7 @@
 
 #include "maliput/api/branch_point.h"
 #include "maliput/api/lane_data.h"
+#include "maliput/common/profiler.h"
 
 using maliput::api::Lane;
 using maliput::api::LaneEnd;
@@ -83,6 +84,7 @@ std::vector<std::vector<const Lane*>> FindLaneSequencesHelper(const Lane* start,
 }  // namespace
 
 std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane* start, const Lane* end, double max_length_m) {
+  MALIPUT_PROFILE("maliput::routing::FindLaneSequences");
   if (start->id() == end->id()) {
     return {{start}};
   }

--- a/src/utility/CMakeLists.txt
+++ b/src/utility/CMakeLists.txt
@@ -29,6 +29,13 @@ target_link_libraries(utility
     maliput::math
 )
 
+if(MALIPUT_PROFILER_ENABLE)
+  target_link_libraries(utility
+    PRIVATE
+      ignition-common3::profiler
+  )
+endif()
+
 target_include_directories(utility
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/utility/generate_obj.cc
+++ b/src/utility/generate_obj.cc
@@ -48,6 +48,7 @@
 #include "maliput/api/segment.h"
 #include "maliput/common/logger.h"
 #include "maliput/common/maliput_abort.h"
+#include "maliput/common/profiler.h"
 #include "maliput/math/vector.h"
 #include "maliput/utility/mesh.h"
 #include "maliput/utility/mesh_simplification.h"
@@ -116,6 +117,7 @@ std::string FormatMaterial(const Material& mat, int precision) {
 // center, left most and right most lines of the `lane`'s segment
 // surface is bigger than `grid_unit` or the end of the `lane` is reached.
 double ComputeSampleStep(const maliput::api::Lane* lane, double s0, double grid_unit) {
+  MALIPUT_PROFILE("maliput::utility::ComputeSampleStep");
   MALIPUT_DEMAND(lane != nullptr);
 
   const double length = lane->length();
@@ -174,6 +176,7 @@ double ComputeSampleStep(const maliput::api::Lane* lane, double s0, double grid_
 // vertices.
 void GenerateOptimizedRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid_unit, bool use_segment_bounds,
                                const std::function<double(double, double)>& elevation) {
+  MALIPUT_PROFILE("maliput::utility::GenerateOptimizedRoadMesh");
   const double s_max = lane->length();
   for (double s0 = 0, s1; s0 < s_max; s0 = s1) {
     const double step_increment = ComputeSampleStep(lane, s0, grid_unit);
@@ -202,6 +205,7 @@ void GenerateOptimizedRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid
 
 void GeneratePreciseRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid_unit, bool use_segment_bounds,
                              const std::function<double(double, double)>& elevation) {
+  MALIPUT_PROFILE("maliput::utility::GeneratePreciseRoadMesh");
   const double linear_tolerance = lane->segment()->junction()->road_geometry()->linear_tolerance();
   const double s_max = lane->length();
   for (double s0 = 0, s1; s0 < s_max; s0 = s1) {
@@ -278,6 +282,7 @@ void GeneratePreciseRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid_u
 //        the corresponding elevation `h`, to yield a quad vertex `(s, r, h)`.
 void CoverLaneWithQuads(GeoMesh* mesh, const api::Lane* lane, double grid_unit, bool use_segment_bounds,
                         const std::function<double(double, double)>& elevation, bool optimize_generation) {
+  MALIPUT_PROFILE("maliput::utility::CoverLaneWithQuads");
   if (optimize_generation) {
     GenerateOptimizedRoadMesh(mesh, lane, grid_unit, use_segment_bounds, elevation);
   } else {
@@ -340,6 +345,7 @@ void StripeLaneBounds(GeoMesh* mesh, const api::Lane* lane, double grid_unit, do
 // @param h_offset  h value of each vertex (height above road surface)
 void DrawLaneArrow(GeoMesh* mesh, const api::Lane* lane, double grid_unit, double s_offset, double s_size,
                    double h_offset) {
+  MALIPUT_PROFILE("maliput::utility::DrawLaneArrow");
   MALIPUT_DEMAND(s_offset >= 0.);
   MALIPUT_DEMAND((s_offset + s_size) <= lane->length());
   const double kRelativeWidth = 0.8;
@@ -436,6 +442,7 @@ void DrawLaneArrow(GeoMesh* mesh, const api::Lane* lane, double grid_unit, doubl
 // @param grid_unit  size of each quad (length of edge in s and r dimensions)
 // @param h_offset  h value of each vertex (height above road surface)
 void MarkLaneEnds(GeoMesh* mesh, const api::Lane* lane, double grid_unit, double h_offset) {
+  MALIPUT_PROFILE("maliput::utility::MarkLaneEnds");
   // To avoid crossing boundaries (and tripping assertions) due to
   // numeric precision issues, we will nudge the arrows inward from
   // the ends of the lanes by the RoadGeometry's linear_tolerance().
@@ -469,6 +476,7 @@ void MarkLaneEnds(GeoMesh* mesh, const api::Lane* lane, double grid_unit, double
 // Note that @p max_size would be the maximum possible grid unit every time it
 // it is bigger than @p linear_tolerance.
 double PickGridUnit(const api::Lane* lane, double max_size, double min_resolution, double linear_tolerance) {
+  MALIPUT_PROFILE("maliput::utility::PickGridUnit");
   double result = max_size;
 
   const api::RBounds rb0 = lane->lane_bounds(0.);
@@ -498,6 +506,7 @@ double PickGridUnit(const api::Lane* lane, double max_size, double min_resolutio
 // @param as_diamond  whether a diamond shape is desired or not
 // @param mesh        the mesh to store the created shapes in
 void DrawBranch(double elevation, double height, const api::LaneEnd& lane_end, bool as_diamond, GeoMesh* mesh) {
+  MALIPUT_PROFILE("maliput::utility::DrawBranch");
   MALIPUT_THROW_UNLESS(mesh != nullptr && elevation >= 0 && height >= 0);
 
   static const double kWidthFactor = 0.1;
@@ -550,6 +559,7 @@ void DrawBranch(double elevation, double height, const api::LaneEnd& lane_end, b
 //                    for
 // @param mesh        the mesh to store the created shapes in
 void DrawArrows(double elevation, double height, const api::LaneEndSet* set, GeoMesh* mesh) {
+  MALIPUT_PROFILE("maliput::utility::DrawArrows");
   MALIPUT_THROW_UNLESS(set != nullptr && mesh != nullptr);
 
   for (int i = 0; i < set->size(); ++i) {
@@ -569,6 +579,7 @@ void DrawArrows(double elevation, double height, const api::LaneEndSet* set, Geo
 // center of this BranchPoint.
 void RenderBranchPoint(const api::BranchPoint* const branch_point, const double base_elevation, const double height,
                        GeoMesh* mesh, std::vector<api::InertialPosition>* previous_centers) {
+  MALIPUT_PROFILE("maliput::utility::RenderBranchPoint");
   if ((branch_point->GetASide()->size() == 0) && (branch_point->GetBSide()->size() == 0)) {
     // No branches?  Odd, but, oh, well... nothing to do here.
     return;
@@ -624,6 +635,7 @@ void RenderBranchPoint(const api::BranchPoint* const branch_point, const double 
 }
 
 GeoMesh SimplifyMesh(const GeoMesh& mesh, const ObjFeatures& features) {
+  MALIPUT_PROFILE("maliput::utility::SimplifyMesh");
   if (features.simplify_mesh_threshold == 0.) {
     return mesh;  // Passes given mesh unmodified.
   }
@@ -647,6 +659,7 @@ GeoMesh SimplifyMesh(const GeoMesh& mesh, const ObjFeatures& features) {
 // TODO(#392): Receive the RoadRulebook pointer to modify the mesh creation accordingly.
 void RenderSegment(const api::Segment* segment, const ObjFeatures& features, GeoMesh* asphalt_mesh, GeoMesh* lane_mesh,
                    GeoMesh* marker_mesh, GeoMesh* h_bounds_mesh, GeoMesh* sidewalk_mesh) {
+  MALIPUT_PROFILE("maliput::utility::RenderSegment");
   MALIPUT_THROW_UNLESS(segment != nullptr);
   MALIPUT_THROW_UNLESS(segment->junction() != nullptr);
   MALIPUT_THROW_UNLESS(segment->junction()->road_geometry() != nullptr);
@@ -777,6 +790,7 @@ Material GetMaterialFromMesh(const MaterialType mesh_material) {
 
 std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const ObjFeatures& features,
                                              const api::LaneId& lane_id, const MaterialType& mesh_material) {
+  MALIPUT_PROFILE("maliput::utility::BuildMesh(Lane)");
   MALIPUT_DEMAND(rg != nullptr);
   MALIPUT_THROW_UNLESS(mesh_material != MaterialType::BranchPointGlow);
 
@@ -864,6 +878,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
 std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const ObjFeatures& features,
                                              const api::BranchPointId& branch_point_id,
                                              const MaterialType& mesh_material) {
+  MALIPUT_PROFILE("maliput::utility::BuildMesh(BranchPoint)");
   MALIPUT_DEMAND(rg != nullptr);
   MALIPUT_THROW_UNLESS(mesh_material == MaterialType::BranchPointGlow);
 
@@ -884,6 +899,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
 
 std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const ObjFeatures& features,
                                              const api::SegmentId& segment_id, const MaterialType& mesh_material) {
+  MALIPUT_PROFILE("maliput::utility::BuildMesh(Segment)");
   MALIPUT_DEMAND(rg != nullptr);
   MALIPUT_THROW_UNLESS(mesh_material == MaterialType::Asphalt || mesh_material == MaterialType::GrayedAsphalt);
 
@@ -909,6 +925,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
 }
 
 RoadGeometryMesh BuildRoadGeometryMesh(const api::RoadGeometry* rg, const ObjFeatures& features) {
+  MALIPUT_PROFILE("maliput::utility::BuildRoadGeometryMesh");
   RoadGeometryMesh meshes;
 
   GeoMesh asphalt_mesh;
@@ -970,6 +987,7 @@ RoadGeometryMesh BuildRoadGeometryMesh(const api::RoadGeometry* rg, const ObjFea
 
 std::map<std::string, std::pair<mesh::GeoMesh, Material>> BuildMeshes(const api::RoadGeometry* rg,
                                                                       const ObjFeatures& features) {
+  MALIPUT_PROFILE("maliput::utility::BuildMeshes");
   MALIPUT_THROW_UNLESS(rg != nullptr);
   maliput::log()->trace("Building Meshes for RoadGeometry id {}...", rg->id().string());
 
@@ -1046,6 +1064,7 @@ std::map<std::string, std::pair<mesh::GeoMesh, Material>> BuildMeshes(const api:
 
 void GenerateObjFile(const api::RoadGeometry* rg, const std::string& dirpath, const std::string& fileroot,
                      const ObjFeatures& features) {
+  MALIPUT_PROFILE("maliput::utility::GenerateObjFile");
   MALIPUT_THROW_UNLESS(rg != nullptr);
 
   std::map<std::string, std::pair<mesh::GeoMesh, Material>> meshes = BuildMeshes(rg, features);
@@ -1067,6 +1086,7 @@ void GenerateObjFile(const api::RoadGeometry* rg, const std::string& dirpath, co
 
   // Create the requested OBJ file.
   {
+    // MALIPUT_PROFILE("maliput::utility::GenerateObjFile: Create the requested OBJ fil");
     // Figure out the fixed-point precision necessary to render OBJ vertices
     // with enough precision relative to linear_tolerance().
     //

--- a/src/utility/generate_obj.cc
+++ b/src/utility/generate_obj.cc
@@ -117,7 +117,7 @@ std::string FormatMaterial(const Material& mat, int precision) {
 // center, left most and right most lines of the `lane`'s segment
 // surface is bigger than `grid_unit` or the end of the `lane` is reached.
 double ComputeSampleStep(const maliput::api::Lane* lane, double s0, double grid_unit) {
-  MALIPUT_PROFILE("maliput::utility::ComputeSampleStep");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_DEMAND(lane != nullptr);
 
   const double length = lane->length();
@@ -176,7 +176,7 @@ double ComputeSampleStep(const maliput::api::Lane* lane, double s0, double grid_
 // vertices.
 void GenerateOptimizedRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid_unit, bool use_segment_bounds,
                                const std::function<double(double, double)>& elevation) {
-  MALIPUT_PROFILE("maliput::utility::GenerateOptimizedRoadMesh");
+  MALIPUT_PROFILE_FUNC();
   const double s_max = lane->length();
   for (double s0 = 0, s1; s0 < s_max; s0 = s1) {
     const double step_increment = ComputeSampleStep(lane, s0, grid_unit);
@@ -205,7 +205,7 @@ void GenerateOptimizedRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid
 
 void GeneratePreciseRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid_unit, bool use_segment_bounds,
                              const std::function<double(double, double)>& elevation) {
-  MALIPUT_PROFILE("maliput::utility::GeneratePreciseRoadMesh");
+  MALIPUT_PROFILE_FUNC();
   const double linear_tolerance = lane->segment()->junction()->road_geometry()->linear_tolerance();
   const double s_max = lane->length();
   for (double s0 = 0, s1; s0 < s_max; s0 = s1) {
@@ -282,7 +282,7 @@ void GeneratePreciseRoadMesh(GeoMesh* mesh, const api::Lane* lane, double grid_u
 //        the corresponding elevation `h`, to yield a quad vertex `(s, r, h)`.
 void CoverLaneWithQuads(GeoMesh* mesh, const api::Lane* lane, double grid_unit, bool use_segment_bounds,
                         const std::function<double(double, double)>& elevation, bool optimize_generation) {
-  MALIPUT_PROFILE("maliput::utility::CoverLaneWithQuads");
+  MALIPUT_PROFILE_FUNC();
   if (optimize_generation) {
     GenerateOptimizedRoadMesh(mesh, lane, grid_unit, use_segment_bounds, elevation);
   } else {
@@ -345,7 +345,7 @@ void StripeLaneBounds(GeoMesh* mesh, const api::Lane* lane, double grid_unit, do
 // @param h_offset  h value of each vertex (height above road surface)
 void DrawLaneArrow(GeoMesh* mesh, const api::Lane* lane, double grid_unit, double s_offset, double s_size,
                    double h_offset) {
-  MALIPUT_PROFILE("maliput::utility::DrawLaneArrow");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_DEMAND(s_offset >= 0.);
   MALIPUT_DEMAND((s_offset + s_size) <= lane->length());
   const double kRelativeWidth = 0.8;
@@ -442,7 +442,7 @@ void DrawLaneArrow(GeoMesh* mesh, const api::Lane* lane, double grid_unit, doubl
 // @param grid_unit  size of each quad (length of edge in s and r dimensions)
 // @param h_offset  h value of each vertex (height above road surface)
 void MarkLaneEnds(GeoMesh* mesh, const api::Lane* lane, double grid_unit, double h_offset) {
-  MALIPUT_PROFILE("maliput::utility::MarkLaneEnds");
+  MALIPUT_PROFILE_FUNC();
   // To avoid crossing boundaries (and tripping assertions) due to
   // numeric precision issues, we will nudge the arrows inward from
   // the ends of the lanes by the RoadGeometry's linear_tolerance().
@@ -476,7 +476,7 @@ void MarkLaneEnds(GeoMesh* mesh, const api::Lane* lane, double grid_unit, double
 // Note that @p max_size would be the maximum possible grid unit every time it
 // it is bigger than @p linear_tolerance.
 double PickGridUnit(const api::Lane* lane, double max_size, double min_resolution, double linear_tolerance) {
-  MALIPUT_PROFILE("maliput::utility::PickGridUnit");
+  MALIPUT_PROFILE_FUNC();
   double result = max_size;
 
   const api::RBounds rb0 = lane->lane_bounds(0.);
@@ -506,7 +506,7 @@ double PickGridUnit(const api::Lane* lane, double max_size, double min_resolutio
 // @param as_diamond  whether a diamond shape is desired or not
 // @param mesh        the mesh to store the created shapes in
 void DrawBranch(double elevation, double height, const api::LaneEnd& lane_end, bool as_diamond, GeoMesh* mesh) {
-  MALIPUT_PROFILE("maliput::utility::DrawBranch");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_THROW_UNLESS(mesh != nullptr && elevation >= 0 && height >= 0);
 
   static const double kWidthFactor = 0.1;
@@ -559,7 +559,7 @@ void DrawBranch(double elevation, double height, const api::LaneEnd& lane_end, b
 //                    for
 // @param mesh        the mesh to store the created shapes in
 void DrawArrows(double elevation, double height, const api::LaneEndSet* set, GeoMesh* mesh) {
-  MALIPUT_PROFILE("maliput::utility::DrawArrows");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_THROW_UNLESS(set != nullptr && mesh != nullptr);
 
   for (int i = 0; i < set->size(); ++i) {
@@ -579,7 +579,7 @@ void DrawArrows(double elevation, double height, const api::LaneEndSet* set, Geo
 // center of this BranchPoint.
 void RenderBranchPoint(const api::BranchPoint* const branch_point, const double base_elevation, const double height,
                        GeoMesh* mesh, std::vector<api::InertialPosition>* previous_centers) {
-  MALIPUT_PROFILE("maliput::utility::RenderBranchPoint");
+  MALIPUT_PROFILE_FUNC();
   if ((branch_point->GetASide()->size() == 0) && (branch_point->GetBSide()->size() == 0)) {
     // No branches?  Odd, but, oh, well... nothing to do here.
     return;
@@ -635,7 +635,7 @@ void RenderBranchPoint(const api::BranchPoint* const branch_point, const double 
 }
 
 GeoMesh SimplifyMesh(const GeoMesh& mesh, const ObjFeatures& features) {
-  MALIPUT_PROFILE("maliput::utility::SimplifyMesh");
+  MALIPUT_PROFILE_FUNC();
   if (features.simplify_mesh_threshold == 0.) {
     return mesh;  // Passes given mesh unmodified.
   }
@@ -659,7 +659,7 @@ GeoMesh SimplifyMesh(const GeoMesh& mesh, const ObjFeatures& features) {
 // TODO(#392): Receive the RoadRulebook pointer to modify the mesh creation accordingly.
 void RenderSegment(const api::Segment* segment, const ObjFeatures& features, GeoMesh* asphalt_mesh, GeoMesh* lane_mesh,
                    GeoMesh* marker_mesh, GeoMesh* h_bounds_mesh, GeoMesh* sidewalk_mesh) {
-  MALIPUT_PROFILE("maliput::utility::RenderSegment");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_THROW_UNLESS(segment != nullptr);
   MALIPUT_THROW_UNLESS(segment->junction() != nullptr);
   MALIPUT_THROW_UNLESS(segment->junction()->road_geometry() != nullptr);
@@ -790,7 +790,7 @@ Material GetMaterialFromMesh(const MaterialType mesh_material) {
 
 std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const ObjFeatures& features,
                                              const api::LaneId& lane_id, const MaterialType& mesh_material) {
-  MALIPUT_PROFILE("maliput::utility::BuildMesh(Lane)");
+  MALIPUT_PROFILE("BuildMesh: For lanes");
   MALIPUT_DEMAND(rg != nullptr);
   MALIPUT_THROW_UNLESS(mesh_material != MaterialType::BranchPointGlow);
 
@@ -878,7 +878,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
 std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const ObjFeatures& features,
                                              const api::BranchPointId& branch_point_id,
                                              const MaterialType& mesh_material) {
-  MALIPUT_PROFILE("maliput::utility::BuildMesh(BranchPoint)");
+  MALIPUT_PROFILE("BuildMesh: For BranchPoints");
   MALIPUT_DEMAND(rg != nullptr);
   MALIPUT_THROW_UNLESS(mesh_material == MaterialType::BranchPointGlow);
 
@@ -899,7 +899,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
 
 std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const ObjFeatures& features,
                                              const api::SegmentId& segment_id, const MaterialType& mesh_material) {
-  MALIPUT_PROFILE("maliput::utility::BuildMesh(Segment)");
+  MALIPUT_PROFILE("BuildMesh: For Segments");
   MALIPUT_DEMAND(rg != nullptr);
   MALIPUT_THROW_UNLESS(mesh_material == MaterialType::Asphalt || mesh_material == MaterialType::GrayedAsphalt);
 
@@ -925,7 +925,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
 }
 
 RoadGeometryMesh BuildRoadGeometryMesh(const api::RoadGeometry* rg, const ObjFeatures& features) {
-  MALIPUT_PROFILE("maliput::utility::BuildRoadGeometryMesh");
+  MALIPUT_PROFILE_FUNC();
   RoadGeometryMesh meshes;
 
   GeoMesh asphalt_mesh;
@@ -987,7 +987,7 @@ RoadGeometryMesh BuildRoadGeometryMesh(const api::RoadGeometry* rg, const ObjFea
 
 std::map<std::string, std::pair<mesh::GeoMesh, Material>> BuildMeshes(const api::RoadGeometry* rg,
                                                                       const ObjFeatures& features) {
-  MALIPUT_PROFILE("maliput::utility::BuildMeshes");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_THROW_UNLESS(rg != nullptr);
   maliput::log()->trace("Building Meshes for RoadGeometry id {}...", rg->id().string());
 
@@ -1064,7 +1064,7 @@ std::map<std::string, std::pair<mesh::GeoMesh, Material>> BuildMeshes(const api:
 
 void GenerateObjFile(const api::RoadGeometry* rg, const std::string& dirpath, const std::string& fileroot,
                      const ObjFeatures& features) {
-  MALIPUT_PROFILE("maliput::utility::GenerateObjFile");
+  MALIPUT_PROFILE_FUNC();
   MALIPUT_THROW_UNLESS(rg != nullptr);
 
   std::map<std::string, std::pair<mesh::GeoMesh, Material>> meshes = BuildMeshes(rg, features);
@@ -1086,7 +1086,6 @@ void GenerateObjFile(const api::RoadGeometry* rg, const std::string& dirpath, co
 
   // Create the requested OBJ file.
   {
-    // MALIPUT_PROFILE("maliput::utility::GenerateObjFile: Create the requested OBJ fil");
     // Figure out the fixed-point precision necessary to render OBJ vertices
     // with enough precision relative to linear_tolerance().
     //

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -5,6 +5,7 @@ ament_add_gtest(maliput_hash_test maliput_hash_test.cc)
 ament_add_gtest(maliput_never_destroyed_test maliput_never_destroyed_test.cc)
 ament_add_gtest(maliput_throw_test maliput_throw_test.cc)
 ament_add_gtest(range_validator_test range_validator_test.cc)
+ament_add_gtest(profiler_test profiler_test.cc)
 
 macro(add_dependencies_to_test target)
     if (TARGET ${target})
@@ -30,6 +31,13 @@ add_dependencies_to_test(maliput_hash_test)
 add_dependencies_to_test(maliput_never_destroyed_test)
 add_dependencies_to_test(maliput_throw_test)
 add_dependencies_to_test(range_validator_test)
+add_dependencies_to_test(profiler_test)
+
+if(MALIPUT_PROFILER_ENABLE)
+  target_link_libraries(profiler_test
+      ignition-common3::profiler
+  )
+endif()
 
 # TODO(#335): When a sanitizer is enabled, tests where assert are checked are disabled.
 if (NOT ${SANITIZERS})

--- a/test/common/profiler_test.cc
+++ b/test/common/profiler_test.cc
@@ -1,0 +1,51 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput/common/profiler.h"
+
+#include <gtest/gtest.h>
+
+namespace maliput {
+namespace common {
+namespace test {
+namespace {
+
+// By default the profiler is disabled and it is not expected to be enabled in production.
+GTEST_TEST(Profiler, TestDefaultValue) {
+#if MALIPUT_PROFILER_ENABLE
+  EXPECT_TRUE(MALIPUT_PROFILER_VALID);
+#else
+  EXPECT_FALSE(MALIPUT_PROFILER_VALID);
+#endif
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace common
+}  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

## Summary

It adds a profiler to maliput's api.
 - By default it is disabled, for enabling maliput should be compiled using `MALIPUT_PROFILER_ENABLE` cmake argument
 - It is not causing any performance drop when it is disabled as the correct use of macros/defines is implemented.
 - It relies on ign-common's profiler component.
 - No hard dependency:
   - Dependency is only added if the argument above is passed.
   - Dependency is not replicated downstream to avoid recompiling in downstream packages.
 - README is updated to help enabling the profiler.
 - Code being profiled(more could be covered in the future if necessity arises):
   - API
     - RoadGeometry
     - Lane
   - routing
   - utility::generateobj

## For reviewers
- Commits added to facilitate revision, review commit by commit!

## Test it
- `sudo apt install libignition-common3-dev`
- Compile from source
- Run `delphyne_gazoo`
   - Or `delphyne_gazoo -m maliput_osm`
- Run `ign_remotery_viz`

![image](https://user-images.githubusercontent.com/53065142/213566805-e7ceb1d8-c9d9-4462-887e-c9810232f93c.png)


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

