### PR TITLE
Fixes logger-level-0ff behavior.

### DIFF
--- a/include/maliput/common/logger.h
+++ b/include/maliput/common/logger.h
@@ -77,13 +77,13 @@ namespace logger {
 
 /// Logging levels.
 enum level {
-  off = 0,
-  trace,
+  trace = 0,
   debug,
   info,
   warn,
   error,
   critical,
+  off,
   unchanged,
 };
 

--- a/test/common/logger_test.cc
+++ b/test/common/logger_test.cc
@@ -144,6 +144,13 @@ TEST_F(LoggingMesagesTest, CriticalLog) {
   EXPECT_EQ(mock_sink_ptr->get_log_message(), expected_message);
 }
 
+TEST_F(LoggingMesagesTest, OffLevelLog) {
+  log()->set_level(logger::level::off);
+  const std::string expected_empty_message{};
+  log()->critical(kMessage1, kMessage2, kPI);
+  EXPECT_EQ(mock_sink_ptr->get_log_message(), expected_empty_message);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace common


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #539 

## Summary
Off-level wasn't disabling the logger output.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
