### PR TITLE
Excludes drake from codecov.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -28,7 +28,7 @@ github_checks:
 
 # Exclude unwanted directories from code coverage reports.
 ignore:
-  - "doc"
-  - "test"
-  - "tools"
-  - "*/drake/*" # Exclude drake as it is brought under direct copy.
+  - "**/doc"
+  - "**/test"
+  - "**/tools"
+  - "**/drake"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -31,3 +31,4 @@ ignore:
   - "doc"
   - "test"
   - "tools"
+  - "*/drake/*" # Exclude drake as it is brought under direct copy.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,7 @@ jobs:
         # Regarding token use in public repo:
         # See https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
         token: ${{ secrets.CODECOV_TOKEN }}
-        directory: lcov
-        working-directory: ros_ws
+        files: ros_ws/lcov/total_coverage.info
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
 - Drake namespace is a copy-paste from drake repository and therefore we don't have tests for those methods. So, this isn't representative of the code coverage of maliput.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)


