### PR TITLE
Updates configuration of codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,7 +23,8 @@ fixes:
   - "ros_ws/src/*/maliput/::"
 
 github_checks:
-  annotations: true
+  # Disable GitHub line-by-line annotations.
+  annotations: false
 
 # Exclude unwanted directories from code coverage reports.
 ignore:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,10 +15,7 @@ coverage:
       default:
         target: auto
         threshold: 5%
-        removed_code_behavior: fully_covered_patch
-    patch:
-      default:
-        target: auto
+        base: auto
         removed_code_behavior: fully_covered_patch
 
 # Recommended by https://github.com/ros-tooling/action-ros-ci#integrate-action-ros-ci-with-codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,9 @@ jobs:
           {
             "build": {
               "mixin": ["coverage-gcc"]
+            },
+            "lcov-result": {
+              "lcov-config-file": "${{ github.workspace }}/.lcovrc"
             }
           }
         # If possible, pin the repository in the workflow to a specific commit to avoid

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ros-tooling/setup-ros@v0.3
-    - uses: ros-tooling/action-ros-ci@v0.2
+    - uses: ros-tooling/action-ros-ci@v0.3
       id: action_ros_ci_step
       with:
         package-name: ${{ env.PACKAGE_NAME }}
@@ -56,17 +56,34 @@ jobs:
           }
         # If possible, pin the repository in the workflow to a specific commit to avoid
         # changes in colcon-mixin-repository from breaking your tests.
-        colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml
-    - uses: codecov/codecov-action@v1.2.1
+        colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/c75e4b34a3959524564afb584e2aa33c7eec323c/index.yaml
+    - uses: codecov/codecov-action@v3
       with:
         # Regarding token use in public repo:
         # See https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ros_ws/lcov/total_coverage.info
+        directory: lcov
+        working-directory: ros_ws
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true
         verbose: true
+
+    # Uploads the logs to the workflow run
+    - uses: actions/upload-artifact@v3
+      with:
+        name: colcon-logs
+        retention-days: 7
+        path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/log
+      # Uploads when the build fails
+      if: always() # upload the logs even when the build fails
+
+    # Uploads the lcov files to the workflow run
+    - uses: actions/upload-artifact@v3
+      with:
+        name: lcov
+        retention-days: 7
+        path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/lcov
 
     # create tarball to push to github artifacts
     # Note that a file with the name of the bundle is created to pass the value

--- a/.lcovrc
+++ b/.lcovrc
@@ -1,3 +1,27 @@
+# Specify size of tabs
+genhtml_num_spaces = 2
+
+# Include color legend in HTML output if non-zero
+genhtml_legend = 1
+
+# Include function coverage data display
+genhtml_function_coverage = 0
+
+# Include branch coverage data display
+genhtml_branch_coverage = 0
+
+# Specify if geninfo should try to automatically determine
+# the base-directory when collecting coverage data.
+geninfo_auto_base = 1
+
+# Specify whether to capture coverage data for external source
+# files
+geninfo_external = 0
+
+# Specify if function coverage data should be collected and
+# processed.
+lcov_function_coverage = 0
+
 # Specify if branch coverage data should be collected and
 # processed.
 lcov_branch_coverage = 0

--- a/.lcovrc
+++ b/.lcovrc
@@ -1,0 +1,3 @@
+# Specify if branch coverage data should be collected and
+# processed.
+lcov_branch_coverage = 0


### PR DESCRIPTION
# 🦟 Bug fix

related to #552

## Summary
 - Remove the coverage information about branches:
   - See https://stackoverflow.com/questions/42003783/lcov-gcov-branch-coverage-with-c-producing-branches-all-over-the-place
   - A configuration file is added: https://linux.die.net/man/5/lcovrc
 - Add information for the coverage of the entire project
 - Upload artifacts about lcov with (7 days of retention)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
