### PR TITLE
Provides LaneSRange::GetIntersection method.

### DIFF
--- a/include/maliput/api/regions.h
+++ b/include/maliput/api/regions.h
@@ -118,6 +118,10 @@ class LaneSRange {
   /// and reducing the minimum each range. When `tolerance` is negative, it shrinks both ranges.
   bool Intersects(const LaneSRange& lane_s_range, double tolerance) const;
 
+  /// Returns a std::optional<LaneSRange> bearing the intersected LaneSRange that results overlapping
+  /// this LaneSRange with `lane_s_range`. When there is no common area, std::nullopt is returned.
+  std::optional<LaneSRange> GetIntersection(const LaneSRange& lane_s_range, double tolerance) const;
+
  private:
   LaneId lane_id_;
   SRange s_range_;

--- a/src/api/regions.cc
+++ b/src/api/regions.cc
@@ -108,6 +108,15 @@ bool LaneSRange::Intersects(const LaneSRange& lane_s_range, const double toleran
   return lane_id_ == lane_s_range.lane_id() ? s_range_.Intersects(lane_s_range.s_range(), tolerance) : false;
 }
 
+std::optional<LaneSRange> LaneSRange::GetIntersection(const LaneSRange& lane_s_range, double tolerance) const {
+  if (Intersects(lane_s_range, tolerance)) {
+    const auto intersection = s_range_.GetIntersection(lane_s_range.s_range(), tolerance);
+    MALIPUT_THROW_UNLESS(intersection.has_value());
+    return std::optional<LaneSRange>{LaneSRange(lane_id_, intersection.value())};
+  }
+  return std::nullopt;
+}
+
 bool LaneSRoute::Intersects(const LaneSRoute& lane_s_route, double tolerance) const {
   for (const auto& s_range : ranges()) {
     const auto lane_s_range_it =

--- a/test/api/regions_test.cc
+++ b/test/api/regions_test.cc
@@ -207,6 +207,24 @@ GTEST_TEST(LaneSRangeTest, Intersects) {
   EXPECT_FALSE(lane_s_range_a.Intersects(LaneSRange{kLaneId3, SRange(70., 10.)}, kLinearTolerance));
 }
 
+GTEST_TEST(LaneSRangeTest, GetIntersection) {
+  const LaneSRange lane_s_range_a(kLaneId1, SRange(20., 30.));
+
+  // Different lane id. No intersection is expected
+  auto dut = lane_s_range_a.GetIntersection(LaneSRange{kLaneId2, SRange(25., 35.)}, kLinearTolerance);
+  EXPECT_FALSE(dut.has_value());
+
+  // Intersection is expected.
+  LaneSRange expected_intersection{kLaneId1, SRange(25., 30.)};
+  dut = lane_s_range_a.GetIntersection(LaneSRange{kLaneId1, SRange(25., 35.)}, kLinearTolerance);
+  ASSERT_TRUE(dut.has_value());
+  EXPECT_TRUE(MALIPUT_REGIONS_IS_EQUAL(dut.value(), expected_intersection));
+
+  // Same lane id, different range. No intersection is expected.
+  dut = lane_s_range_a.GetIntersection(LaneSRange{kLaneId1, SRange(35., 40.)}, kLinearTolerance);
+  EXPECT_FALSE(dut.has_value());
+}
+
 class LaneSRouteTest : public ::testing::Test {
  protected:
   void SetUp() override {


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/maliput/maliput/issues/453

## Summary
Provides a `LaneSRange::GetIntersection` method.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

