### PR TITLE
Removes fmt from tests.

### DIFF
--- a/test/base/phase_ring_book_loader_test.cc
+++ b/test/base/phase_ring_book_loader_test.cc
@@ -32,8 +32,6 @@
 #include <fstream>
 #include <memory>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <gtest/gtest.h>
 
 #include "maliput/api/rules/discrete_value_rule.h"
@@ -151,64 +149,66 @@ class StraightRoadNetworkHelpers {
 
   // Returns a YAML description based on the proposed RoadNetwork sample.
   static std::string PhaseRingBookYamlDescription() {
-    return fmt::format(
-        R"R(PhaseRings:
-- ID: StraightRoadCrossingPath
-  Rules: [{0}, {1}]
-  Phases:
-  - ID: AllGo
-    RightOfWayRuleStates: {{{0}: Go, {1}: Go}}
-    TrafficLightStates:
-      WestFacing:
-          WestFacingBulbs: {{RedBulb: Off, YellowBulb: Off, GreenBulb: On}}
-      EastFacing:
-          EastFacingBulbs: {{RedBulb: Off, YellowBulb: Off, GreenBulb: On}}
-  - ID: AllStop
-    RightOfWayRuleStates: {{{0}: Stop, {1}: Stop}}
-    TrafficLightStates:
-      WestFacing:
-          WestFacingBulbs: {{RedBulb: On, YellowBulb: Off, GreenBulb: Off}}
-      EastFacing:
-          EastFacingBulbs: {{RedBulb: On, YellowBulb: Off, GreenBulb: Off}}
-  PhaseTransitionGraph:
-    AllGo:
-    - ID: AllStop
-      duration_until: 45
-    AllStop:
-    - ID: AllGo
-)R",
-        maliput::RightOfWayRuleTypeId().string() + "/0_0_1", maliput::RightOfWayRuleTypeId().string() + "/0_1_2");
+    const std::string rule_1 = maliput::RightOfWayRuleTypeId().string() + "/0_0_1";
+    const std::string rule_2 = maliput::RightOfWayRuleTypeId().string() + "/0_1_2";
+    std::stringstream ss;
+    ss << "PhaseRings:\n"
+       << "- ID: StraightRoadCrossingPath\n"
+       << "  Rules: [" << rule_1 << ", " << rule_2 << "]\n"
+       << "  Phases:\n"
+       << "  - ID: AllGo\n"
+       << "    RightOfWayRuleStates: {" << rule_1 << ": Go, " << rule_2 << ": Go}\n"
+       << "    TrafficLightStates:\n"
+       << "      WestFacing:\n"
+       << "          WestFacingBulbs: {RedBulb: Off, YellowBulb: Off, GreenBulb: On}\n"
+       << "      EastFacing:\n"
+       << "          EastFacingBulbs: {RedBulb: Off, YellowBulb: Off, GreenBulb: On}\n"
+       << "  - ID: AllStop\n"
+       << "    RightOfWayRuleStates: {" << rule_1 << ": Stop, " << rule_2 << ": Stop}\n"
+       << "    TrafficLightStates:\n"
+       << "      WestFacing:\n"
+       << "          WestFacingBulbs: {RedBulb: On, YellowBulb: Off, GreenBulb: Off}\n"
+       << "      EastFacing:\n"
+       << "          EastFacingBulbs: {RedBulb: On, YellowBulb: Off, GreenBulb: Off}\n"
+       << "  PhaseTransitionGraph:\n"
+       << "    AllGo:\n"
+       << "    - ID: AllStop\n"
+       << "      duration_until: 45\n"
+       << "    AllStop:\n"
+       << "    - ID: AllGo\n";
+    return ss.str();
   }
 
   // Returns a YAML description based on the proposed RoadNetwork sample without RightOfWayRuleStates.
   static std::string PhaseRingBookYamlDescriptionWithoutRightOfWayRuleStates() {
-    return fmt::format(
-        R"R(PhaseRings:
-- ID: StraightRoadCrossingPath
-  Rules: [{0}, {1}]
-  Phases:
-  - ID: AllGo
-    RightOfWayRuleStates: {2}
-    TrafficLightStates:
-      WestFacing:
-          WestFacingBulbs: {{RedBulb: Off, YellowBulb: Off, GreenBulb: On}}
-      EastFacing:
-          EastFacingBulbs: {{RedBulb: Off, YellowBulb: Off, GreenBulb: On}}
-  - ID: AllStop
-    TrafficLightStates:
-      WestFacing:
-          WestFacingBulbs: {{RedBulb: On, YellowBulb: Off, GreenBulb: Off}}
-      EastFacing:
-          EastFacingBulbs: {{RedBulb: On, YellowBulb: Off, GreenBulb: Off}}
-  PhaseTransitionGraph:
-    AllGo:
-    - ID: AllStop
-      duration_until: 45
-    AllStop:
-    - ID: AllGo
-)R",
-        maliput::RightOfWayRuleTypeId().string() + "/0_0_1", maliput::RightOfWayRuleTypeId().string() + "/0_1_2",
-        "{}" /* Empty map */);
+    const std::string rule_1 = maliput::RightOfWayRuleTypeId().string() + "/0_0_1";
+    const std::string rule_2 = maliput::RightOfWayRuleTypeId().string() + "/0_1_2";
+    const std::string empty_right_of_way_rule_states = "{}";
+    std::stringstream ss;
+    ss << "PhaseRings:\n"
+       << "- ID: StraightRoadCrossingPath\n"
+       << "  Rules: [" << rule_1 << ", " << rule_2 << "]\n"
+       << "  Phases:\n"
+       << "  - ID: AllGo\n"
+       << "    RightOfWayRuleStates: " << empty_right_of_way_rule_states << "\n"
+       << "    TrafficLightStates:\n"
+       << "      WestFacing:\n"
+       << "          WestFacingBulbs: {RedBulb: Off, YellowBulb: Off, GreenBulb: On}\n"
+       << "      EastFacing:\n"
+       << "          EastFacingBulbs: {RedBulb: Off, YellowBulb: Off, GreenBulb: On}\n"
+       << "  - ID: AllStop\n"
+       << "    TrafficLightStates:\n"
+       << "      WestFacing:\n"
+       << "          WestFacingBulbs: {RedBulb: On, YellowBulb: Off, GreenBulb: Off}\n"
+       << "      EastFacing:\n"
+       << "          EastFacingBulbs: {RedBulb: On, YellowBulb: Off, GreenBulb: Off}\n"
+       << "  PhaseTransitionGraph:\n"
+       << "    AllGo:\n"
+       << "    - ID: AllStop\n"
+       << "      duration_until: 45\n"
+       << "    AllStop:\n"
+       << "    - ID: AllGo\n";
+    return ss.str();
   }
 
  private:

--- a/test/base/rule_registry_loader_test.cc
+++ b/test/base/rule_registry_loader_test.cc
@@ -32,8 +32,6 @@
 #include <fstream>
 #include <variant>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <gtest/gtest.h>
 
 #include "maliput/api/rules/discrete_value_rule.h"
@@ -70,42 +68,39 @@ class TestLoadingRuleTypesFromYaml : public ::testing::Test {
     const std::string kDirectionUsageRuleType = DirectionUsageRuleTypeId().string();
     const std::string kSpeedLimitRuleType = SpeedLimitRuleTypeId().string();
     const std::string kVehicleInStopBehaviour = VehicleStopInZoneBehaviorRuleTypeId().string();
-
-    return fmt::format(
-        R"R(RuleRegistry:
-  {}:
-    - value: "Go"
-      severity: 0
-      related_rules: [{}, {}]
-      related_unique_ids: [{}]
-    - value: "Stop"
-      severity: 1
-      related_rules: [{}]
-    - value: "StopThenGo"
-  {}:
-    - value: "Bidirectional"
-      severity: 0
-    - value: "WithS"
-      severity: 0
-    - value: "AgaintsS"
-      severity: 0
-    - value: "Undefined"
-      severity: 1
-  {}:
-    - range: [16.6, 27.8]
-      description: "Interstate highway - day time"
-      severity: 0
-    - range: [16.6, 22.2]
-      description: "Arterial road in Ciudad Autonoma de Buenos Aires"
-      severity: 1
-)R",
-        kRightOfWayRuleType, kVehicleInStopBehaviour, RelatedRulesKeys::kYieldGroup, RelatedUniqueIdsKeys::kBulbGroup,
-        kVehicleInStopBehaviour, kDirectionUsageRuleType, kSpeedLimitRuleType);
+    std::stringstream ss;
+    ss << "RuleRegistry:\n"
+       << "    " << kRightOfWayRuleType << ":\n"
+       << "      - value: \"Go\"\n"
+       << "        severity: 0\n"
+       << "        related_rules: [" << kVehicleInStopBehaviour << ", " << RelatedRulesKeys::kYieldGroup << "]\n"
+       << "        related_unique_ids: [" << RelatedUniqueIdsKeys::kBulbGroup << "]\n"
+       << "      - value: \"Stop\"\n"
+       << "        severity: 1\n"
+       << "        related_rules: [" << kVehicleInStopBehaviour << "]\n"
+       << "      - value: \"StopThenGo\"\n"
+       << "    " << kDirectionUsageRuleType << ":\n"
+       << "      - value: \"Bidirectional\"\n"
+       << "        severity: 0\n"
+       << "      - value: \"WithS\"\n"
+       << "        severity: 0\n"
+       << "      - value: \"AgaintsS\"\n"
+       << "        severity: 0\n"
+       << "      - value: \"Undefined\"\n"
+       << "        severity: 1\n"
+       << "    " << kSpeedLimitRuleType << ":\n"
+       << "      - range: [16.6, 27.8]\n"
+       << "        description: \"Interstate highway - day time\"\n"
+       << "        severity: 0\n"
+       << "      - range: [16.6, 22.2]\n"
+       << "        description: \"Arterial road in Ciudad Autonoma de Buenos Aires\"\n"
+       << "        severity: 1\n";
+    return ss.str();
   }
 
   void GenerateYamlFileFromString(const std::string& string_to_yaml, const std::string& filepath) {
     std::ofstream os(filepath);
-    fmt::print(os, string_to_yaml);
+    os << string_to_yaml;
   }
 
   common::Path directory_;


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput/issues/564

## Summary
 - Removes fmt usage in the tests suite.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
