### PR TITLE
Commented build rule for test_utilities

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,7 +112,7 @@ cc_library(
     ],
 )
 
-# TODO(stonier): prune, simplify and merge into common/math
+# TODO(stonier): Prune, simplify and merge into common/math
 cc_library(
     name = "drake",
     srcs = glob(["src/drake/**/*.cc"]),
@@ -124,3 +124,25 @@ cc_library(
         "@eigen",
     ],
 )
+
+# TODO(stonier): Need to ponder what to do with this. Downstream
+# (e.g. maliput_malidrive) depends on this library for unit testing,
+# but if we were to ship this here, it would bring in gtest as
+# part of the actual software package (undesired).
+#
+# cc_library(
+#     name = "test_utilities",
+#     srcs = glob(["src/test_utilities/**/*.cc"]),
+#     hdrs = glob(["include/maliput/test_utilities/**/*.h"]),
+#     copts = ["-std=c++17"],
+#     strip_include_prefix = "include",
+#     visibility = ["//visibility:public"],
+#     deps = [
+#         ":api",
+#         ":common",
+#         ":geometry_base",
+#         "@googletest//:gtest",
+#         ":math",
+#         ":routing",
+#     ],
+# )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,3 +11,5 @@ module(
 bazel_dep(name = "rules_cc", version = "0.0.8")
 bazel_dep(name = "eigen", version = "3.4.0")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
+
+bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)


### PR DESCRIPTION
In a bazel-verse, you don't want to ship this library, since that would ship gtest with the library (undesired). This needs a rethink, see #585.

This merely includes some commented code with a TODO noting the problem. I think it's worth that for the visibility.