### PR TITLE
Adds dimension static const to vector class.

### DIFF
--- a/include/maliput/math/vector.h
+++ b/include/maliput/math/vector.h
@@ -54,6 +54,9 @@ template <std::size_t N, typename Derived>
 class VectorBase {
   // TODO(francocipollone): Move VectorBase to a VectorBase.h header.
  public:
+  /// The dimension of the vector.
+  static constexpr std::size_t kDimension{N};
+
   /// @return An N-dimensional vector filled with zeros.
   static Derived Zero();
 
@@ -165,7 +168,7 @@ class VectorBase {
 
 /// A N-dimensional vector.
 /// @tparam N Is the dimension of the vector.
-template <size_t N>
+template <std::size_t N>
 class Vector : public VectorBase<N, Vector<N>> {
  public:
   /// Constructs a null N-dimensional vector.

--- a/test/math/vector_test.cc
+++ b/test/math/vector_test.cc
@@ -40,11 +40,13 @@ GTEST_TEST(VectorTest, Constructors) {
     EXPECT_EQ(Vector<2>({0., 0.}), Vector<2>());
     EXPECT_EQ(Vector<2>({5., 98.}), Vector<2>({5., 98.}));
     EXPECT_EQ(Vector<2>({1., 2.}), Vector<2>(std::array<double, 2>{1., 2.}));
+    EXPECT_EQ(static_cast<std::size_t>(2), Vector<2>::kDimension);
   }
   {  // 2- dimension vector.
     EXPECT_EQ(Vector2(0., 0.), Vector2());
     EXPECT_EQ(Vector2(5., 98.), Vector2({5., 98.}));
     EXPECT_EQ(Vector2(1., 2.), Vector2(std::array<double, 2>{1., 2.}));
+    EXPECT_EQ(static_cast<std::size_t>(2), Vector2::kDimension);
     {
       const Vector2 kExpected{3., 4.};
       const Vector2 kDut = kExpected;
@@ -60,6 +62,7 @@ GTEST_TEST(VectorTest, Constructors) {
     EXPECT_EQ(Vector3(0., 0., 0.), Vector3());
     EXPECT_EQ(Vector3(5., 98., -35.), Vector3({5., 98., -35.}));
     EXPECT_EQ(Vector3(1., 2., 3.), Vector3(std::array<double, 3>{1., 2., 3.}));
+    EXPECT_EQ(static_cast<std::size_t>(3), Vector3::kDimension);
     {
       const Vector3 kExpected{3., 4., 1.};
       const Vector3 kDut = kExpected;
@@ -75,6 +78,7 @@ GTEST_TEST(VectorTest, Constructors) {
     EXPECT_EQ(Vector4(0., 0., 0., 0.), Vector4());
     EXPECT_EQ(Vector4(5., 98., -35., 56.), Vector4({5., 98., -35., 56.}));
     EXPECT_EQ(Vector4(1., 2., 3., 4.), Vector4(std::array<double, 4>{1., 2., 3., 4.}));
+    EXPECT_EQ(static_cast<std::size_t>(4), Vector4::kDimension);
     {
       const Vector4 kExpected{3., 4., 1., 10.};
       const Vector4 kDut = kExpected;


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_sparse/pull/52

## Summary
Adds a kDimension static constexpr to the vector class.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
