### PR TITLE
A devcontainer for development workflows with bazel.

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,36 @@
+# DevContainers
+
+- [DevContainers](#devcontainers)
+  - [Bazel-Zen](#bazel-zen)
+      - [Image Details](#image-details)
+      - [Getting Started](#getting-started)
+  - [ROS-Zen](#ros-zen)
+
+## Bazel-Zen
+
+:warning: This is as yet an unsupported workflow! YMMV.
+
+#### Image Details
+
+* Base Image: `focal` (ubuntu)
+* Bazel:
+  * Installed via Bazelisk.
+  * `bazel` and `bazelisk` invocations both work (a bash alias supports this).
+  * The bazel version is configured via `./bazel/devcontainer.json` [1]
+
+[1] Override if necessary. At a later date, we might configure the bazel version via a marker file at the project root.
+
+#### Getting Started
+
+* [Install VSCode](https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions)
+* Open the project in VSCode
+* CTRL-SHIFT-P &rarr; Reopen in Container
+* Open a terminal in the container and run
+
+```
+(docker) zen@bazel-zen:/workspaces/maliput$ bazel build //...
+```
+
+## ROS-Zen
+
+TODO

--- a/.devcontainer/bazel-zen/Dockerfile
+++ b/.devcontainer/bazel-zen/Dockerfile
@@ -1,0 +1,81 @@
+################################################################################
+# Custom Extension
+################################################################################
+
+ARG BASE_IMAGE=focal
+
+FROM mcr.microsoft.com/devcontainers/base:${BASE_IMAGE}
+
+ARG NAME=bazel-zen
+
+################################################################################
+# Unset gcr configured ubuntu user
+################################################################################
+
+USER root
+
+################################################################################
+# Tools & Utilities
+################################################################################
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # development
+    curl \
+    bash \
+    g++ \
+    gcc \
+    git \
+    graphviz \
+    make \
+    pkg-config \
+    ssh \
+    wget \
+    vim \
+    less \
+    zip \
+    # python
+    python3-dev \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+################################################################################
+# Bazelisk
+################################################################################
+
+ARG BAZEL_VERSION=6.1.1
+ARG BAZELISK_VERSION=v1.10.1
+ARG BAZELISK_DOWNLOAD_SHA=dev-mode
+RUN curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64 \
+    && ([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check - ) \
+    && chmod 0755 /usr/local/bin/bazelisk
+ENV USE_BAZEL_VERSION "${BAZEL_VERSION}"
+
+################################################################################
+# Login Shell
+################################################################################
+
+ENV TERM xterm-256color
+ENTRYPOINT ["/bin/bash", "--login", "-i"]
+
+################################################################################
+# User 'zen'
+################################################################################
+
+ARG USERNAME=zen
+
+# Automatically creates a UID, group ${USERNAME}, adds ${USERNAME} to the group
+#
+# NB: If using this image as a base for a devcontainer, it is critical to have
+# just one user, since dynamic UID mapping will not work otherwise, refer to:
+#   https://github.com/microsoft/vscode-remote-release/issues/1155
+#
+RUN useradd -o --uid 1000 -s "/bin/bash" -m ${USERNAME} && \
+    apt-get install -y sudo && \
+    echo "${USERNAME} ALL=NOPASSWD: ALL" > /etc/sudoers.d/${USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${USERNAME}
+
+RUN echo "export PS1='\[\033[01;36m\](docker)\[\033[00m\] \[\033[01;32m\]\u@${NAME}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> /home/${USERNAME}/.bashrc && \
+    echo "alias ll='ls --color=auto -alFNh'" >> /home/${USERNAME}/.bashrc && \
+    echo "alias ls='ls --color=auto -Nh'" >> /home/${USERNAME}/.bashrc && \
+    echo "alias bazel='bazelisk'" >> /home/${USERNAME}/.bashrc
+
+ENV BLESSING="May you be blessed by a tickle from his noodly apppendages..."

--- a/.devcontainer/bazel-zen/devcontainer.json
+++ b/.devcontainer/bazel-zen/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "Bazel Zen",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Override image args only for special cases.
+        //
+        // If updating the officially supported image/version,
+        // update that in Dockerfile since that is a single source
+        // of truth for both local devcontainers (here) and
+        // the ci containers (.github/workflows/containers.yml).
+        // "args": {
+        //     "BASE_IMAGE": "focal",
+        //     "BAZEL_VERSION": "6.1.1"
+        // },
+        "context": ".."
+    },
+    "remoteUser": "zen",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bazelbuild.vscode-bazel",
+                "bierner.github-markdown-preview",
+                "bierner.markdown-preview-github-styles",
+                "github.vscode-github-actions",
+                "ms-vscode.cpptools-extension-pack",
+                "pbkit.vscode-pbkit",
+                "streetsidesoftware.code-spell-checker",
+                "yzhang.markdown-all-in-one"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary

A devcontainer for bazel workflows

* [x] `Dockerfile` based on focal, installs `bazelisk` adds user `zen`, also adds some minor conveniences
* [x] A `devcontainer.json` that just reflects the `Dockerfile` to a local vscode workflow

## Test it

* Install vscode
* Launch vscode from the project root (or open it from inside vscode)
* Reopen in container
* Open a terminal
* Build

```
bazel build //...
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added example and/or tutorial - Getting Started instructions in the README
- [x] Updated documentation (as needed) - README


FYI @liangfok 