### PR TITLE
Build on PR only, not push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: gcc
 
 on:
-  push:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# 🦟 Bug fix

Avoid excessive use of CI (it runs every job twice for a PR, because it's a push as well).

NB: Commits on non-PR branches can still be run manually.

## Summary

* Removes `push` from the triggers in `build.yml`

## Checklist
- [x] Signed all commits for DCO
