### PR TITLE
Route part two

### DIFF
--- a/include/maliput/routing/lane_s_range_relation.h
+++ b/include/maliput/routing/lane_s_range_relation.h
@@ -33,8 +33,10 @@ namespace routing {
 
 /// Defines the possible relationships the routing API can interpret between
 /// two api::LaneSRanges within a Route.
-/// Relations described in this enum must be mutually exclusive. The following
-/// ASCII art helps to understand the relative relations described below.
+/// Relations described in this enum must be mutually exclusive and comprehensive, i.e.,
+/// exactly one relation will apply for any given pair of `LaneSRange` objects.
+///
+/// The following ASCII art helps to understand the relative relations described below.
 ///
 /// <pre>
 ///
@@ -51,6 +53,7 @@ namespace routing {
 /// - The letters name the api::LaneSRanges in the Route.
 ///
 /// Thus,
+/// - `A` is LaneSRangeRelation::kCoincident with `A`.
 /// - `A` is LaneSRangeRelation::kAdjacentLeft of `B`.
 /// - `B` is LaneSRangeRelation::kAdjacentRight of `A`.
 /// - `A` is LaneSRangeRelation::kLeft of `D`.
@@ -65,6 +68,7 @@ namespace routing {
 ///
 /// LaneSRangeRelation::kUnknown represents the case when any of the
 /// api::LaneSRanges is not found in the Route.
+// TODO(#543): revisit the need of kAdjacentLeft and kAdjacentRight.
 enum class LaneSRangeRelation {
   kAdjacentLeft,
   kAdjacentRight,
@@ -76,6 +80,7 @@ enum class LaneSRangeRelation {
   kPreceedingStraight,
   kPreceedingLeft,
   kPreceedingRight,
+  kCoincident,
   kUnrelated,
   kUnknown,
 };
@@ -93,6 +98,7 @@ inline std::map<LaneSRangeRelation, const char*> LaneSRangeRelationMapper() {
       {LaneSRangeRelation::kPreceedingStraight, "kPreceedingStraight"},
       {LaneSRangeRelation::kPreceedingLeft, "kPreceedingLeft"},
       {LaneSRangeRelation::kPreceedingRight, "kPreceedingRight"},
+      {LaneSRangeRelation::kCoincident, "kCoincident"},
       {LaneSRangeRelation::kUnrelated, "kUnrelated"},
       {LaneSRangeRelation::kUnknown, "kUnknown"},
   };

--- a/include/maliput/routing/phase.h
+++ b/include/maliput/routing/phase.h
@@ -74,9 +74,9 @@ class Phase final {
   /// @param end_position The end api::RoadPositions of this
   /// Phase. Each api::RoadPosition must be valid and it must be in
   /// @p lane_s_ranges. There must be at least one api::RoadPosition.
-  /// @param lane_s_ranges List of api::LaneSRanges. It must not be empty, all
-  /// elements must exist in @p road_network and should be consecutively
-  /// adjacent.
+  /// @param lane_s_ranges A right-to-left (see api::Segment semantics) ordered
+  /// list of api::LaneSRanges. It must not be empty, all elements must exist
+  /// in @p road_network and should be consecutively adjacent and ordered.
   /// @param road_network The pointer to the api::RoadNetwork. It must
   /// not be nullptr. The lifetime of this pointer must exceed that of this
   /// object.
@@ -95,7 +95,7 @@ class Phase final {
   /// positions in @p lane_s_ranges.
   /// @throws common::assertion_error When @p lane_s_ranges is empty.
   /// @throws common::assertion_error When @p lane_s_ranges contains
-  /// non-adjacent consecutive api::LaneSRanges.
+  /// non-adjacent or ordered consecutive api::LaneSRanges.
   /// @throws common::assertion_error When @p lane_s_ranges contains
   /// api::LaneSRanges that do not exist in @p road_network.
   /// @throws common::assertion_error When @p road_network is nullptr.

--- a/include/maliput/routing/route.h
+++ b/include/maliput/routing/route.h
@@ -28,9 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <optional>
+#include <utility>
 #include <vector>
 
 #include "maliput/api/lane_data.h"
+#include "maliput/api/regions.h"
 #include "maliput/api/road_network.h"
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/common/maliput_throw.h"
@@ -184,17 +187,15 @@ class Route final {
   /// valid.
   RoutePositionResult FindRoutePosition(const api::RoadPosition& road_position) const;
 
-  /// Finds the relation between @p lane_s_range_b with respect to
+  /// Computes the relation between @p lane_s_range_b with respect to
   /// @p lane_s_range_a.
   ///
   /// @param lane_s_range_a An api::LaneSRange.
   /// @param lane_s_range_b An api::LaneSRange.
   /// @return The LaneSRangeRelation between @p lane_s_range_b with respect to
   /// @p lane_s_range_a.
-  LaneSRangeRelation LaneSRangeRelationFor(const api::LaneSRange& lane_s_range_a,
-                                           const api::LaneSRange& lane_s_range_b) const {
-    MALIPUT_THROW_MESSAGE("Unimplemented");
-  }
+  LaneSRangeRelation ComputeLaneSRangeRelation(const api::LaneSRange& lane_s_range_a,
+                                               const api::LaneSRange& lane_s_range_b) const;
 
   /// Computes an api::LaneSRoute that connects @p start_position with
   /// end_route_position().
@@ -215,6 +216,21 @@ class Route final {
   }
 
  private:
+  // Type alias to index an api::LaneSRange within this Route.
+  // std::pair::first indexes the RoutePhase.
+  // std::pair::second indexes the api::LaneSRange in the RoutePhase.
+  using LaneSRangeIndex = std::pair<size_t, size_t>;
+
+  // Finds the LaneSRangeIndex for an api::LaneSRange.
+  //
+  // To provide a match, @p lane_s_range must be within RoadNetwork's tolerance
+  // of any of the existing api::LaneSRanges within this Route.
+  //
+  // @param lane_s_range The api::LaneSRange to look for.
+  // @return An optional containing the index of the api::LaneSRange within this
+  // Route.
+  std::optional<LaneSRangeIndex> FindLaneSRangeIndex(const api::LaneSRange& lane_s_range) const;
+
   std::vector<Phase> phases_;
   const api::RoadNetwork* road_network_{};
 };

--- a/src/routing/route.cc
+++ b/src/routing/route.cc
@@ -92,5 +92,129 @@ RoutePositionResult Route::FindRoutePosition(const api::RoadPosition& road_posit
   return RoutePositionResult{phase_index, route_phase_it->FindPhasePosition(road_position)};
 }
 
+namespace {
+
+enum class RelativePosition { kLeft = 0, kCenter, kRight };
+
+RelativePosition ComputeRelativePositionFor(const api::RoadPosition& pos_a, const api::RoadPosition& pos_b,
+                                            double tolerance) {
+  const api::InertialPosition inerital_pos_a = pos_a.lane->ToInertialPosition(pos_a.pos);
+  const api::InertialPosition inerital_pos_b = pos_b.lane->ToInertialPosition(pos_b.pos);
+
+  // When points are within tolerance, they are considered the same.
+  const math::Vector3 b_to_a = inerital_pos_b.xyz() - inerital_pos_a.xyz();
+  if (b_to_a.norm() <= tolerance) {
+    return RelativePosition::kCenter;
+  }
+
+  const api::Rotation inertial_rotation_a = pos_a.lane->GetOrientation(pos_a.pos);
+  const math::Vector3& s_hat_a = inertial_rotation_a.Apply({1., 0., 0.}).xyz();
+  const math::Vector3& h_hat_a = inertial_rotation_a.Apply({0., 0., 1.}).xyz();
+
+  const math::Vector3 norm_b_to_a = (inerital_pos_b.xyz() - inerital_pos_a.xyz()).normalized();
+
+  const bool is_to_left = s_hat_a.cross(norm_b_to_a).dot(h_hat_a) > 0.;
+  return is_to_left ? RelativePosition::kLeft : RelativePosition::kRight;
+}
+
+}  // namespace
+
+LaneSRangeRelation Route::ComputeLaneSRangeRelation(const api::LaneSRange& lane_s_range_a,
+                                                    const api::LaneSRange& lane_s_range_b) const {
+  // Find index of lane_s_range_a and lane_s_range_b.
+  const std::optional<LaneSRangeIndex> lane_s_range_a_index = FindLaneSRangeIndex(lane_s_range_a);
+  const std::optional<LaneSRangeIndex> lane_s_range_b_index = FindLaneSRangeIndex(lane_s_range_b);
+
+  // Determine whether lane_s_range_a and lane_s_range_b are in the same Route.
+  if (!lane_s_range_a_index.has_value() || !lane_s_range_b_index.has_value()) {
+    return LaneSRangeRelation::kUnknown;
+  }
+
+  // lane_s_range_b is unrelated to lane_s_range_a since they are in non-adjacent phases.
+  if (lane_s_range_a_index->first > lane_s_range_b_index->first + 1 ||
+      lane_s_range_b_index->first > lane_s_range_a_index->first + 1) {
+    return LaneSRangeRelation::kUnrelated;
+  }
+
+  const size_t lane_s_range_b_next_index = lane_s_range_b_index->second + 1;
+  const size_t lane_s_range_b_previous_index = lane_s_range_b_index->second - 1;
+
+  // When both phase indices are the same, we should look into the indices for the lane_s_ranges.
+  if (lane_s_range_a_index->first == lane_s_range_b_index->first) {
+    if (lane_s_range_a_index->second == lane_s_range_b_index->second) {
+      return LaneSRangeRelation::kCoincident;
+    } else if (lane_s_range_a_index->second == lane_s_range_b_next_index) {
+      return LaneSRangeRelation::kAdjacentRight;
+    } else if (lane_s_range_a_index->second > lane_s_range_b_next_index) {
+      return LaneSRangeRelation::kRight;
+    } else if (lane_s_range_a_index->second == lane_s_range_b_previous_index) {
+      return LaneSRangeRelation::kAdjacentLeft;
+    } else {  // (lane_s_range_a_index->second < lane_s_range_b_previous_index)
+      return LaneSRangeRelation::kLeft;
+    }
+  }
+
+  auto get_lane_s_range_road_position = [&](size_t route_phase_index, size_t lane_range_index, bool start) {
+    const auto& lane_s_range = phases_[route_phase_index].lane_s_ranges()[lane_range_index];
+    const api::Lane* lane = road_network_->road_geometry()->ById().GetLane(lane_s_range.lane_id());
+    return api::RoadPosition(
+        lane, api::LanePosition(start ? lane_s_range.s_range().s0() : lane_s_range.s_range().s1(), 0., 0.));
+  };
+
+  static constexpr bool kStart{true};
+  static constexpr bool kEnd{!kStart};
+  static constexpr std::array<LaneSRangeRelation, 3> kRelativePositionToSuceedingLaneSRange{
+      LaneSRangeRelation::kSucceedingLeft, LaneSRangeRelation::kSucceedingStraight,
+      LaneSRangeRelation::kSucceedingRight};
+  static constexpr std::array<LaneSRangeRelation, 3> kRelativePositionToPreceedingLaneSRange{
+      LaneSRangeRelation::kPreceedingLeft, LaneSRangeRelation::kPreceedingStraight,
+      LaneSRangeRelation::kPreceedingRight};
+  const double tolerance = road_network_->road_geometry()->linear_tolerance();
+
+  // Determine whether lane_s_range_b is ahead of lane_s_range_a.
+  if (lane_s_range_a_index->first == lane_s_range_b_index->first - 1) {
+    const api::RoadPosition lane_s_range_a_road_pos =
+        get_lane_s_range_road_position(lane_s_range_a_index->first, lane_s_range_a_index->second, kEnd);
+    const api::RoadPosition lane_s_range_b_road_pos =
+        get_lane_s_range_road_position(lane_s_range_b_index->first, lane_s_range_b_index->second, kStart);
+
+    return kRelativePositionToSuceedingLaneSRange[static_cast<size_t>(
+        ComputeRelativePositionFor(lane_s_range_a_road_pos, lane_s_range_b_road_pos, tolerance))];
+  }
+
+  // lane_s_range_b is behind of lane_s_range_a.
+  // lane_s_range_a_index->first == lane_s_range_b_index->first - 1
+  const api::RoadPosition lane_s_range_a_road_pos =
+      get_lane_s_range_road_position(lane_s_range_a_index->first, lane_s_range_a_index->second, kStart);
+  const api::RoadPosition lane_s_range_b_road_pos =
+      get_lane_s_range_road_position(lane_s_range_b_index->first, lane_s_range_b_index->second, kEnd);
+
+  return kRelativePositionToPreceedingLaneSRange[static_cast<size_t>(
+      ComputeRelativePositionFor(lane_s_range_a_road_pos, lane_s_range_b_road_pos, tolerance))];
+}
+
+std::optional<Route::LaneSRangeIndex> Route::FindLaneSRangeIndex(const api::LaneSRange& lane_s_range) const {
+  auto is_lane_s_range_contained = [tolerance = road_network_->road_geometry()->linear_tolerance()](
+                                       const api::LaneSRange& lane_s_range_a, const api::LaneSRange& lane_s_range_b) {
+    if (lane_s_range_a.lane_id() != lane_s_range_b.lane_id()) {
+      return false;
+    }
+    const bool s1_is_in_range = lane_s_range_a.s_range().s1() + tolerance >= lane_s_range_b.s_range().s1() &&
+                                lane_s_range_a.s_range().s0() - tolerance <= lane_s_range_b.s_range().s1();
+    const bool s0_is_in_range = lane_s_range_a.s_range().s1() + tolerance >= lane_s_range_b.s_range().s0() &&
+                                lane_s_range_a.s_range().s0() - tolerance <= lane_s_range_b.s_range().s0();
+    return s1_is_in_range && s0_is_in_range;
+  };
+
+  for (size_t i = 0; i < phases_.size(); ++i) {
+    for (size_t j = 0; j < phases_[i].lane_s_ranges().size(); ++j) {
+      if (is_lane_s_range_contained(phases_[i].lane_s_ranges()[j], lane_s_range)) {
+        return {std::make_pair(i, j)};
+      }
+    }
+  }
+  return {};
+}
+
 }  // namespace routing
 }  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

Part of #543 
Goes on top of #554 

Implements `Route::LaneSRelationFor()`

## Summary

Implements and tests `Route::LaneSRelationFor()`. Same route as in the `maliput::routing::LaneSRelation` definition has been used. Also, added a new definition for coincident `maliput::api::LaneSRanges` which was missing to complete the space of `maliput::routing::LaneSRelations`.

## Test it

Via unit tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maliput/maliput/555)
<!-- Reviewable:end -->
