### PR TITLE
Removes unnecessary gflags dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
 find_package(fmt 6.1.2 EXACT REQUIRED)
-find_package(gflags REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 ##############################################################################

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
   <depend>fmt</depend>
-  <depend>libgflags-dev</depend>
   <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>


### PR DESCRIPTION
## Summary
 - gflags dependency isn't necessary.
   - This might have been used in the past but the dependency was never removed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

