### PR TITLE
Remove extra macro MALIPUT_USED.

### DIFF
--- a/include/maliput/drake/common/default_scalars.h
+++ b/include/maliput/drake/common/default_scalars.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 // N.B. `CommonScalarPack` and `NonSymbolicScalarPack` in `systems_pybind.h`
 // should be kept in sync with this file.
 

--- a/include/maliput/drake/common/drake_assert.h
+++ b/include/maliput/drake/common/drake_assert.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <type_traits>
 
 /// @file

--- a/include/maliput/drake/common/drake_bool.h
+++ b/include/maliput/drake/common/drake_bool.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <type_traits>
 
 #include <Eigen/Core>

--- a/include/maliput/drake/common/drake_copyable.h
+++ b/include/maliput/drake/common/drake_copyable.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 // ============================================================================
 // N.B. The spelling of the macro names between doc/Doxyfile_CXX.in and this
 // file must be kept in sync!

--- a/include/maliput/drake/common/drake_deprecated.h
+++ b/include/maliput/drake/common/drake_deprecated.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 /** @file
 Provides a portable macro for use in generating compile-time warnings for
 use of code that is permitted but discouraged. */

--- a/include/maliput/drake/common/drake_throw.h
+++ b/include/maliput/drake/common/drake_throw.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <type_traits>
 
 #include "maliput/drake/common/drake_assert.h"

--- a/include/maliput/drake/common/eigen_types.h
+++ b/include/maliput/drake/common/eigen_types.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 /// @file
 /// This file contains abbreviated definitions for certain specializations of
 /// Eigen::Matrix that are commonly used in Drake.

--- a/include/maliput/drake/common/extract_double.h
+++ b/include/maliput/drake/common/extract_double.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <stdexcept>
 
 #include "maliput/drake/common/drake_deprecated.h"

--- a/include/maliput/drake/common/nice_type_name.h
+++ b/include/maliput/drake/common/nice_type_name.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <string>
 #include <typeinfo>

--- a/include/maliput/drake/common/text_logging.h
+++ b/include/maliput/drake/common/text_logging.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 /**
 @file
 This is the entry point for all text logging within Drake.

--- a/include/maliput/drake/common/trajectories/piecewise_polynomial.h
+++ b/include/maliput/drake/common/trajectories/piecewise_polynomial.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <limits>
 #include <memory>
 #include <vector>

--- a/include/maliput/drake/common/unused.h
+++ b/include/maliput/drake/common/unused.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 namespace maliput::drake {
 
 /// Documents the argument(s) as unused, placating GCC's -Wunused-parameter

--- a/include/maliput/drake/common/value.h
+++ b/include/maliput/drake/common/value.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <stdexcept>
 #include <string>

--- a/include/maliput/drake/systems/analysis/antiderivative_function.h
+++ b/include/maliput/drake/systems/analysis/antiderivative_function.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <optional>
 #include <utility>

--- a/include/maliput/drake/systems/analysis/dense_output.h
+++ b/include/maliput/drake/systems/analysis/dense_output.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include "maliput/drake/common/default_scalars.h"
 #include "maliput/drake/common/drake_copyable.h"
 #include "maliput/drake/common/eigen_types.h"

--- a/include/maliput/drake/systems/analysis/hermitian_dense_output.h
+++ b/include/maliput/drake/systems/analysis/hermitian_dense_output.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <algorithm>
 #include <limits>
 #include <stdexcept>

--- a/include/maliput/drake/systems/analysis/initial_value_problem.h
+++ b/include/maliput/drake/systems/analysis/initial_value_problem.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <optional>
 #include <utility>

--- a/include/maliput/drake/systems/analysis/integrator_base.h
+++ b/include/maliput/drake/systems/analysis/integrator_base.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/include/maliput/drake/systems/analysis/runge_kutta3_integrator.h
+++ b/include/maliput/drake/systems/analysis/runge_kutta3_integrator.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <utility>
 

--- a/include/maliput/drake/systems/analysis/scalar_dense_output.h
+++ b/include/maliput/drake/systems/analysis/scalar_dense_output.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include "maliput/drake/common/default_scalars.h"
 #include "maliput/drake/common/drake_copyable.h"
 #include "maliput/drake/systems/analysis/dense_output.h"

--- a/include/maliput/drake/systems/analysis/scalar_initial_value_problem.h
+++ b/include/maliput/drake/systems/analysis/scalar_initial_value_problem.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <optional>
 #include <utility>

--- a/include/maliput/drake/systems/analysis/scalar_view_dense_output.h
+++ b/include/maliput/drake/systems/analysis/scalar_view_dense_output.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <utility>
 

--- a/include/maliput/drake/systems/analysis/stepwise_dense_output.h
+++ b/include/maliput/drake/systems/analysis/stepwise_dense_output.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include "maliput/drake/common/default_scalars.h"
 #include "maliput/drake/common/drake_copyable.h"
 #include "maliput/drake/systems/analysis/dense_output.h"

--- a/include/maliput/drake/systems/framework/abstract_value_cloner.h
+++ b/include/maliput/drake/systems/framework/abstract_value_cloner.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 
 #include "maliput/drake/common/copyable_unique_ptr.h"

--- a/include/maliput/drake/systems/framework/abstract_values.h
+++ b/include/maliput/drake/systems/framework/abstract_values.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <memory>
 #include <vector>

--- a/include/maliput/drake/systems/framework/basic_vector.h
+++ b/include/maliput/drake/systems/framework/basic_vector.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <initializer_list>
 #include <memory>

--- a/include/maliput/drake/systems/framework/context.h
+++ b/include/maliput/drake/systems/framework/context.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <optional>
 #include <string>

--- a/include/maliput/drake/systems/framework/context_base.h
+++ b/include/maliput/drake/systems/framework/context_base.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <algorithm>
 #include <cstdint>
 #include <functional>

--- a/include/maliput/drake/systems/framework/continuous_state.h
+++ b/include/maliput/drake/systems/framework/continuous_state.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 
 #include "maliput/drake/common/default_scalars.h"

--- a/include/maliput/drake/systems/framework/discrete_values.h
+++ b/include/maliput/drake/systems/framework/discrete_values.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <memory>
 #include <utility>

--- a/include/maliput/drake/systems/framework/framework_common.h
+++ b/include/maliput/drake/systems/framework/framework_common.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <algorithm>
 #include <memory>
 #include <optional>

--- a/include/maliput/drake/systems/framework/leaf_output_port.h
+++ b/include/maliput/drake/systems/framework/leaf_output_port.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <functional>
 #include <memory>

--- a/include/maliput/drake/systems/framework/leaf_system.h
+++ b/include/maliput/drake/systems/framework/leaf_system.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <functional>
 #include <map>
 #include <memory>

--- a/include/maliput/drake/systems/framework/model_values.h
+++ b/include/maliput/drake/systems/framework/model_values.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <memory>
 #include <utility>

--- a/include/maliput/drake/systems/framework/parameters.h
+++ b/include/maliput/drake/systems/framework/parameters.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <utility>
 #include <vector>

--- a/include/maliput/drake/systems/framework/scalar_conversion_traits.h
+++ b/include/maliput/drake/systems/framework/scalar_conversion_traits.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <type_traits>
-
-// #include "maliput/drake/common/symbolic.h"
 
 namespace maliput::drake {
 namespace systems {

--- a/include/maliput/drake/systems/framework/state.h
+++ b/include/maliput/drake/systems/framework/state.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <memory>
 #include <utility>
 

--- a/include/maliput/drake/systems/framework/system.h
+++ b/include/maliput/drake/systems/framework/system.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <cmath>
 #include <functional>
 #include <limits>

--- a/include/maliput/drake/systems/framework/system_constraint.h
+++ b/include/maliput/drake/systems/framework/system_constraint.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <functional>
 #include <limits>

--- a/include/maliput/drake/systems/framework/system_output.h
+++ b/include/maliput/drake/systems/framework/system_output.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <memory>
 #include <utility>

--- a/include/maliput/drake/systems/framework/system_scalar_converter.h
+++ b/include/maliput/drake/systems/framework/system_scalar_converter.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <functional>
 #include <memory>

--- a/include/maliput/drake/systems/framework/value_producer.h
+++ b/include/maliput/drake/systems/framework/value_producer.h
@@ -1,5 +1,4 @@
 #pragma once
-#define MALIPUT_USED
 
 #include <functional>
 #include <memory>

--- a/include/maliput/drake/systems/framework/vector_base.h
+++ b/include/maliput/drake/systems/framework/vector_base.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define MALIPUT_USED
-
 #include <initializer_list>
 #include <ostream>
 #include <sstream>

--- a/src/drake/systems/analysis/antiderivative_function.cc
+++ b/src/drake/systems/analysis/antiderivative_function.cc
@@ -1,6 +1,4 @@
 #include "maliput/drake/systems/analysis/antiderivative_function.h"
 
-#define MALIPUT_USED
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class maliput::drake::systems::AntiderivativeFunction)

--- a/src/drake/systems/analysis/initial_value_problem.cc
+++ b/src/drake/systems/analysis/initial_value_problem.cc
@@ -1,7 +1,5 @@
 #include "maliput/drake/systems/analysis/initial_value_problem.h"
 
-#define MALIPUT_USED
-
 #include <stdexcept>
 
 #include "maliput/drake/systems/analysis/hermitian_dense_output.h"


### PR DESCRIPTION
# 🦟 Bug fix

Part of #561 

## Summary

This macro has been introduced to trace necessary files. It is useless and it is a leftover from the migration from maliput_drake.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
