### PR TITLE
Decouples maliput math compare methods from test.

### DIFF
--- a/include/maliput/common/compare.h
+++ b/include/maliput/common/compare.h
@@ -1,0 +1,51 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace maliput {
+namespace common {
+
+/// @brief ComparisonResult is a struct that holds the result of a comparison
+///        between two objects of type T.
+///         - If the objects are equal, then message is empty.
+///         - If the objects are not equal, then message contains a string
+///           describing the difference.
+///        Used as return type by compare methods in maliput.
+/// @tparam T The type of the objects being compared.
+/// @returns A ComparisonResult<T> object.
+template <typename T>
+struct ComparisonResult {
+  std::optional<std::string> message;
+};
+
+}  // namespace common
+}  // namespace maliput

--- a/include/maliput/math/compare.h
+++ b/include/maliput/math/compare.h
@@ -1,0 +1,72 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "maliput/common/compare.h"
+#include "maliput/math/matrix.h"
+
+namespace maliput {
+namespace math {
+
+enum class CompareType { kAbsolute, kRelative };
+
+/**
+ * Evaluate that two vectors @p v1 and @p v2 are equal down to a certain @p tolerance.
+ *
+ * Instantiations for comparing Vector2, Vector3 and Vector4 are provided.
+ *
+ * @param v1 The first vector to compare.
+ * @param v2 The second vector to compare.
+ * @param tolerance The tolerance for determining equivalence.
+ * @param compare_type Whether the tolerance is absolute or relative.
+ * @return A ComparisonResult<VectorBase<N, Derived>> object.
+ */
+template <std::size_t N, typename Derived>
+common::ComparisonResult<math::VectorBase<N, Derived>> CompareVectors(
+    const math::VectorBase<N, Derived>& v1, const math::VectorBase<N, Derived>& v2, double tolerance = 0.0,
+    CompareType compare_type = CompareType::kAbsolute);
+
+/**
+ * Evaluate that two matrices @p m1 and @p m2 are equal down to a certain @p tolerance.
+ *
+ * Instantiations for comparing Matrix2, Matrix3 and Matrix4 are provided.
+ *
+ * @param m1 The first matrix to compare.
+ * @param m2 The second matrix to compare.
+ * @param tolerance The tolerance for determining equivalence.
+ * @param compare_type Whether the tolerance is absolute or relative.
+ * @return A ComparisonResult<Matrix<N>> object.
+ */
+template <std::size_t N>
+common::ComparisonResult<math::Matrix<N>> CompareMatrices(const math::Matrix<N>& m1, const math::Matrix<N>& m2,
+                                                          double tolerance = 0.0,
+                                                          CompareType compare_type = CompareType::kAbsolute);
+
+}  // namespace math
+}  // namespace maliput

--- a/include/maliput/math/matrix.h
+++ b/include/maliput/math/matrix.h
@@ -139,6 +139,9 @@ class Matrix {
   /// @throw common::assertion_error When matrix is singular.
   Matrix<N> inverse() const;
 
+  /// @return A string representation of the matrix.
+  std::string to_str() const;
+
   /// Assignment operator overload.
   /// @param other Matrix<N> object.
   Matrix<N>& operator=(const Matrix<N>& other);

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(MATH_SOURCES
   axis_aligned_box.cc
   bounding_box.cc
+  compare.cc
   matrix.cc
   quaternion.cc
   overlapping_type.cc

--- a/src/math/compare.cc
+++ b/src/math/compare.cc
@@ -1,0 +1,168 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput/math/compare.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <optional>
+
+namespace maliput {
+namespace math {
+
+template <std::size_t N, typename Derived>
+common::ComparisonResult<math::VectorBase<N, Derived>> CompareVectors(const math::VectorBase<N, Derived>& v1,
+                                                                      const math::VectorBase<N, Derived>& v2,
+                                                                      double tolerance, CompareType compare_type) {
+  for (int i = 0; i < static_cast<int>(N); i++) {
+    // First handle the corner cases of positive infinity, negative infinity,
+    // and NaN
+    const auto both_positive_infinity =
+        v1[i] == std::numeric_limits<double>::infinity() && v2[i] == std::numeric_limits<double>::infinity();
+
+    const auto both_negative_infinity =
+        v1[i] == -std::numeric_limits<double>::infinity() && v2[i] == -std::numeric_limits<double>::infinity();
+
+    const auto both_nan = std::isnan(v1[i]) && std::isnan(v2[i]);
+
+    if (both_positive_infinity || both_negative_infinity || both_nan) continue;
+
+    // Check for case where one value is NaN and the other is not
+    if ((std::isnan(v1[i]) && !std::isnan(v2[i])) || (!std::isnan(v1[i]) && std::isnan(v2[i]))) {
+      return {"Nan mismatch at (" + std::to_string(i) + "):\nv1 =\n" + v1.to_str() + "\nv2 =\n" + v2.to_str()};
+    }
+
+    // Determine whether the difference between the two vectors is less than
+    // the tolerance.
+    const auto delta = std::abs(v1[i] - v2[i]);
+
+    if (compare_type == CompareType::kAbsolute) {
+      // Perform comparison using absolute tolerance.
+
+      if (delta > tolerance) {
+        return {"Value at (" + std::to_string(i) + ") exceeds tolerance: " + std::to_string(v1[i]) + " vs. " +
+                std::to_string(v2[i]) + ", diff = " + std::to_string(delta) +
+                ", tolerance = " + std::to_string(tolerance) + "\nv1 =\n" + v1.to_str() + "\nv2 =\n" + v2.to_str() +
+                "\ndelta=\n" + (v1 - v2).to_str()};
+      }
+    } else {
+      // Perform comparison using relative tolerance, see:
+      // http://realtimecollisiondetection.net/blog/?p=89
+      const auto max_value = std::max(std::abs(v1[i]), std::abs(v2[i]));
+      const auto relative_tolerance = tolerance * std::max(1., max_value);
+
+      if (delta > relative_tolerance) {
+        return {"Value at (" + std::to_string(i) + ") exceeds tolerance: " + std::to_string(v1[i]) + " vs. " +
+                std::to_string(v2[i]) + ", diff = " + std::to_string(delta) + ", tolerance = " +
+                std::to_string(tolerance) + ", relative tolerance = " + std::to_string(relative_tolerance) +
+                "\nv1 =\n" + v1.to_str() + "\nv2 =\n" + v2.to_str() + "\ndelta=\n" + (v1 - v2).to_str()};
+      }
+    }
+  }
+
+  return {std::nullopt};
+}
+
+template <std::size_t N>
+common::ComparisonResult<math::Matrix<N>> CompareMatrices(const math::Matrix<N>& m1, const math::Matrix<N>& m2,
+                                                          double tolerance, CompareType compare_type) {
+  for (int ii = 0; ii < static_cast<int>(N); ii++) {
+    for (int jj = 0; jj < static_cast<int>(N); jj++) {
+      // First handle the corner cases of positive infinity, negative infinity,
+      // and NaN
+      const auto both_positive_infinity = m1[ii][jj] == std::numeric_limits<double>::infinity() &&
+                                          m2[ii][jj] == std::numeric_limits<double>::infinity();
+
+      const auto both_negative_infinity = m1[ii][jj] == -std::numeric_limits<double>::infinity() &&
+                                          m2[ii][jj] == -std::numeric_limits<double>::infinity();
+
+      const auto both_nan = std::isnan(m1[ii][jj]) && std::isnan(m2[ii][jj]);
+
+      if (both_positive_infinity || both_negative_infinity || both_nan) continue;
+
+      // Check for case where one value is NaN and the other is not
+      if ((std::isnan(m1[ii][jj]) && !std::isnan(m2[ii][jj])) || (!std::isnan(m1[ii][jj]) && std::isnan(m2[ii][jj]))) {
+        return {"NaN mismatch at (" + std::to_string(ii) + ", " + std::to_string(jj) + "):\nm1 =\n" + m1.to_str() +
+                "\nm2 =\n" + m2.to_str()};
+      }
+
+      // Determine whether the difference between the two matrices is less than
+      // the tolerance.
+      const auto delta = std::abs(m1[ii][jj] - m2[ii][jj]);
+
+      if (compare_type == CompareType::kAbsolute) {
+        // Perform comparison using absolute tolerance.
+
+        if (delta > tolerance) {
+          return {"Value at (" + std::to_string(ii) + ", " + std::to_string(jj) +
+                  ") exceeds tolerance: " + std::to_string(m1[ii][jj]) + " vs. " + std::to_string(m2[ii][jj]) +
+                  ", diff = " + std::to_string(delta) + ", tolerance = " + std::to_string(tolerance) + "\nm1 =\n" +
+                  m1.to_str() + "\nm2 =\n" + m2.to_str() + "\ndelta=\n" + (m1 - m2).to_str()};
+        }
+      } else {
+        // Perform comparison using relative tolerance, see:
+        // http://realtimecollisiondetection.net/blog/?p=89
+        const auto max_value = std::max(std::abs(m1[ii][jj]), std::abs(m2[ii][jj]));
+        const auto relative_tolerance = tolerance * std::max(1., max_value);
+
+        if (delta > relative_tolerance) {
+          return {"Value at (" + std::to_string(ii) + ", " + std::to_string(jj) +
+                  ") exceeds tolerance: " + std::to_string(m1[ii][jj]) + " vs. " + std::to_string(m2[ii][jj]) +
+                  ", diff = " + std::to_string(delta) + ", tolerance = " + std::to_string(tolerance) +
+                  ", relative tolerance = " + std::to_string(relative_tolerance) + "\nm1 =\n" + m1.to_str() +
+                  "\nm2 =\n" + m2.to_str() + "\ndelta=\n" + (m1 - m2).to_str()};
+        }
+      }
+    }
+  }
+
+  return {std::nullopt};
+}
+
+//! @cond Doxygen_Suppress
+// Explicit instantiations
+template common::ComparisonResult<math::VectorBase<2, Vector2>> CompareVectors(const VectorBase<2, Vector2>&,
+                                                                               const VectorBase<2, Vector2>&, double,
+                                                                               CompareType);
+template common::ComparisonResult<math::VectorBase<3, Vector3>> CompareVectors(const VectorBase<3, Vector3>&,
+                                                                               const VectorBase<3, Vector3>&, double,
+                                                                               CompareType);
+template common::ComparisonResult<math::VectorBase<4, Vector4>> CompareVectors(const VectorBase<4, Vector4>&,
+                                                                               const VectorBase<4, Vector4>&, double,
+                                                                               CompareType);
+template common::ComparisonResult<math::Matrix<2>> CompareMatrices(const Matrix<2>&, const Matrix<2>&, double,
+                                                                   CompareType);
+template common::ComparisonResult<math::Matrix<3>> CompareMatrices(const Matrix<3>&, const Matrix<3>&, double,
+                                                                   CompareType);
+template common::ComparisonResult<math::Matrix<4>> CompareMatrices(const Matrix<4>&, const Matrix<4>&, double,
+                                                                   CompareType);
+//! @endcond
+
+}  // namespace math
+}  // namespace maliput

--- a/src/math/matrix.cc
+++ b/src/math/matrix.cc
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cmath>
 #include <numeric>
+#include <sstream>
 
 #include "maliput/common/maliput_throw.h"
 
@@ -170,6 +171,13 @@ Matrix<N> Matrix<N>::inverse() const {
   const double d = determinant();
   if (std::abs(d) < kTolerance) MALIPUT_THROW_MESSAGE("Matrix is singular");
   return {(1 / d) * adjoint()};
+}
+
+template <std::size_t N>
+std::string Matrix<N>::to_str() const {
+  std::stringstream ss;
+  ss << (*this);
+  return ss.str();
 }
 
 template <std::size_t N>

--- a/src/test_utilities/CMakeLists.txt
+++ b/src/test_utilities/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(
   test_utilities
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/src/test_utilities/assert_compare.h
+++ b/src/test_utilities/assert_compare.h
@@ -1,0 +1,47 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "maliput/common/compare.h"
+
+namespace maliput {
+namespace test {
+
+template <typename T>
+::testing::AssertionResult AssertCompare(const common::ComparisonResult<T>& res) {
+  if (!res.message.has_value()) {
+    return ::testing::AssertionSuccess();
+  }
+  return ::testing::AssertionFailure() << res.message.value();
+}
+
+}  // namespace test
+}  // namespace maliput

--- a/test/api/lane_data_test.cc
+++ b/test/api/lane_data_test.cc
@@ -32,12 +32,14 @@
 #include <gtest/gtest.h>
 
 #include "maliput/common/assertion_error.h"
+#include "maliput/common/compare.h"
+#include "maliput/math/compare.h"
 #include "maliput/math/matrix.h"
 #include "maliput/math/quaternion.h"
 #include "maliput/math/vector.h"
-#include "maliput/test_utilities/maliput_math_compare.h"
 #include "maliput/test_utilities/maliput_types_compare.h"
 #include "maliput/test_utilities/mock.h"
+#include "test_utilities/assert_compare.h"
 
 namespace maliput {
 namespace api {
@@ -230,16 +232,17 @@ const double kRotationTolerance = 1e-15;
 
 // TODO(francocipollone): Once RollPitchYaw and Quaternion implementation are
 //                        complete the followings arguments of the CompareVectors could be modified.
-#define CHECK_ALL_ROTATION_ACCESSORS(dut, _w, _x, _y, _z, _ro, _pi, _ya, _ma)                                        \
-  do {                                                                                                               \
-    EXPECT_TRUE(math::test::CompareVectors(dut.quat().coeffs(), math::Vector4(_w, _x, _y, _z), kRotationTolerance)); \
-    EXPECT_TRUE(math::test::CompareVectors(                                                                          \
-        math::Vector3(dut.rpy().roll_angle(), dut.rpy().pitch_angle(), dut.rpy().yaw_angle()),                       \
-        math::Vector3(_ro, _pi, _ya), kRotationTolerance));                                                          \
-    EXPECT_NEAR(dut.roll(), _ro, kRotationTolerance);                                                                \
-    EXPECT_NEAR(dut.pitch(), _pi, kRotationTolerance);                                                               \
-    EXPECT_NEAR(dut.yaw(), _ya, kRotationTolerance);                                                                 \
-    EXPECT_TRUE(math::test::CompareMatrices(dut.matrix(), _ma, kRotationTolerance));                                 \
+#define CHECK_ALL_ROTATION_ACCESSORS(dut, _w, _x, _y, _z, _ro, _pi, _ya, _ma)                                 \
+  do {                                                                                                        \
+    EXPECT_TRUE(maliput::test::AssertCompare(                                                                 \
+        CompareVectors(dut.quat().coeffs(), math::Vector4(_w, _x, _y, _z), kRotationTolerance)));             \
+    EXPECT_TRUE(maliput::test::AssertCompare(                                                                 \
+        CompareVectors(math::Vector3(dut.rpy().roll_angle(), dut.rpy().pitch_angle(), dut.rpy().yaw_angle()), \
+                       math::Vector3(_ro, _pi, _ya), kRotationTolerance)));                                   \
+    EXPECT_NEAR(dut.roll(), _ro, kRotationTolerance);                                                         \
+    EXPECT_NEAR(dut.pitch(), _pi, kRotationTolerance);                                                        \
+    EXPECT_NEAR(dut.yaw(), _ya, kRotationTolerance);                                                          \
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(dut.matrix(), _ma, kRotationTolerance)));        \
   } while (0)
 
 class RotationTest : public ::testing::Test {
@@ -385,12 +388,12 @@ GTEST_TEST(Rotation, ReverseTest) {
   // Tolerance has been empirically found for these testing values.
   const double kLinearTolerance = 1e-15;
   const Rotation dut = Rotation::FromRpy(0., 0., 0.).Reverse();
-  EXPECT_TRUE(math::test::CompareVectors(math::Vector3(-1., 0., 0.),
-                                         dut.quat().TransformVector(math::Vector3(1., 0., 0)), kLinearTolerance));
-  EXPECT_TRUE(math::test::CompareVectors(math::Vector3(0., -1., 0.),
-                                         dut.quat().TransformVector(math::Vector3(0., 1., 0)), kLinearTolerance));
-  EXPECT_TRUE(math::test::CompareVectors(math::Vector3(0., 0., 1.),
-                                         dut.quat().TransformVector(math::Vector3(0., 0., 1.)), kLinearTolerance));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(
+      math::Vector3(-1., 0., 0.), dut.quat().TransformVector(math::Vector3(1., 0., 0)), kLinearTolerance)));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(
+      math::Vector3(0., -1., 0.), dut.quat().TransformVector(math::Vector3(0., 1., 0)), kLinearTolerance)));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(
+      math::Vector3(0., 0., 1.), dut.quat().TransformVector(math::Vector3(0., 0., 1.)), kLinearTolerance)));
 }
 
 #undef CHECK_ALL_ROTATION_ACCESSORS

--- a/test/math/matrix_test.cc
+++ b/test/math/matrix_test.cc
@@ -40,6 +40,8 @@ namespace {
 
 static constexpr double kTolerance{1e-10};
 
+using maliput::test::AssertCompare;
+
 GTEST_TEST(MatrixTest, Constructors) {
   {  // 2- dimension matrix.
     EXPECT_EQ(Matrix<2>{}, Matrix<2>({0., 0., 0., 0.}));
@@ -104,7 +106,7 @@ GTEST_TEST(MatrixTest, PublicMethods) {
     EXPECT_EQ(kDut.cofactor(), Matrix<2>({{5., -8.}, {-12., 1.}}));
     EXPECT_EQ(kDut * kDut.inverse(), Matrix<2>::Identity());
     const Matrix<2> kResult = kDut * kDut.inverse();
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kResult, Matrix<2>::Identity(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareMatrices(kResult, Matrix<2>::Identity(), kTolerance)));
   }
   {  // 3- dimension matrix.
     const Matrix<3> kDut{{1., 12., 3.}, {8., 5., 3.}, {6., 14., 9.}};
@@ -122,7 +124,7 @@ GTEST_TEST(MatrixTest, PublicMethods) {
     EXPECT_EQ(kDut.reduce(1, 1), Matrix<2>({{1., 3.}, {6., 9.}}));
     EXPECT_EQ(kDut.cofactor(), Matrix<3>({{3., -54., 82.}, {-66., -9., 58.}, {21., 21., -91}}));
     const Matrix<3> kResult = kDut * kDut.inverse();
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kResult, Matrix<3>::Identity(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareMatrices(kResult, Matrix<3>::Identity(), kTolerance)));
   }
   {  // 4- dimension matrix.
     const Matrix<4> kDut{{1., 12., 3., 2.}, {8., 5., 3., 7.}, {6., 14., 9., 25.}, {13., 4., 7., 8.}};
@@ -146,7 +148,7 @@ GTEST_TEST(MatrixTest, PublicMethods) {
                                           {-69., -354., 1705., -399.}}));
     EXPECT_EQ(kDut.cofactor().transpose(), kDut.adjoint());
     const Matrix<4> kResult = kDut * kDut.inverse();
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kResult, Matrix<4>::Identity(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareMatrices(kResult, Matrix<4>::Identity(), kTolerance)));
   }
 }
 

--- a/test/math/matrix_test.cc
+++ b/test/math/matrix_test.cc
@@ -31,7 +31,8 @@
 
 #include <gtest/gtest.h>
 
-#include "maliput/test_utilities/maliput_math_compare.h"
+#include "maliput/math/compare.h"
+#include "test_utilities/assert_compare.h"
 
 namespace maliput {
 namespace math {
@@ -103,7 +104,7 @@ GTEST_TEST(MatrixTest, PublicMethods) {
     EXPECT_EQ(kDut.cofactor(), Matrix<2>({{5., -8.}, {-12., 1.}}));
     EXPECT_EQ(kDut * kDut.inverse(), Matrix<2>::Identity());
     const Matrix<2> kResult = kDut * kDut.inverse();
-    EXPECT_TRUE(test::CompareMatrices(kResult, Matrix<2>::Identity(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kResult, Matrix<2>::Identity(), kTolerance)));
   }
   {  // 3- dimension matrix.
     const Matrix<3> kDut{{1., 12., 3.}, {8., 5., 3.}, {6., 14., 9.}};
@@ -121,7 +122,7 @@ GTEST_TEST(MatrixTest, PublicMethods) {
     EXPECT_EQ(kDut.reduce(1, 1), Matrix<2>({{1., 3.}, {6., 9.}}));
     EXPECT_EQ(kDut.cofactor(), Matrix<3>({{3., -54., 82.}, {-66., -9., 58.}, {21., 21., -91}}));
     const Matrix<3> kResult = kDut * kDut.inverse();
-    EXPECT_TRUE(test::CompareMatrices(kResult, Matrix<3>::Identity(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kResult, Matrix<3>::Identity(), kTolerance)));
   }
   {  // 4- dimension matrix.
     const Matrix<4> kDut{{1., 12., 3., 2.}, {8., 5., 3., 7.}, {6., 14., 9., 25.}, {13., 4., 7., 8.}};
@@ -145,7 +146,7 @@ GTEST_TEST(MatrixTest, PublicMethods) {
                                           {-69., -354., 1705., -399.}}));
     EXPECT_EQ(kDut.cofactor().transpose(), kDut.adjoint());
     const Matrix<4> kResult = kDut * kDut.inverse();
-    EXPECT_TRUE(test::CompareMatrices(kResult, Matrix<4>::Identity(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kResult, Matrix<4>::Identity(), kTolerance)));
   }
 }
 

--- a/test/math/quaternion_test.cc
+++ b/test/math/quaternion_test.cc
@@ -227,6 +227,8 @@ namespace math {
 namespace test {
 namespace {
 
+using maliput::test::AssertCompare;
+
 constexpr double kTolerance{1e-15};
 
 GTEST_TEST(Quaternion, DefaultConstructor) {
@@ -282,7 +284,7 @@ GTEST_TEST(Quaternion, RotationMatrixRoundTrip) {
       for (double yaw = kMinAngle; yaw <= kMaxAngle; yaw += kAngleStep) {
         const Matrix3 kRotationMatrix = RollPitchYaw(roll, pitch, yaw).ToMatrix();
         const Quaternion dut(kRotationMatrix);
-        EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kRotationMatrix, dut.ToRotationMatrix(), kTolerance)));
+        EXPECT_TRUE(AssertCompare(CompareMatrices(kRotationMatrix, dut.ToRotationMatrix(), kTolerance)));
       }
     }
   }
@@ -328,8 +330,8 @@ GTEST_TEST(Quaternion, VectorAndCoefficients) {
   EXPECT_EQ(dut.y(), kY);
   EXPECT_EQ(dut.z(), kZ);
 
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector3(kX, kY, kZ), dut.vec(), 0. /* tolerance */)));
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, kX, kY, kZ), dut.coeffs(), 0. /* tolerance */)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(Vector3(kX, kY, kZ), dut.vec(), 0. /* tolerance */)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(Vector4(kW, kX, kY, kZ), dut.coeffs(), 0. /* tolerance */)));
 }
 
 GTEST_TEST(Quaternion, SetIdentity) {
@@ -421,7 +423,7 @@ GTEST_TEST(Quaternion, NormalizeAndNormalized) {
     Quaternion dut(kW, kX, kY, kZ);
     dut.normalize();
     EXPECT_NEAR(1., dut.norm(), kTolerance);
-    EXPECT_TRUE(maliput::test::AssertCompare(
+    EXPECT_TRUE(AssertCompare(
         CompareVectors(Vector4(0.18257418583505536, 0.3651483716701107, 0.5477225575051661, 0.7302967433402214),
                        dut.coeffs(), kTolerance)));
   }
@@ -429,7 +431,7 @@ GTEST_TEST(Quaternion, NormalizeAndNormalized) {
     const Quaternion dut(kW, kX, kY, kZ);
     const Quaternion normalized_quaternion = dut.normalized();
     EXPECT_NEAR(1., normalized_quaternion.norm(), kTolerance);
-    EXPECT_TRUE(maliput::test::AssertCompare(
+    EXPECT_TRUE(AssertCompare(
         CompareVectors(Vector4(0.18257418583505536, 0.3651483716701107, 0.5477225575051661, 0.7302967433402214),
                        normalized_quaternion.coeffs(), kTolerance)));
   }
@@ -521,13 +523,13 @@ GTEST_TEST(Quaternion, Inverse) {
   const double kZ{0.306};
 
   const Quaternion dut(kW, kX, kY, kZ);
-  EXPECT_TRUE(maliput::test::AssertCompare(
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(Vector4(0.8839496148719523, -0.30598255899413734, -0.1769899115750402, -0.30598255899413734),
                      dut.Inverse().coeffs(), kTolerance)));
   // Zero quaternion is handled separately up to Quaternion's tolerance.
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       Vector4(0., 0., 0., 0.), Quaternion(Quaternion::kTolerance / 2., 0., 0., 0.).Inverse().coeffs(), kTolerance)));
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       Vector4(0., 0., 0., 0.), Quaternion(Quaternion::kTolerance, 0., 0., 0.).Inverse().coeffs(), kTolerance)));
 }
 
@@ -574,13 +576,11 @@ GTEST_TEST(Quaternion, MultiplicationBetweenQuaternions) {
 
   const Quaternion q1 = Quaternion::FromTwoVectors(kUnitX, kUnitY);
   const Quaternion q2 = Quaternion::FromTwoVectors(kUnitY, kUnitX);
-  EXPECT_TRUE(
-      maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), (q1 * q2).coeffs(), kTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), (q1 * q2).coeffs(), kTolerance)));
 
   const Quaternion q3 = Quaternion::FromTwoVectors(kUnitZ, kAnyDirection);
   const Quaternion q4 = Quaternion::FromTwoVectors(kAnyDirection, kUnitZ);
-  EXPECT_TRUE(
-      maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), (q3 * q4).coeffs(), kTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), (q3 * q4).coeffs(), kTolerance)));
 }
 
 GTEST_TEST(Quaternion, MultiplicationAndAssingmentBetweenQuaternions) {
@@ -592,12 +592,12 @@ GTEST_TEST(Quaternion, MultiplicationAndAssingmentBetweenQuaternions) {
   const Quaternion q1 = Quaternion::FromTwoVectors(kUnitX, kUnitY);
   Quaternion q2 = Quaternion::FromTwoVectors(kUnitY, kUnitX);
   q2 *= q1;
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), q2.coeffs(), kTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), q2.coeffs(), kTolerance)));
 
   const Quaternion q3 = Quaternion::FromTwoVectors(kUnitZ, kAnyDirection);
   Quaternion q4 = Quaternion::FromTwoVectors(kAnyDirection, kUnitZ);
   q4 *= q3;
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), q4.coeffs(), kTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), q4.coeffs(), kTolerance)));
 }
 
 GTEST_TEST(Quaternion, TransformVector) {
@@ -605,7 +605,7 @@ GTEST_TEST(Quaternion, TransformVector) {
   const Quaternion dut(1., 0., 1., 0.);
   const Vector3 kExpectedResult(3., 1., 1.);
 
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(kExpectedResult, dut.TransformVector(v), kTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(kExpectedResult, dut.TransformVector(v), kTolerance)));
 }
 
 GTEST_TEST(Quaternion, MultiplicationByVector) {
@@ -613,7 +613,7 @@ GTEST_TEST(Quaternion, MultiplicationByVector) {
   const Quaternion dut(1., 0., 1., 0.);
   const Vector3 kExpectedResult(3., 1., 1.);
 
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(kExpectedResult, dut * v, kTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(kExpectedResult, dut * v, kTolerance)));
 }
 
 GTEST_TEST(Quaternion, Slerp) {
@@ -624,7 +624,7 @@ GTEST_TEST(Quaternion, Slerp) {
 
   // Degrading tolerance in this test on purpose because of the overhead in the
   // computation and the expected result.
-  EXPECT_TRUE(maliput::test::AssertCompare(
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(Vector4(0.554528, -0.717339, 0.32579, 0.267925), q3.coeffs(), 1e-6 /* tolerance */)));
 }
 
@@ -645,30 +645,30 @@ GTEST_TEST(Quaternion, FromTwoVectors) {
 
   {  // X to Y.
     const Quaternion dut = Quaternion::FromTwoVectors(kUnitX, kUnitY);
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance)));
   }
   {
     Quaternion dut;
     dut.SetFromTwoVectors(kUnitX, kUnitY);
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance)));
   }
   {  // Y to Z.
     const Quaternion dut = Quaternion::FromTwoVectors(kUnitY, kUnitZ);
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance)));
   }
   {
     Quaternion dut;
     dut.SetFromTwoVectors(kUnitY, kUnitZ);
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance)));
   }
   {  // Z to X.
     const Quaternion dut = Quaternion::FromTwoVectors(kUnitZ, kUnitX);
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance)));
   }
   {
     Quaternion dut;
     dut.SetFromTwoVectors(kUnitZ, kUnitX);
-    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance)));
+    EXPECT_TRUE(AssertCompare(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance)));
   }
 }
 

--- a/test/math/quaternion_test.cc
+++ b/test/math/quaternion_test.cc
@@ -215,10 +215,12 @@
 
 #include <gtest/gtest.h>
 
+#include "maliput/common/compare.h"
+#include "maliput/math/compare.h"
 #include "maliput/math/matrix.h"
 #include "maliput/math/roll_pitch_yaw.h"
 #include "maliput/math/vector.h"
-#include "maliput/test_utilities/maliput_math_compare.h"
+#include "test_utilities/assert_compare.h"
 
 namespace maliput {
 namespace math {
@@ -280,7 +282,7 @@ GTEST_TEST(Quaternion, RotationMatrixRoundTrip) {
       for (double yaw = kMinAngle; yaw <= kMaxAngle; yaw += kAngleStep) {
         const Matrix3 kRotationMatrix = RollPitchYaw(roll, pitch, yaw).ToMatrix();
         const Quaternion dut(kRotationMatrix);
-        EXPECT_TRUE(CompareMatrices(kRotationMatrix, dut.ToRotationMatrix(), kTolerance));
+        EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(kRotationMatrix, dut.ToRotationMatrix(), kTolerance)));
       }
     }
   }
@@ -326,8 +328,8 @@ GTEST_TEST(Quaternion, VectorAndCoefficients) {
   EXPECT_EQ(dut.y(), kY);
   EXPECT_EQ(dut.z(), kZ);
 
-  EXPECT_TRUE(CompareVectors(Vector3(kX, kY, kZ), dut.vec(), 0. /* tolerance */));
-  EXPECT_TRUE(CompareVectors(Vector4(kW, kX, kY, kZ), dut.coeffs(), 0. /* tolerance */));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector3(kX, kY, kZ), dut.vec(), 0. /* tolerance */)));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, kX, kY, kZ), dut.coeffs(), 0. /* tolerance */)));
 }
 
 GTEST_TEST(Quaternion, SetIdentity) {
@@ -419,15 +421,17 @@ GTEST_TEST(Quaternion, NormalizeAndNormalized) {
     Quaternion dut(kW, kX, kY, kZ);
     dut.normalize();
     EXPECT_NEAR(1., dut.norm(), kTolerance);
-    EXPECT_TRUE(CompareVectors(Vector4(0.18257418583505536, 0.3651483716701107, 0.5477225575051661, 0.7302967433402214),
-                               dut.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(
+        CompareVectors(Vector4(0.18257418583505536, 0.3651483716701107, 0.5477225575051661, 0.7302967433402214),
+                       dut.coeffs(), kTolerance)));
   }
   {
     const Quaternion dut(kW, kX, kY, kZ);
     const Quaternion normalized_quaternion = dut.normalized();
     EXPECT_NEAR(1., normalized_quaternion.norm(), kTolerance);
-    EXPECT_TRUE(CompareVectors(Vector4(0.18257418583505536, 0.3651483716701107, 0.5477225575051661, 0.7302967433402214),
-                               normalized_quaternion.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(
+        CompareVectors(Vector4(0.18257418583505536, 0.3651483716701107, 0.5477225575051661, 0.7302967433402214),
+                       normalized_quaternion.coeffs(), kTolerance)));
   }
 }
 
@@ -517,14 +521,14 @@ GTEST_TEST(Quaternion, Inverse) {
   const double kZ{0.306};
 
   const Quaternion dut(kW, kX, kY, kZ);
-  EXPECT_TRUE(
+  EXPECT_TRUE(maliput::test::AssertCompare(
       CompareVectors(Vector4(0.8839496148719523, -0.30598255899413734, -0.1769899115750402, -0.30598255899413734),
-                     dut.Inverse().coeffs(), kTolerance));
+                     dut.Inverse().coeffs(), kTolerance)));
   // Zero quaternion is handled separately up to Quaternion's tolerance.
-  EXPECT_TRUE(CompareVectors(Vector4(0., 0., 0., 0.),
-                             Quaternion(Quaternion::kTolerance / 2., 0., 0., 0.).Inverse().coeffs(), kTolerance));
-  EXPECT_TRUE(CompareVectors(Vector4(0., 0., 0., 0.), Quaternion(Quaternion::kTolerance, 0., 0., 0.).Inverse().coeffs(),
-                             kTolerance));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(
+      Vector4(0., 0., 0., 0.), Quaternion(Quaternion::kTolerance / 2., 0., 0., 0.).Inverse().coeffs(), kTolerance)));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(
+      Vector4(0., 0., 0., 0.), Quaternion(Quaternion::kTolerance, 0., 0., 0.).Inverse().coeffs(), kTolerance)));
 }
 
 GTEST_TEST(Quaternion, Conjugate) {
@@ -570,11 +574,13 @@ GTEST_TEST(Quaternion, MultiplicationBetweenQuaternions) {
 
   const Quaternion q1 = Quaternion::FromTwoVectors(kUnitX, kUnitY);
   const Quaternion q2 = Quaternion::FromTwoVectors(kUnitY, kUnitX);
-  EXPECT_TRUE(CompareVectors(Quaternion::Identity().coeffs(), (q1 * q2).coeffs(), kTolerance));
+  EXPECT_TRUE(
+      maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), (q1 * q2).coeffs(), kTolerance)));
 
   const Quaternion q3 = Quaternion::FromTwoVectors(kUnitZ, kAnyDirection);
   const Quaternion q4 = Quaternion::FromTwoVectors(kAnyDirection, kUnitZ);
-  EXPECT_TRUE(CompareVectors(Quaternion::Identity().coeffs(), (q3 * q4).coeffs(), kTolerance));
+  EXPECT_TRUE(
+      maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), (q3 * q4).coeffs(), kTolerance)));
 }
 
 GTEST_TEST(Quaternion, MultiplicationAndAssingmentBetweenQuaternions) {
@@ -586,12 +592,12 @@ GTEST_TEST(Quaternion, MultiplicationAndAssingmentBetweenQuaternions) {
   const Quaternion q1 = Quaternion::FromTwoVectors(kUnitX, kUnitY);
   Quaternion q2 = Quaternion::FromTwoVectors(kUnitY, kUnitX);
   q2 *= q1;
-  EXPECT_TRUE(CompareVectors(Quaternion::Identity().coeffs(), q2.coeffs(), kTolerance));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), q2.coeffs(), kTolerance)));
 
   const Quaternion q3 = Quaternion::FromTwoVectors(kUnitZ, kAnyDirection);
   Quaternion q4 = Quaternion::FromTwoVectors(kAnyDirection, kUnitZ);
   q4 *= q3;
-  EXPECT_TRUE(CompareVectors(Quaternion::Identity().coeffs(), q4.coeffs(), kTolerance));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Quaternion::Identity().coeffs(), q4.coeffs(), kTolerance)));
 }
 
 GTEST_TEST(Quaternion, TransformVector) {
@@ -599,7 +605,7 @@ GTEST_TEST(Quaternion, TransformVector) {
   const Quaternion dut(1., 0., 1., 0.);
   const Vector3 kExpectedResult(3., 1., 1.);
 
-  EXPECT_TRUE(CompareVectors(kExpectedResult, dut.TransformVector(v), kTolerance));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(kExpectedResult, dut.TransformVector(v), kTolerance)));
 }
 
 GTEST_TEST(Quaternion, MultiplicationByVector) {
@@ -607,7 +613,7 @@ GTEST_TEST(Quaternion, MultiplicationByVector) {
   const Quaternion dut(1., 0., 1., 0.);
   const Vector3 kExpectedResult(3., 1., 1.);
 
-  EXPECT_TRUE(CompareVectors(kExpectedResult, dut * v, kTolerance));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(kExpectedResult, dut * v, kTolerance)));
 }
 
 GTEST_TEST(Quaternion, Slerp) {
@@ -618,7 +624,8 @@ GTEST_TEST(Quaternion, Slerp) {
 
   // Degrading tolerance in this test on purpose because of the overhead in the
   // computation and the expected result.
-  EXPECT_TRUE(CompareVectors(Vector4(0.554528, -0.717339, 0.32579, 0.267925), q3.coeffs(), 1e-6 /* tolerance */));
+  EXPECT_TRUE(maliput::test::AssertCompare(
+      CompareVectors(Vector4(0.554528, -0.717339, 0.32579, 0.267925), q3.coeffs(), 1e-6 /* tolerance */)));
 }
 
 GTEST_TEST(Quaternion, Serialization) {
@@ -638,30 +645,30 @@ GTEST_TEST(Quaternion, FromTwoVectors) {
 
   {  // X to Y.
     const Quaternion dut = Quaternion::FromTwoVectors(kUnitX, kUnitY);
-    EXPECT_TRUE(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance)));
   }
   {
     Quaternion dut;
     dut.SetFromTwoVectors(kUnitX, kUnitY);
-    EXPECT_TRUE(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., 0., kU), dut.coeffs(), kTolerance)));
   }
   {  // Y to Z.
     const Quaternion dut = Quaternion::FromTwoVectors(kUnitY, kUnitZ);
-    EXPECT_TRUE(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance)));
   }
   {
     Quaternion dut;
     dut.SetFromTwoVectors(kUnitY, kUnitZ);
-    EXPECT_TRUE(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, kU, 0., 0.), dut.coeffs(), kTolerance)));
   }
   {  // Z to X.
     const Quaternion dut = Quaternion::FromTwoVectors(kUnitZ, kUnitX);
-    EXPECT_TRUE(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance)));
   }
   {
     Quaternion dut;
     dut.SetFromTwoVectors(kUnitZ, kUnitX);
-    EXPECT_TRUE(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(CompareVectors(Vector4(kW, 0., kU, 0.), dut.coeffs(), kTolerance)));
   }
 }
 

--- a/test/math/roll_pitch_yaw_test.cc
+++ b/test/math/roll_pitch_yaw_test.cc
@@ -31,7 +31,9 @@
 
 #include <gtest/gtest.h>
 
-#include "maliput/test_utilities/maliput_math_compare.h"
+#include "maliput/common/compare.h"
+#include "maliput/math/compare.h"
+#include "test_utilities/assert_compare.h"
 
 namespace maliput {
 namespace math {
@@ -84,8 +86,8 @@ GTEST_TEST(RollPitchYawTest, PublicMethods) {
     EXPECT_DOUBLE_EQ(kDut.roll_angle(), M_PI / 2);
     EXPECT_DOUBLE_EQ(kDut.pitch_angle(), 0.);
     EXPECT_DOUBLE_EQ(kDut.yaw_angle(), M_PI / 2);
-    EXPECT_TRUE(
-        test::CompareMatrices(kDut.ToMatrix(), Matrix3({{0., 0., 1.}, {1., 0., 0.}, {0., 1., 0.}}), kTolerance));
+    EXPECT_TRUE(maliput::test::AssertCompare(
+        CompareMatrices(kDut.ToMatrix(), Matrix3({{0., 0., 1.}, {1., 0., 0.}, {0., 1., 0.}}), kTolerance)));
     ExpectDoubleEq(kDut.ToQuaternion(), Quaternion(0.5, 0.5, 0.5, 0.5));
   }
   // mutable references
@@ -150,7 +152,7 @@ GTEST_TEST(RollPitchYawTest, OrdinaryDerivativeRotationMatrixRollPitchYaw) {
                      -s1*c0*pDt - s0*c1*rDt});
   // clang-format on
 
-  EXPECT_TRUE(test::CompareMatrices(RDt, MDt, kTolerance));
+  EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(RDt, MDt, kTolerance)));
 }
 
 }  // namespace

--- a/test/math/roll_pitch_yaw_test.cc
+++ b/test/math/roll_pitch_yaw_test.cc
@@ -39,6 +39,8 @@ namespace maliput {
 namespace math {
 namespace {
 
+using maliput::test::AssertCompare;
+
 static constexpr double kTolerance{1e-10};
 
 void ExpectDoubleEq(const RollPitchYaw& rpy1, const RollPitchYaw& rpy2) {
@@ -86,7 +88,7 @@ GTEST_TEST(RollPitchYawTest, PublicMethods) {
     EXPECT_DOUBLE_EQ(kDut.roll_angle(), M_PI / 2);
     EXPECT_DOUBLE_EQ(kDut.pitch_angle(), 0.);
     EXPECT_DOUBLE_EQ(kDut.yaw_angle(), M_PI / 2);
-    EXPECT_TRUE(maliput::test::AssertCompare(
+    EXPECT_TRUE(AssertCompare(
         CompareMatrices(kDut.ToMatrix(), Matrix3({{0., 0., 1.}, {1., 0., 0.}, {0., 1., 0.}}), kTolerance)));
     ExpectDoubleEq(kDut.ToQuaternion(), Quaternion(0.5, 0.5, 0.5, 0.5));
   }
@@ -152,7 +154,7 @@ GTEST_TEST(RollPitchYawTest, OrdinaryDerivativeRotationMatrixRollPitchYaw) {
                      -s1*c0*pDt - s0*c1*rDt});
   // clang-format on
 
-  EXPECT_TRUE(maliput::test::AssertCompare(CompareMatrices(RDt, MDt, kTolerance)));
+  EXPECT_TRUE(AssertCompare(CompareMatrices(RDt, MDt, kTolerance)));
 }
 
 }  // namespace

--- a/test/test_utilities/CMakeLists.txt
+++ b/test/test_utilities/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(ament_cmake_gtest REQUIRED)
 
+ament_add_gtest(assert_compare_test assert_compare_test.cc)
 ament_add_gtest(maliput_routing_position_compare_test maliput_routing_position_compare_test.cc)
 ament_add_gtest(maliput_types_compare_test maliput_types_compare_test.cc)
 
@@ -23,5 +24,6 @@ macro(add_dependencies_to_test target)
     endif()
 endmacro()
 
+add_dependencies_to_test(assert_compare_test)
 add_dependencies_to_test(maliput_routing_position_compare_test)
 add_dependencies_to_test(maliput_types_compare_test)

--- a/test/test_utilities/assert_compare_test.cc
+++ b/test/test_utilities/assert_compare_test.cc
@@ -1,0 +1,46 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "test_utilities/assert_compare.h"
+
+#include <gtest/gtest.h>
+
+namespace maliput {
+namespace test {
+namespace {
+
+TEST(AssertCompare, Test) {
+  common::ComparisonResult<std::string> res;
+  EXPECT_TRUE(AssertCompare(res));
+  res.message = "foo";
+  EXPECT_FALSE(AssertCompare(res));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput/pull/593

## Summary
 - Creates a ComparisonResult struct to hold the result of any comparison type.
 - Moves up the comparison logic for maliput::math types to maliput math library
 - Point all the tests to use this instead of the old maliput_math_compare.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
