### PR TITLE
Adds missing ament_export_dependencies for eigen package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ ament_export_include_directories(include)
 
 ament_environment_hooks(setup.sh.in)
 ament_export_dependencies(ament_cmake)
+ament_export_dependencies(eigen3_cmake_module)
+ament_export_dependencies(Eigen3)
 ament_export_dependencies(yaml-cpp)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_package()


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/maliput/maliput/pull/571

## Summary
 - As maliput_drake was migrated into maliput an eigen dependency now needs to be exported from maliput.

## Extra
- how does `ament_export_dependencies` work? -> [here](https://answers.ros.org/question/331277/ament_cmake-confused-about-ament_export_dependencies-and-ament_export_interfaces/)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

