### PR TITLE
Enables CI workflow run on main branch push.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: gcc
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/maliput/maliput_infrastructure/issues/310

## Summary
- https://github.com/maliput/maliput/pull/581 removes the CI workflow being run in `push` event and that's ok, however, when pushing to `main` we might want to have it enabled: It is useful to maintain the `main` branch curated.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
