### PR TITLE
Adds missing linking from maliput::drake::analysis to trajectories.

### DIFF
--- a/src/drake/systems/analysis/CMakeLists.txt
+++ b/src/drake/systems/analysis/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
   drake_systems_analysis
     Eigen3::Eigen
     maliput::drake_common
+    maliput::drake_common_trajectories
     maliput::drake_systems_framework
 )
 


### PR DESCRIPTION
# 🦟 Bug fix

#571 introduced `maliput_drake` into `maliput`

## Summary
 - This PR adds a missing linking between `maliput::drake::analysis` and `maliput::drake::common::trajectories`

Trajectories used but missing linking.
https://github.com/maliput/maliput/blob/d92e42b3a9f79328480114cd3e59e5b95f9faa47/src/drake/systems/analysis/initial_value_problem.cc#L244

Found out due to:
 - https://github.com/maliput/maliput_malidrive/pull/240

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
