### PR TITLE
Fix missing bazel linkopt to experimental std++fs library

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -87,6 +87,7 @@ cc_library(
     srcs = glob(["src/utility/**/*.cc"]),
     hdrs = glob(["include/maliput/utility/**/*.h"]),
     copts = ["-std=c++17"],
+    linkopts = ["-lstdc++fs"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fixes a missing library dependency for utils (not carried over from CMake to Bazel).

Ostensibly, I think we can drop the need to link to this with g++ v9.4 (ubuntu 20.04), but we should take care to make sure it works reasonably everywhere and for g++ and clang. See #583.

## Checklist
- [x] Signed all commits for DCO
