### PR TITLE
Removes fmt.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,7 +14,6 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
-        "@fmt",
     ],
 )
 
@@ -94,7 +93,6 @@ cc_library(
         ":api",
         ":common",
         ":math",
-        "@fmt",
     ],
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ project(maliput LANGUAGES C CXX VERSION 3.0.0)
 message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
-find_package(fmt 6.1.2 EXACT REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 ##############################################################################
@@ -87,7 +86,6 @@ ament_export_include_directories(include)
 
 ament_environment_hooks(setup.sh.in)
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(fmt)
 ament_export_dependencies(yaml-cpp)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_package()

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,4 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.8")
 
-# TODO(stonier) delete once https://github.com/maliput/maliput/pull/568 merges
-bazel_dep(name = "fmt", version = "10.1.0")
-
 bazel_dep(name = "yaml-cpp", version = "0.8.0")

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
-  <depend>fmt</depend>
   <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -28,7 +28,6 @@ macro(add_dependencies_to_test target)
       target_link_libraries(${target}
           maliput::api
           maliput::base
-          fmt::fmt
           test_utilities
       )
 


### PR DESCRIPTION
# 🎉 New feature

Related to #564 

## Summary
 - Removes `fmt` dependency from `maliput` package

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
