### PR TITLE
Decouples test_utilities compare methods

### DIFF
--- a/include/maliput/api/compare.h
+++ b/include/maliput/api/compare.h
@@ -29,7 +29,15 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <optional>
+#include <string>
+
+#include "maliput/api/branch_point.h"
+#include "maliput/api/junction.h"
 #include "maliput/api/lane_data.h"
+#include "maliput/api/regions.h"
+#include "maliput/api/road_geometry.h"
+#include "maliput/api/segment.h"
 #include "maliput/common/compare.h"
 
 namespace maliput {
@@ -101,6 +109,39 @@ common::ComparisonResult<HBounds> IsHBoundsClose(const HBounds& hbounds1, const 
 /// @param lane_end2 A LaneEnd object to compare.
 /// @returns A ComparisonResult indicating whether the two LaneEnds are equal.
 common::ComparisonResult<LaneEnd> IsLaneEndEqual(const LaneEnd& lane_end1, const LaneEnd& lane_end2);
+
+common::ComparisonResult<Junction> IsEqual(const char* a_expression, const char* b_expression, const Junction* a,
+                                           const Junction* b);
+common::ComparisonResult<Segment> IsEqual(const char* a_expression, const char* b_expression, const Segment* a,
+                                          const Segment* b);
+common::ComparisonResult<Lane> IsEqual(const char* a_expression, const char* b_expression, const Lane* a,
+                                       const Lane* b);
+common::ComparisonResult<BranchPoint> IsEqual(const char* a_expression, const char* b_expression, const BranchPoint* a,
+                                              const BranchPoint* b);
+
+common::ComparisonResult<bool> IsEqual(const char* a_expression, const char* b_expression, bool a, bool b);
+common::ComparisonResult<double> IsEqual(const char* a_expression, const char* b_expression, double a, double b);
+common::ComparisonResult<std::size_t> IsEqual(const char* a_expression, const char* b_expression, std::size_t a,
+                                              std::size_t b);
+
+template <typename T>
+common::ComparisonResult<TypeSpecificIdentifier<T>> IsEqual(const char* a_expression, const char* b_expression,
+                                                            const TypeSpecificIdentifier<T>& a,
+                                                            const TypeSpecificIdentifier<T>& b) {
+  if (a != b) {
+    return {"Values are different. " + std::string(a_expression) + ": " + a.string() + " vs. " +
+            std::string(b_expression) + ": " + b.string() + "\n"};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<SRange> IsEqual(const SRange& srange1, const SRange& srange2);
+common::ComparisonResult<LaneSRange> IsEqual(const LaneSRange& lane_s_range_1, const LaneSRange& lane_s_range_2);
+common::ComparisonResult<std::vector<LaneSRange>> IsEqual(const std::vector<LaneSRange>& lane_s_ranges_1,
+                                                          const std::vector<LaneSRange>& lane_s_ranges_2);
+common::ComparisonResult<LaneSRoute> IsEqual(const LaneSRoute& lane_s_route_1, const LaneSRoute& lane_s_route_2);
+
+std::optional<std::string> CheckIdIndexing(const RoadGeometry* road_geometry);
 
 }  // namespace api
 }  // namespace maliput

--- a/include/maliput/api/compare.h
+++ b/include/maliput/api/compare.h
@@ -141,6 +141,11 @@ common::ComparisonResult<std::vector<LaneSRange>> IsEqual(const std::vector<Lane
                                                           const std::vector<LaneSRange>& lane_s_ranges_2);
 common::ComparisonResult<LaneSRoute> IsEqual(const LaneSRoute& lane_s_route_1, const LaneSRoute& lane_s_route_2);
 
+common::ComparisonResult<InertialPosition> IsEqual(const InertialPosition& inertial_position_1,
+                                                   const InertialPosition& inertial_position_2);
+
+common::ComparisonResult<Rotation> IsEqual(const Rotation& rotation_1, const Rotation& rotation_2);
+
 std::optional<std::string> CheckIdIndexing(const RoadGeometry* road_geometry);
 
 }  // namespace api

--- a/include/maliput/api/compare.h
+++ b/include/maliput/api/compare.h
@@ -110,20 +110,74 @@ common::ComparisonResult<HBounds> IsHBoundsClose(const HBounds& hbounds1, const 
 /// @returns A ComparisonResult indicating whether the two LaneEnds are equal.
 common::ComparisonResult<LaneEnd> IsLaneEndEqual(const LaneEnd& lane_end1, const LaneEnd& lane_end2);
 
+/// Compares equality of two Junction objects.
+/// @param a_expression Literal expression of the first Junction.
+/// @param b_expression Literal expression of the second Junction.
+/// @param a The first Junction to compare.
+/// @param b The second Junction to compare.
+/// @returns A ComparisonResult indicating whether the two Junctions are the same.
 common::ComparisonResult<Junction> IsEqual(const char* a_expression, const char* b_expression, const Junction* a,
                                            const Junction* b);
+
+/// Compares equality of two Segment objects.
+/// @param a_expression Literal expression of the first Segment.
+/// @param b_expression Literal expression of the second Segment.
+/// @param a The first Segment to compare.
+/// @param b The second Segment to compare.
+/// @returns A ComparisonResult indicating whether the two Segments are the same.
 common::ComparisonResult<Segment> IsEqual(const char* a_expression, const char* b_expression, const Segment* a,
                                           const Segment* b);
+
+/// Compares equality of two Lane objects.
+/// @param a_expression Literal expression of the first Lane.
+/// @param b_expression Literal expression of the second Lane.
+/// @param a The first Lane to compare.
+/// @param b The second Lane to compare.
+/// @returns A ComparisonResult indicating whether the two Lanes are the same.
 common::ComparisonResult<Lane> IsEqual(const char* a_expression, const char* b_expression, const Lane* a,
                                        const Lane* b);
+
+/// Compares equality of two BranchPoint objects.
+/// @param a_expression Literal expression of the first BranchPoint.
+/// @param b_expression Literal expression of the second BranchPoint.
+/// @param a The first BranchPoint to compare.
+/// @param b The second BranchPoint to compare.
+/// @returns A ComparisonResult indicating whether the two BranchPoints are the same.
 common::ComparisonResult<BranchPoint> IsEqual(const char* a_expression, const char* b_expression, const BranchPoint* a,
                                               const BranchPoint* b);
 
+/// Compares equality of two booleans.
+/// @param a_expression Literal expression of the first boolean.
+/// @param b_expression Literal expression of the second boolean.
+/// @param a The first boolean to compare.
+/// @param b The second boolean to compare.
+/// @returns A ComparisonResult indicating whether the two booleans are equal.
 common::ComparisonResult<bool> IsEqual(const char* a_expression, const char* b_expression, bool a, bool b);
+
+/// Compares equality of two doubles.
+/// @param a_expression Literal expression of the first double.
+/// @param b_expression Literal expression of the second double.
+/// @param a The first double to compare.
+/// @param b The second double to compare.
+/// @returns A ComparisonResult indicating whether the two doubles are equal.
 common::ComparisonResult<double> IsEqual(const char* a_expression, const char* b_expression, double a, double b);
+
+/// Compares equality of two std::size_t.
+/// @param a_expression Literal expression of the first std::size_t.
+/// @param b_expression Literal expression of the second std::size_t.
+/// @param a The first std::size_t to compare.
+/// @param b The second std::size_t to compare.
+/// @returns A ComparisonResult indicating whether the two std::size_t are equal.
 common::ComparisonResult<std::size_t> IsEqual(const char* a_expression, const char* b_expression, std::size_t a,
                                               std::size_t b);
 
+/// Compares equality of two TypeSpecificIdentifier<T>.
+/// @paramT T The type of the TypeSpecificIdentifier.
+/// @param a_expression Literal expression of the first TypeSpecificIdentifier.
+/// @param b_expression Literal expression of the second TypeSpecificIdentifier.
+/// @param a The first TypeSpecificIdentifier to compare.
+/// @param b The second TypeSpecificIdentifier to compare.
+/// @returns A ComparisonResult indicating whether the two TypeSpecificIdentifiers are equal.
 template <typename T>
 common::ComparisonResult<TypeSpecificIdentifier<T>> IsEqual(const char* a_expression, const char* b_expression,
                                                             const TypeSpecificIdentifier<T>& a,
@@ -135,17 +189,47 @@ common::ComparisonResult<TypeSpecificIdentifier<T>> IsEqual(const char* a_expres
   return {std::nullopt};
 }
 
-common::ComparisonResult<SRange> IsEqual(const SRange& srange1, const SRange& srange2);
+/// Compares equality of two SRanges.
+/// @param s_range_1 The first SRange to compare.
+/// @param s_range_2 The second SRange to compare.
+/// @returns A ComparisonResult indicating whether the two SRanges are equal.
+common::ComparisonResult<SRange> IsEqual(const SRange& s_range_1, const SRange& s_range_2);
+
+/// Compares equality of two LaneSRange.
+/// @param lane_s_range_1 The first LaneSRange to compare.
+/// @param lane_s_range_2 The second LaneSRange to compare.
+/// @returns A ComparisonResult indicating whether the two LaneSRanges are equal.
 common::ComparisonResult<LaneSRange> IsEqual(const LaneSRange& lane_s_range_1, const LaneSRange& lane_s_range_2);
+
+/// Compares equality of two std::vector<LaneSRange>.
+/// @param lane_s_ranges_1 The first std::vector<LaneSRange> to compare.
+/// @param lane_s_ranges_2 The second std::vector<LaneSRange> to compare.
+/// @return A ComparisonResult indicating whether the two std::vector<LaneSRange> are equal.
 common::ComparisonResult<std::vector<LaneSRange>> IsEqual(const std::vector<LaneSRange>& lane_s_ranges_1,
                                                           const std::vector<LaneSRange>& lane_s_ranges_2);
+
+/// Compares equality of two LaneSRoute.
+/// @param lane_s_route_1 The first LaneSRoute to compare.
+/// @param lane_s_route_2 The second LaneSRoute to compare.
+/// @returns A ComparisonResult indicating whether the two LaneSRoutes are equal.
 common::ComparisonResult<LaneSRoute> IsEqual(const LaneSRoute& lane_s_route_1, const LaneSRoute& lane_s_route_2);
 
+/// Compares equality of two InertialPosition.
+/// @param inertial_position_1 The first InertialPosition to compare.
+/// @param inertial_position_2 The second InertialPosition to compare.
+/// @returns A ComparisonResult indicating whether the two InertialPositions are equal.
 common::ComparisonResult<InertialPosition> IsEqual(const InertialPosition& inertial_position_1,
                                                    const InertialPosition& inertial_position_2);
 
+/// Compares equality of two Rotation.
+/// @param rotation_1 The first Rotation to compare.
+/// @param rotation_2 The second Rotation to compare.
+/// @returns A ComparisonResult indicating whether the two Rotations are equal.
 common::ComparisonResult<Rotation> IsEqual(const Rotation& rotation_1, const Rotation& rotation_2);
 
+/// Checks that the given RoadGeometry's ById() indexing is correct.
+/// @param road_geometry The RoadGeometry to check.
+/// @returns A std::optional<std::string> containing an error message if the indexing is incorrect.
 std::optional<std::string> CheckIdIndexing(const RoadGeometry* road_geometry);
 
 }  // namespace api

--- a/include/maliput/api/rules/compare.h
+++ b/include/maliput/api/rules/compare.h
@@ -1,0 +1,70 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "maliput/api/rules/phase.h"
+#include "maliput/api/rules/phase_ring.h"
+#include "maliput/api/rules/traffic_lights.h"
+#include "maliput/common/compare.h"
+
+namespace maliput {
+namespace api {
+namespace rules {
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+common::ComparisonResult<RuleStates> IsEqual(const RuleStates& a, const RuleStates& b);
+#pragma GCC diagnostic pop
+
+common::ComparisonResult<DiscreteValueRule::DiscreteValue> IsEqual(const DiscreteValueRule::DiscreteValue& a,
+                                                                   const DiscreteValueRule::DiscreteValue& b);
+
+common::ComparisonResult<std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>> IsEqual(
+    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& a,
+    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& b);
+
+common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b);
+common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
+                                                            const std::optional<BulbStates>& b);
+
+common::ComparisonResult<Phase> IsEqual(const Phase& a, const Phase& b);
+
+common::ComparisonResult<PhaseRing::NextPhase> IsEqual(const PhaseRing::NextPhase& a, const PhaseRing::NextPhase& b);
+
+common::ComparisonResult<std::vector<PhaseRing::NextPhase>> IsEqual(const std::vector<PhaseRing::NextPhase>& a,
+                                                                    const std::vector<PhaseRing::NextPhase>& b);
+
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput

--- a/include/maliput/api/rules/compare.h
+++ b/include/maliput/api/rules/compare.h
@@ -53,10 +53,6 @@ namespace rules {
 common::ComparisonResult<RuleStates> IsEqual(const RuleStates& a, const RuleStates& b);
 #pragma GCC diagnostic pop
 
-common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b);
-common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
-                                                            const std::optional<BulbStates>& b);
-
 common::ComparisonResult<Phase> IsEqual(const Phase& a, const Phase& b);
 
 common::ComparisonResult<PhaseRing::NextPhase> IsEqual(const PhaseRing::NextPhase& a, const PhaseRing::NextPhase& b);
@@ -130,6 +126,28 @@ common::ComparisonResult<rules::SpeedLimitRule> IsEqual(const rules::SpeedLimitR
 common::ComparisonResult<std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>> IsEqual(
     const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& a,
     const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& b);
+
+common::ComparisonResult<BulbColor> IsEqual(const BulbColor& a, const BulbColor& b);
+
+common::ComparisonResult<BulbType> IsEqual(const BulbType& a, const BulbType& b);
+
+common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b);
+common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
+                                                            const std::optional<BulbStates>& b);
+
+common::ComparisonResult<std::optional<double>> IsEqual(const std::optional<double>& a, const std::optional<double>& b);
+
+common::ComparisonResult<Bulb::BoundingBox> IsEqual(const Bulb::BoundingBox& a, const Bulb::BoundingBox& b);
+
+common::ComparisonResult<Bulb> IsEqual(const Bulb* a, const Bulb* b);
+
+common::ComparisonResult<std::vector<const Bulb*>> IsEqual(const char* a_expression, const char* b_expression,
+                                                           const std::vector<const Bulb*>& a,
+                                                           const std::vector<const Bulb*>& b);
+
+common::ComparisonResult<BulbGroup> IsEqual(const BulbGroup* a, const BulbGroup* b);
+
+common::ComparisonResult<TrafficLight> IsEqual(const TrafficLight* a, const TrafficLight* b);
 
 }  // namespace rules
 }  // namespace api

--- a/include/maliput/api/rules/compare.h
+++ b/include/maliput/api/rules/compare.h
@@ -40,6 +40,7 @@
 #include "maliput/api/rules/range_value_rule.h"
 #include "maliput/api/rules/right_of_way_rule.h"
 #include "maliput/api/rules/right_of_way_rule_state_provider.h"
+#include "maliput/api/rules/speed_limit_rule.h"
 #include "maliput/api/rules/traffic_lights.h"
 #include "maliput/common/compare.h"
 
@@ -118,6 +119,11 @@ common::ComparisonResult<rules::RightOfWayRule> IsEqual(const rules::RightOfWayR
 common::ComparisonResult<rules::RightOfWayRuleStateProvider::RightOfWayResult> IsEqual(
     const rules::RightOfWayRuleStateProvider::RightOfWayResult& a,
     const rules::RightOfWayRuleStateProvider::RightOfWayResult& b);
+
+common::ComparisonResult<rules::SpeedLimitRule::Severity> IsEqual(rules::SpeedLimitRule::Severity a,
+                                                                  rules::SpeedLimitRule::Severity b);
+
+common::ComparisonResult<rules::SpeedLimitRule> IsEqual(const rules::SpeedLimitRule& a, const rules::SpeedLimitRule& b);
 
 #pragma GCC diagnostic pop
 

--- a/include/maliput/api/rules/compare.h
+++ b/include/maliput/api/rules/compare.h
@@ -33,8 +33,10 @@
 #include <string>
 #include <vector>
 
+#include "maliput/api/rules/discrete_value_rule.h"
 #include "maliput/api/rules/phase.h"
 #include "maliput/api/rules/phase_ring.h"
+#include "maliput/api/rules/range_value_rule.h"
 #include "maliput/api/rules/traffic_lights.h"
 #include "maliput/common/compare.h"
 
@@ -47,13 +49,6 @@ namespace rules {
 common::ComparisonResult<RuleStates> IsEqual(const RuleStates& a, const RuleStates& b);
 #pragma GCC diagnostic pop
 
-common::ComparisonResult<DiscreteValueRule::DiscreteValue> IsEqual(const DiscreteValueRule::DiscreteValue& a,
-                                                                   const DiscreteValueRule::DiscreteValue& b);
-
-common::ComparisonResult<std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>> IsEqual(
-    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& a,
-    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& b);
-
 common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b);
 common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
                                                             const std::optional<BulbStates>& b);
@@ -64,6 +59,22 @@ common::ComparisonResult<PhaseRing::NextPhase> IsEqual(const PhaseRing::NextPhas
 
 common::ComparisonResult<std::vector<PhaseRing::NextPhase>> IsEqual(const std::vector<PhaseRing::NextPhase>& a,
                                                                     const std::vector<PhaseRing::NextPhase>& b);
+
+common::ComparisonResult<RangeValueRule::Range> IsEqual(const rules::RangeValueRule::Range& a,
+                                                        const rules::RangeValueRule::Range& b);
+common::ComparisonResult<RangeValueRule> IsEqual(const rules::RangeValueRule& a, const rules::RangeValueRule& b);
+common::ComparisonResult<std::vector<rules::RangeValueRule::Range>> IsEqual(
+    const std::vector<rules::RangeValueRule::Range>& a, const std::vector<rules::RangeValueRule::Range>& b);
+
+common::ComparisonResult<DiscreteValueRule::DiscreteValue> IsEqual(const DiscreteValueRule::DiscreteValue& a,
+                                                                   const DiscreteValueRule::DiscreteValue& b);
+common::ComparisonResult<DiscreteValueRule> IsEqual(const DiscreteValueRule& a, const DiscreteValueRule& b);
+common::ComparisonResult<std::vector<DiscreteValueRule::DiscreteValue>> IsEqual(
+    const std::vector<DiscreteValueRule::DiscreteValue>& a, const std::vector<DiscreteValueRule::DiscreteValue>& b);
+
+common::ComparisonResult<std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>> IsEqual(
+    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& a,
+    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& b);
 
 }  // namespace rules
 }  // namespace api

--- a/include/maliput/api/rules/compare.h
+++ b/include/maliput/api/rules/compare.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <vector>
 
+#include "maliput/api/rules/direction_usage_rule.h"
 #include "maliput/api/rules/discrete_value_rule.h"
 #include "maliput/api/rules/phase.h"
 #include "maliput/api/rules/phase_ring.h"
@@ -75,6 +76,25 @@ common::ComparisonResult<std::vector<DiscreteValueRule::DiscreteValue>> IsEqual(
 common::ComparisonResult<std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>> IsEqual(
     const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& a,
     const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& b);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+common::ComparisonResult<DirectionUsageRule::State::Type> IsEqual(DirectionUsageRule::State::Type a,
+                                                                  DirectionUsageRule::State::Type b);
+
+common::ComparisonResult<DirectionUsageRule::State::Severity> IsEqual(DirectionUsageRule::State::Severity a,
+                                                                      DirectionUsageRule::State::Severity b);
+
+common::ComparisonResult<DirectionUsageRule::State> IsEqual(const DirectionUsageRule::State& a,
+                                                            const DirectionUsageRule::State& b);
+
+common::ComparisonResult<std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>> IsEqual(
+
+    const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& a,
+    const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& b);
+
+common::ComparisonResult<DirectionUsageRule> IsEqual(const DirectionUsageRule& a, const DirectionUsageRule& b);
+#pragma GCC diagnostic pop
 
 }  // namespace rules
 }  // namespace api

--- a/include/maliput/api/rules/compare.h
+++ b/include/maliput/api/rules/compare.h
@@ -50,103 +50,252 @@ namespace rules {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+/// Evaluates the equality of two RuleStates.
+/// @param a The first RuleStates to compare.
+/// @param b The second RuleStates to compare.
+/// @returns A ComparisonResult indicating whether the two RuleStates are equal.
 common::ComparisonResult<RuleStates> IsEqual(const RuleStates& a, const RuleStates& b);
 #pragma GCC diagnostic pop
 
+/// Evaluates the equality of two Phase.
+/// @param a The first Phase to compare.
+/// @param b The second Phase to compare.
+/// @returns A ComparisonResult indicating whether the two Phase are equal.
 common::ComparisonResult<Phase> IsEqual(const Phase& a, const Phase& b);
 
+/// Evaluates the equality of two PhaseRing::NextPhase.
+/// @param a The first PhaseRing::NextPhase to compare.
+/// @param b The second PhaseRing::NextPhase to compare.
+/// @returns A ComparisonResult indicating whether the two PhaseRing::NextPhase are equal.
 common::ComparisonResult<PhaseRing::NextPhase> IsEqual(const PhaseRing::NextPhase& a, const PhaseRing::NextPhase& b);
 
+/// Evaluates the equality of two std::vector<PhaseRing::NextPhase>.
+/// @param a The first std::vector<PhaseRing::NextPhase> to compare.
+/// @param b The second std::vector<PhaseRing::NextPhase> to compare.
+/// @returns A ComparisonResult indicating whether the two std::vector<PhaseRing::NextPhase> are equal.
 common::ComparisonResult<std::vector<PhaseRing::NextPhase>> IsEqual(const std::vector<PhaseRing::NextPhase>& a,
                                                                     const std::vector<PhaseRing::NextPhase>& b);
 
-common::ComparisonResult<RangeValueRule::Range> IsEqual(const rules::RangeValueRule::Range& a,
-                                                        const rules::RangeValueRule::Range& b);
-common::ComparisonResult<RangeValueRule> IsEqual(const rules::RangeValueRule& a, const rules::RangeValueRule& b);
-common::ComparisonResult<std::vector<rules::RangeValueRule::Range>> IsEqual(
-    const std::vector<rules::RangeValueRule::Range>& a, const std::vector<rules::RangeValueRule::Range>& b);
+/// Evaluates the equality of two RangeValueRule::Range.
+/// @param a The first RangeValueRule::Range to compare.
+/// @param b The second RangeValueRule::Range to compare.
+/// @returns A ComparisonResult indicating whether the two RangeValueRule::Range are equal.
+common::ComparisonResult<RangeValueRule::Range> IsEqual(const RangeValueRule::Range& a, const RangeValueRule::Range& b);
 
+/// Evaluates the equality of two RangeValueRule.
+/// @param a The first RangeValueRule to compare.
+/// @param b The second RangeValueRule to compare.
+/// @returns A ComparisonResult indicating whether the two RangeValueRule are equal.
+common::ComparisonResult<RangeValueRule> IsEqual(const RangeValueRule& a, const RangeValueRule& b);
+
+/// Evaluates the equality of two std::vector<RangeValueRule::Range>.
+/// @param a The first std::vector<RangeValueRule::Range> to compare.
+/// @param b The second std::vector<RangeValueRule::Range> to compare.
+/// @returns A ComparisonResult indicating whether the two std::vector<RangeValueRule::Range> are equal.
+common::ComparisonResult<std::vector<RangeValueRule::Range>> IsEqual(const std::vector<RangeValueRule::Range>& a,
+                                                                     const std::vector<RangeValueRule::Range>& b);
+
+/// Evaluates the equality of two DiscreteValueRule::DiscreteValue.
+/// @param a The first DiscreteValueRule::DiscreteValue to compare.
+/// @param b The second DiscreteValueRule::DiscreteValue to compare.
+/// @returns A ComparisonResult indicating whether the two DiscreteValueRule::DiscreteValue are equal.
 common::ComparisonResult<DiscreteValueRule::DiscreteValue> IsEqual(const DiscreteValueRule::DiscreteValue& a,
                                                                    const DiscreteValueRule::DiscreteValue& b);
+
+/// Evaluates the equality of two DiscreteValueRule.
+/// @param a The first DiscreteValueRule to compare.
+/// @param b The second DiscreteValueRule to compare.
+/// @returns A ComparisonResult indicating whether the two DiscreteValueRule are equal.
 common::ComparisonResult<DiscreteValueRule> IsEqual(const DiscreteValueRule& a, const DiscreteValueRule& b);
+
+/// Evaluates the equality of two std::vector<DiscreteValueRule::DiscreteValue>.
+/// @param a The first std::vector<DiscreteValueRule::DiscreteValue> to compare.
+/// @param b The second std::vector<DiscreteValueRule::DiscreteValue> to compare.
+/// @returns A ComparisonResult indicating whether the two std::vector<DiscreteValueRule::DiscreteValue> are equal.
 common::ComparisonResult<std::vector<DiscreteValueRule::DiscreteValue>> IsEqual(
     const std::vector<DiscreteValueRule::DiscreteValue>& a, const std::vector<DiscreteValueRule::DiscreteValue>& b);
 
+/// Evaluates the equality of two std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>.
+/// @param a The first std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue> to compare.
+/// @param b The second std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue> to compare.
+/// @returns A ComparisonResult indicating whether the two std::unordered_map<Rule::Id,
+/// DiscreteValueRule::DiscreteValue> are equal.
 common::ComparisonResult<std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>> IsEqual(
     const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& a,
     const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& b);
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+/// Evaluates the equality of two DirectionUsageRule::State::Type.
+/// @param a The first DirectionUsageRule::State::Type to compare.
+/// @param b The second DirectionUsageRule::State::Type to compare.
+/// @returns A ComparisonResult indicating whether the two DirectionUsageRule::State::Type are equal.
 common::ComparisonResult<DirectionUsageRule::State::Type> IsEqual(DirectionUsageRule::State::Type a,
                                                                   DirectionUsageRule::State::Type b);
 
+/// Evaluates the equality of two DirectionUsageRule::State::Severity.
+/// @param a The first DirectionUsageRule::State::Severity to compare.
+/// @param b The second DirectionUsageRule::State::Severity to compare.
+/// @returns A ComparisonResult indicating whether the two DirectionUsageRule::State::Severity are equal.
 common::ComparisonResult<DirectionUsageRule::State::Severity> IsEqual(DirectionUsageRule::State::Severity a,
                                                                       DirectionUsageRule::State::Severity b);
 
+/// Evaluates the equality of two DirectionUsageRule::State.
+/// @param a The first DirectionUsageRule::State to compare.
+/// @param b The second DirectionUsageRule::State to compare.
+/// @returns A ComparisonResult indicating whether the two DirectionUsageRule::State are equal.
 common::ComparisonResult<DirectionUsageRule::State> IsEqual(const DirectionUsageRule::State& a,
                                                             const DirectionUsageRule::State& b);
 
+/// Evaluates the equality of two std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>.
+/// @param a The first std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State> to compare.
+/// @param b The second std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State> to compare.
+/// @returns A ComparisonResult indicating whether the two std::unordered_map<DirectionUsageRule::State::Id,
+/// DirectionUsageRule::State> are equal.
 common::ComparisonResult<std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>> IsEqual(
-
     const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& a,
     const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& b);
 
+/// Evaluates the equality of two DirectionUsageRule.
+/// @param a The first DirectionUsageRule to compare.
+/// @param b The second DirectionUsageRule to compare.
+/// @returns A ComparisonResult indicating whether the two DirectionUsageRule are equal.
 common::ComparisonResult<DirectionUsageRule> IsEqual(const DirectionUsageRule& a, const DirectionUsageRule& b);
 
-common::ComparisonResult<rules::RightOfWayRule::ZoneType> IsEqual(rules::RightOfWayRule::ZoneType a,
-                                                                  rules::RightOfWayRule::ZoneType b);
+/// Evaluates the equality of two RightOfWayRule::ZoneType.
+/// @param a The first RightOfWayRule::ZoneType to compare.
+/// @param b The second RightOfWayRule::ZoneType to compare.
+/// @returns A ComparisonResult indicating whether the two RightOfWayRule::ZoneType are equal.
+common::ComparisonResult<RightOfWayRule::ZoneType> IsEqual(RightOfWayRule::ZoneType a, RightOfWayRule::ZoneType b);
 
-common::ComparisonResult<rules::RightOfWayRule::State::Type> IsEqual(rules::RightOfWayRule::State::Type a,
-                                                                     rules::RightOfWayRule::State::Type b);
+/// Evaluates the equality of two RightOfWayRule::State::Type.
+/// @param a The first RightOfWayRule::State::Type to compare.
+/// @param b The second RightOfWayRule::State::Type to compare.
+/// @returns A ComparisonResult indicating whether the two RightOfWayRule::State::Type are equal.
+common::ComparisonResult<RightOfWayRule::State::Type> IsEqual(RightOfWayRule::State::Type a,
+                                                              RightOfWayRule::State::Type b);
 
-common::ComparisonResult<std::vector<rules::RightOfWayRule::Id>> IsEqual(
-    const std::vector<rules::RightOfWayRule::Id>& a, const std::vector<rules::RightOfWayRule::Id>& b);
+/// Evaluates the equality of two std::vector<RightOfWayRule::Id>.
+/// @param a The first std::vector<RightOfWayRule::Id> to compare.
+/// @param b The second std::vector<RightOfWayRule::Id> to compare.
+/// @returns A ComparisonResult indicating whether the two std::vector<RightOfWayRule::Id> are equal.
+common::ComparisonResult<std::vector<RightOfWayRule::Id>> IsEqual(const std::vector<RightOfWayRule::Id>& a,
+                                                                  const std::vector<RightOfWayRule::Id>& b);
 
-common::ComparisonResult<rules::RightOfWayRule::State> IsEqual(const rules::RightOfWayRule::State& a,
-                                                               const rules::RightOfWayRule::State& b);
+/// Evaluates the equality of two RightOfWayRule::State.
+/// @param a The first RightOfWayRule::State to compare.
+/// @param b The second RightOfWayRule::State to compare.
+/// @returns A ComparisonResult indicating whether the two RightOfWayRule::State are equal.
+common::ComparisonResult<RightOfWayRule::State> IsEqual(const RightOfWayRule::State& a, const RightOfWayRule::State& b);
 
-common::ComparisonResult<std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>> IsEqual(
-    const std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>& a,
-    const std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>& b);
+/// Evaluates the equality of two std::unordered_map<RightOfWayRule::State::Id, RightOfWayRule::State>.
+/// @param a The first std::unordered_map<RightOfWayRule::State::Id, RightOfWayRule::State> to compare.
+/// @param b The second std::unordered_map<RightOfWayRule::State::Id, RightOfWayRule::State> to compare.
+/// @returns A ComparisonResult indicating whether the two std::unordered_map<RightOfWayRule::State::Id,
+/// RightOfWayRule::State> are equal.
+common::ComparisonResult<std::unordered_map<RightOfWayRule::State::Id, RightOfWayRule::State>> IsEqual(
+    const std::unordered_map<RightOfWayRule::State::Id, RightOfWayRule::State>& a,
+    const std::unordered_map<RightOfWayRule::State::Id, RightOfWayRule::State>& b);
 
-common::ComparisonResult<rules::RightOfWayRule> IsEqual(const rules::RightOfWayRule& a, const rules::RightOfWayRule& b);
+/// Evaluates the equality of two RightOfWayRule.
+/// @param a The first RightOfWayRule to compare.
+/// @param b The second RightOfWayRule to compare.
+/// @returns A ComparisonResult indicating whether the two RightOfWayRule are equal.
+common::ComparisonResult<RightOfWayRule> IsEqual(const RightOfWayRule& a, const RightOfWayRule& b);
 
-common::ComparisonResult<rules::RightOfWayRuleStateProvider::RightOfWayResult> IsEqual(
-    const rules::RightOfWayRuleStateProvider::RightOfWayResult& a,
-    const rules::RightOfWayRuleStateProvider::RightOfWayResult& b);
+/// Evaluates the equality of two RightOfWayRuleStateProvider::RightOfWayResult.
+/// @param a The first RightOfWayRuleStateProvider::RightOfWayResult to compare.
+/// @param b The second RightOfWayRuleStateProvider::RightOfWayResult to compare.
+/// @returns A ComparisonResult indicating whether the two RightOfWayRuleStateProvider::RightOfWayResult are equal.
+common::ComparisonResult<RightOfWayRuleStateProvider::RightOfWayResult> IsEqual(
+    const RightOfWayRuleStateProvider::RightOfWayResult& a, const RightOfWayRuleStateProvider::RightOfWayResult& b);
 
-common::ComparisonResult<rules::SpeedLimitRule::Severity> IsEqual(rules::SpeedLimitRule::Severity a,
-                                                                  rules::SpeedLimitRule::Severity b);
+/// Evaluates the equality of two SpeedLimitRule::Severity.
+/// @param a The first SpeedLimitRule::Severity to compare.
+/// @param b The second SpeedLimitRule::Severity to compare.
+/// @returns A ComparisonResult indicating whether the two SpeedLimitRule::Severity are equal.
+common::ComparisonResult<SpeedLimitRule::Severity> IsEqual(SpeedLimitRule::Severity a, SpeedLimitRule::Severity b);
 
-common::ComparisonResult<rules::SpeedLimitRule> IsEqual(const rules::SpeedLimitRule& a, const rules::SpeedLimitRule& b);
+/// Evaluates the equality of two SpeedLimitRule.
+/// @param a The first SpeedLimitRule to compare.
+/// @param b The second SpeedLimitRule to compare.
+/// @returns A ComparisonResult indicating whether the two SpeedLimitRule are equal.
+common::ComparisonResult<SpeedLimitRule> IsEqual(const SpeedLimitRule& a, const SpeedLimitRule& b);
 
 #pragma GCC diagnostic pop
 
+/// Evaluates the equality of two std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>.
+/// @param a The first std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>> to compare.
+/// @param b The second std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>> to compare.
+/// @returns A ComparisonResult indicating whether the two std::unordered_map<TrafficLight::Id,
+/// std::vector<BulbGroup::Id>> are equal.
 common::ComparisonResult<std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>> IsEqual(
     const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& a,
     const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& b);
 
+/// Evaluates the equality of two BulbColor.
+/// @param a The first BulbColor to compare.
+/// @param b The second BulbColor to compare.
+/// @returns A ComparisonResult indicating whether the two BulbColor are equal.
 common::ComparisonResult<BulbColor> IsEqual(const BulbColor& a, const BulbColor& b);
 
+/// Evaluates the equality of two BulbType.
+/// @param a The first BulbType to compare.
+/// @param b The second BulbType to compare.
+/// @returns A ComparisonResult indicating whether the two BulbType are equal.
 common::ComparisonResult<BulbType> IsEqual(const BulbType& a, const BulbType& b);
 
+/// Evaluates the equality of two BulbState.
+/// @param a The first BulbState to compare.
+/// @param b The second BulbState to compare.
+/// @returns A ComparisonResult indicating whether the two BulbState are equal.
 common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b);
+
+/// Evaluates the equality of two std::optional<BulbStates>.
+/// @param a The first std::optional<BulbStates> to compare.
+/// @param b The second std::optional<BulbStates> to compare.
+/// @returns A ComparisonResult indicating whether the two std::optional<BulbStates> are equal.
 common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
                                                             const std::optional<BulbStates>& b);
 
+/// Evaluates the equality of two std::optional<double>.
+/// @param a The first std::optional<double> to compare.
+/// @param b The second std::optional<double> to compare.
+/// @returns A ComparisonResult indicating whether the two std::optional<double> are equal.
 common::ComparisonResult<std::optional<double>> IsEqual(const std::optional<double>& a, const std::optional<double>& b);
 
+/// Evaluates the equality of two Bulb::BoundingBox.
+/// @param a The first Bulb::BoundingBox to compare.
+/// @param b The second Bulb::BoundingBox to compare.
+/// @returns A ComparisonResult indicating whether the two Bulb::BoundingBox are equal.
 common::ComparisonResult<Bulb::BoundingBox> IsEqual(const Bulb::BoundingBox& a, const Bulb::BoundingBox& b);
 
+/// Evaluates the equality of two Bulb.
+/// @param a The first Bulb to compare.
+/// @param b The second Bulb to compare.
+/// @returns A ComparisonResult indicating whether the two Bulb are equal.
 common::ComparisonResult<Bulb> IsEqual(const Bulb* a, const Bulb* b);
 
+/// Evaluates the equality of two std::vector<const Bulb*>.
+/// @param a_expression The expression of the first std::vector<const Bulb*> to compare.
+/// @param b_expression The expression of the second std::vector<const Bulb*> to compare.
+/// @param a The first std::vector<const Bulb*> to compare.
+/// @param b The second std::vector<const Bulb*> to compare.
+/// @returns A ComparisonResult indicating whether the two std::vector<const Bulb*> are equal.
 common::ComparisonResult<std::vector<const Bulb*>> IsEqual(const char* a_expression, const char* b_expression,
                                                            const std::vector<const Bulb*>& a,
                                                            const std::vector<const Bulb*>& b);
 
+/// Evaluates the equality of two BulbGroup.
+/// @param a The first BulbGroup to compare.
+/// @param b The second BulbGroup to compare.
+/// @returns A ComparisonResult indicating whether the two BulbGroup are equal.
 common::ComparisonResult<BulbGroup> IsEqual(const BulbGroup* a, const BulbGroup* b);
 
+/// Evaluates the equality of two TrafficLight.
+/// @param a The first TrafficLight to compare.
+/// @param b The second TrafficLight to compare.
+/// @returns A ComparisonResult indicating whether the two TrafficLight are equal.
 common::ComparisonResult<TrafficLight> IsEqual(const TrafficLight* a, const TrafficLight* b);
 
 }  // namespace rules

--- a/include/maliput/api/rules/compare.h
+++ b/include/maliput/api/rules/compare.h
@@ -38,6 +38,8 @@
 #include "maliput/api/rules/phase.h"
 #include "maliput/api/rules/phase_ring.h"
 #include "maliput/api/rules/range_value_rule.h"
+#include "maliput/api/rules/right_of_way_rule.h"
+#include "maliput/api/rules/right_of_way_rule_state_provider.h"
 #include "maliput/api/rules/traffic_lights.h"
 #include "maliput/common/compare.h"
 
@@ -94,7 +96,34 @@ common::ComparisonResult<std::unordered_map<DirectionUsageRule::State::Id, Direc
     const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& b);
 
 common::ComparisonResult<DirectionUsageRule> IsEqual(const DirectionUsageRule& a, const DirectionUsageRule& b);
+
+common::ComparisonResult<rules::RightOfWayRule::ZoneType> IsEqual(rules::RightOfWayRule::ZoneType a,
+                                                                  rules::RightOfWayRule::ZoneType b);
+
+common::ComparisonResult<rules::RightOfWayRule::State::Type> IsEqual(rules::RightOfWayRule::State::Type a,
+                                                                     rules::RightOfWayRule::State::Type b);
+
+common::ComparisonResult<std::vector<rules::RightOfWayRule::Id>> IsEqual(
+    const std::vector<rules::RightOfWayRule::Id>& a, const std::vector<rules::RightOfWayRule::Id>& b);
+
+common::ComparisonResult<rules::RightOfWayRule::State> IsEqual(const rules::RightOfWayRule::State& a,
+                                                               const rules::RightOfWayRule::State& b);
+
+common::ComparisonResult<std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>> IsEqual(
+    const std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>& a,
+    const std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>& b);
+
+common::ComparisonResult<rules::RightOfWayRule> IsEqual(const rules::RightOfWayRule& a, const rules::RightOfWayRule& b);
+
+common::ComparisonResult<rules::RightOfWayRuleStateProvider::RightOfWayResult> IsEqual(
+    const rules::RightOfWayRuleStateProvider::RightOfWayResult& a,
+    const rules::RightOfWayRuleStateProvider::RightOfWayResult& b);
+
 #pragma GCC diagnostic pop
+
+common::ComparisonResult<std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>> IsEqual(
+    const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& a,
+    const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& b);
 
 }  // namespace rules
 }  // namespace api

--- a/include/maliput/common/compare.h
+++ b/include/maliput/common/compare.h
@@ -47,5 +47,43 @@ struct ComparisonResult {
   std::optional<std::string> message;
 };
 
+/// @brief ComparisonResultCollector is a class that collects the results of a series
+///       of comparisons between objects of type T.
+class ComparisonResultCollector {
+ public:
+  ComparisonResultCollector() = default;
+
+  template <typename T>
+  void AddResult(const char* filename, int line, const char* expression, ComparisonResult<T> result) {
+    ++count_;
+    if (result.message.has_value()) {
+      ++failed_;
+      failure_message_ = failure_message_ + filename + ":" + std::to_string(line) + ": Failure #" +
+                         std::to_string(failed_) + ":\n" + "Expression '" + expression + "' failed:\n" +
+                         result.message.value() + "\n";
+    }
+  }
+  std::optional<std::string> result() const {
+    if (failed_ > 0) {
+      return std::to_string(failed_) + " out of " + std::to_string(count_) + " comparisons failed:\n" +
+             failure_message_;
+    }
+    return std::nullopt;
+  }
+
+  /// Returns the number of results collected.
+  int count() const { return count_; }
+
+  /// Returns the number of failure results collected.
+  int failed() const { return failed_; }
+
+ private:
+  int count_{0};
+  int failed_{0};
+  std::string failure_message_;
+};
+
+#define MALIPUT_ADD_RESULT(collector, result) collector.AddResult(__FILE__, __LINE__, #result, result)
+
 }  // namespace common
 }  // namespace maliput

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -12,6 +12,7 @@ set(API_SOURCES
   road_geometry.cc
   road_network.cc
   road_network_validator.cc
+  rules/compare.cc
   rules/direction_usage_rule.cc
   rules/discrete_value_rule.cc
   rules/phase.cc

--- a/src/api/compare.cc
+++ b/src/api/compare.cc
@@ -354,5 +354,23 @@ std::optional<std::string> CheckIdIndexing(const RoadGeometry* road_geometry) {
   return c.result();
 }
 
+common::ComparisonResult<InertialPosition> IsEqual(const InertialPosition& inertial_position_1,
+                                                   const InertialPosition& inertial_position_2) {
+  if (inertial_position_1 != inertial_position_2) {
+    return {std::string("InertialPositions are different. ") +
+            "inertial_position_1: " + inertial_position_1.xyz().to_str() +
+            " vs. inertial_position_2: " + inertial_position_2.xyz().to_str() + "\n"};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<Rotation> IsEqual(const Rotation& rotation_1, const Rotation& rotation_2) {
+  if (rotation_1.matrix() != rotation_2.matrix()) {
+    return {std::string("Rotations are different. ") + "rotation_1: " + rotation_1.matrix().to_str() +
+            " vs. rotation_2: " + rotation_2.matrix().to_str() + "\n"};
+  }
+  return {std::nullopt};
+}
+
 }  // namespace api
 }  // namespace maliput

--- a/src/api/compare.cc
+++ b/src/api/compare.cc
@@ -30,6 +30,7 @@
 #include "maliput/api/compare.h"
 
 #include <cmath>
+#include <limits>
 #include <optional>
 #include <string>
 
@@ -258,7 +259,7 @@ common::ComparisonResult<bool> IsEqual(const char* a_expression, const char* b_e
 
 common::ComparisonResult<double> IsEqual(const char* a_expression, const char* b_expression, double a, double b) {
   const double delta = std::abs(a - b);
-  if (delta > 1e-6) {
+  if (delta > std::numeric_limits<double>::epsilon()) {
     return {"Values are different. " + std::string(a_expression) + ": " + std::to_string(a) + " vs. " +
             std::string(b_expression) + ": " + std::to_string(b) + ", diff = " + std::to_string(delta) + "\n"};
   }

--- a/src/api/rules/compare.cc
+++ b/src/api/rules/compare.cc
@@ -183,7 +183,6 @@ common::ComparisonResult<DirectionUsageRule::State> IsEqual(const DirectionUsage
 }
 
 common::ComparisonResult<std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>> IsEqual(
-
     const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& a,
     const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& b) {
   common::ComparisonResultCollector c;

--- a/src/api/rules/compare.cc
+++ b/src/api/rules/compare.cc
@@ -326,6 +326,25 @@ common::ComparisonResult<rules::RightOfWayRuleStateProvider::RightOfWayResult> I
   return {c.result()};
 }
 
+common::ComparisonResult<rules::SpeedLimitRule::Severity> IsEqual(rules::SpeedLimitRule::Severity a,
+                                                                  rules::SpeedLimitRule::Severity b) {
+  if (a != b) {
+    return {"SpeedLimitRule::Severity are different"};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<rules::SpeedLimitRule> IsEqual(const rules::SpeedLimitRule& a,
+                                                        const rules::SpeedLimitRule& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a.zone(), b.zone()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.severity(), b.severity()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.max()", "b.max()", a.max(), b.max()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.min()", "b.min()", a.min(), b.min()));
+  return {c.result()};
+}
+
 #pragma GCC diagnostic pop
 
 common::ComparisonResult<std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>> IsEqual(

--- a/src/api/rules/compare.cc
+++ b/src/api/rules/compare.cc
@@ -174,6 +174,68 @@ common::ComparisonResult<std::vector<DiscreteValueRule::DiscreteValue>> IsEqual(
   return {c.result()};
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+common::ComparisonResult<DirectionUsageRule::State::Type> IsEqual(DirectionUsageRule::State::Type a,
+                                                                  DirectionUsageRule::State::Type b) {
+  if (a != b) {
+    return {"DirectionUsageRule::State::Type are different"};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<DirectionUsageRule::State::Severity> IsEqual(DirectionUsageRule::State::Severity a,
+                                                                      DirectionUsageRule::State::Severity b) {
+  if (a != b) {
+    return {"DirectionUsageRule::State::Severity are different"};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<DirectionUsageRule::State> IsEqual(const DirectionUsageRule::State& a,
+                                                            const DirectionUsageRule::State& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.severity(), b.severity()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.type(), b.type()));
+  return {c.result()};
+}
+
+common::ComparisonResult<std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>> IsEqual(
+
+    const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& a,
+    const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  const std::unordered_map<DirectionUsageRule::State::Id, DirectionUsageRule::State>& largest =
+      (a.size() < b.size()) ? b : a;
+  for (const auto& pair : largest) {
+    const DirectionUsageRule::State::Id& key = pair.first;
+    auto a_it = a.find(key);
+    auto b_it = b.find(key);
+    MALIPUT_ADD_RESULT(c, api::IsEqual("(a_it != a.cend())", "true", (a_it != a.cend()), true));
+    MALIPUT_ADD_RESULT(c, api::IsEqual("(b_it != b.cend())", "true", (b_it != b.cend()), true));
+    if ((a_it != a.cend()) && (b_it != b.cend())) {
+      MALIPUT_ADD_RESULT(c, IsEqual(a_it->second, b_it->second));
+    }
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<DirectionUsageRule> IsEqual(const DirectionUsageRule& a, const DirectionUsageRule& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a.zone(), b.zone()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.states(), b.states()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.is_static()", "b.is_static()", a.is_static(), b.is_static()));
+  if (a.is_static() && b.is_static()) {
+    MALIPUT_ADD_RESULT(c, IsEqual(a.static_state(), b.static_state()));
+  }
+  return {c.result()};
+}
+#pragma GCC diagnostic pop
+
 }  // namespace rules
 }  // namespace api
 }  // namespace maliput

--- a/src/api/rules/compare.cc
+++ b/src/api/rules/compare.cc
@@ -68,26 +68,6 @@ common::ComparisonResult<std::unordered_map<Rule::Id, DiscreteValueRule::Discret
   }
   return {c.result()};
 }
-common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b) {
-  if (a != b) {
-    return {"BulbStates are different: " + std::string(BulbStateMapper().at(a)) +
-            " != " + std::string(BulbStateMapper().at(b))};
-  }
-  return {std::nullopt};
-}
-
-common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
-                                                            const std::optional<BulbStates>& b) {
-  common::ComparisonResultCollector c;
-  MALIPUT_ADD_RESULT(c, api::IsEqual("a.has_value()", "b.has_value()", a.has_value(), b.has_value()));
-  if (a.has_value()) {
-    MALIPUT_ADD_RESULT(c, api::IsEqual("a->size()", "b->size()", a->size(), b->size()));
-    for (const auto& bulb_state : *a) {
-      MALIPUT_ADD_RESULT(c, IsEqual(b->at(bulb_state.first), bulb_state.second));
-    }
-  }
-  return {c.result()};
-}
 
 common::ComparisonResult<Phase> IsEqual(const Phase& a, const Phase& b) {
   common::ComparisonResultCollector c;
@@ -368,6 +348,118 @@ common::ComparisonResult<std::unordered_map<TrafficLight::Id, std::vector<BulbGr
         }
       }
     }
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<BulbColor> IsEqual(const BulbColor& a, const BulbColor& b) {
+  if (a != b) {
+    return {"BulbColors are different: " + std::string(BulbColorMapper().at(a)) +
+            " != " + std::string(BulbColorMapper().at(b))};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<BulbType> IsEqual(const BulbType& a, const BulbType& b) {
+  if (a != b) {
+    return {"BulbTypes are different: " + std::string(BulbTypeMapper().at(a)) +
+            " != " + std::string(BulbTypeMapper().at(b))};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b) {
+  if (a != b) {
+    return {"BulbStates are different: " + std::string(BulbStateMapper().at(a)) +
+            " != " + std::string(BulbStateMapper().at(b))};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
+                                                            const std::optional<BulbStates>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.has_value()", "b.has_value()", a.has_value(), b.has_value()));
+  if (a.has_value()) {
+    MALIPUT_ADD_RESULT(c, api::IsEqual("a->size()", "b->size()", a->size(), b->size()));
+    for (const auto& bulb_state : *a) {
+      MALIPUT_ADD_RESULT(c, IsEqual(b->at(bulb_state.first), bulb_state.second));
+    }
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<std::optional<double>> IsEqual(const std::optional<double>& a,
+                                                        const std::optional<double>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.has_value()", "b.has_value()", a.has_value(), b.has_value()));
+  if (a.has_value()) {
+    MALIPUT_ADD_RESULT(c, api::IsEqual("a.value()", "b.value()", a.value(), b.value()));
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<Bulb::BoundingBox> IsEqual(const Bulb::BoundingBox& a, const Bulb::BoundingBox& b) {
+  common::ComparisonResultCollector c;
+  for (int i = 0; i < 3; ++i) {
+    MALIPUT_ADD_RESULT(c, api::IsEqual("a.p_BMin[i]", "b.p_BMin[i]", a.p_BMin[i], b.p_BMin[i]));
+    MALIPUT_ADD_RESULT(c, api::IsEqual("a.p_BMax[i]", "b.p_BMax[i]", a.p_BMax[i], b.p_BMax[i]));
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<Bulb> IsEqual(const Bulb* a, const Bulb* b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a->id()", "b->id()", a->id(), b->id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a->position_bulb_group(), b->position_bulb_group()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a->orientation_bulb_group(), b->orientation_bulb_group()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a->color(), b->color()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a->type(), b->type()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a->arrow_orientation_rad(), b->arrow_orientation_rad()));
+  const std::vector<BulbState>& a_states = a->states();
+  const std::vector<BulbState>& b_states = b->states();
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a->states().size()", "b->states().size()", a_states.size(), b_states.size()));
+  const int smallest = std::min(a_states.size(), b_states.size());
+  for (int i = 0; i < smallest; ++i) {
+    MALIPUT_ADD_RESULT(c, IsEqual(a_states.at(i), b_states.at(i)));
+  }
+  MALIPUT_ADD_RESULT(c, IsEqual(a->bounding_box(), b->bounding_box()));
+  return {c.result()};
+}
+
+common::ComparisonResult<std::vector<const Bulb*>> IsEqual(const char* a_expression, const char* b_expression,
+                                                           const std::vector<const Bulb*>& a,
+                                                           const std::vector<const Bulb*>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a_expression, b_expression, a.size(), b.size()));
+  const int smallest = std::min(a.size(), b.size());
+  for (int i = 0; i < smallest; ++i) {
+    MALIPUT_ADD_RESULT(c, IsEqual(a.at(i), b.at(i)));
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<BulbGroup> IsEqual(const BulbGroup* a, const BulbGroup* b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a->id()", "b->id()", a->id(), b->id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a->position_traffic_light(), b->position_traffic_light()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a->orientation_traffic_light(), b->orientation_traffic_light()));
+  MALIPUT_ADD_RESULT(c, IsEqual("a->bulbs()", "b->bulbs()", a->bulbs(), b->bulbs()));
+  return {c.result()};
+}
+
+common::ComparisonResult<TrafficLight> IsEqual(const TrafficLight* a, const TrafficLight* b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a->id()", "b->id()", a->id(), b->id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a->position_road_network(), b->position_road_network()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a->orientation_road_network(), b->orientation_road_network()));
+  const std::vector<const BulbGroup*> bulb_groups_a = a->bulb_groups();
+  const std::vector<const BulbGroup*> bulb_groups_b = b->bulb_groups();
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a->bulb_groups().size()", "b->bulb_groups().size()", bulb_groups_a.size(),
+                                     bulb_groups_b.size()));
+  const int smallest = std::min(bulb_groups_a.size(), bulb_groups_b.size());
+  for (int i = 0; i < smallest; ++i) {
+    MALIPUT_ADD_RESULT(c, IsEqual(bulb_groups_a.at(i), bulb_groups_b.at(i)));
   }
   return {c.result()};
 }

--- a/src/api/rules/compare.cc
+++ b/src/api/rules/compare.cc
@@ -123,6 +123,57 @@ common::ComparisonResult<std::vector<PhaseRing::NextPhase>> IsEqual(const std::v
   return {c.result()};
 }
 
+common::ComparisonResult<RangeValueRule::Range> IsEqual(const rules::RangeValueRule::Range& a,
+                                                        const rules::RangeValueRule::Range& b) {
+  return {a != b ? std::make_optional<std::string>(
+                       "Range with min: " + std::to_string(a.min) + " , max: " + std::to_string(a.max) +
+                       " and description: " + a.description +
+                       " is different from Range with min: " + std::to_string(b.min) +
+                       " , max: " + std::to_string(b.max) + " and description: " + b.description)
+                 : std::nullopt};
+}
+
+common::ComparisonResult<std::vector<rules::RangeValueRule::Range>> IsEqual(
+    const std::vector<rules::RangeValueRule::Range>& a, const std::vector<rules::RangeValueRule::Range>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  const int smallest = std::min(a.size(), b.size());
+  for (int i = 0; i < smallest; ++i) {
+    MALIPUT_ADD_RESULT(c, IsEqual(a.at(i), b.at(i)));
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<RangeValueRule> IsEqual(const rules::RangeValueRule& a, const rules::RangeValueRule& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.type_id()", "b.type_id()", a.type_id(), b.type_id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a.zone(), b.zone()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.states(), b.states()));
+  return {c.result()};
+}
+
+common::ComparisonResult<DiscreteValueRule> IsEqual(const DiscreteValueRule& a, const DiscreteValueRule& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.type_id()", "b.type_id()", a.type_id(), b.type_id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a.zone(), b.zone()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.states(), b.states()));
+  return {c.result()};
+}
+
+common::ComparisonResult<std::vector<DiscreteValueRule::DiscreteValue>> IsEqual(
+    const std::vector<DiscreteValueRule::DiscreteValue>& a, const std::vector<DiscreteValueRule::DiscreteValue>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  const int smallest = std::min(a.size(), b.size());
+  for (int i = 0; i < smallest; ++i) {
+    MALIPUT_ADD_RESULT(c, api::IsEqual("std::find(b.begin(), b.end(), a.at(i)) != b.end()", "true",
+                                       std::find(b.begin(), b.end(), a.at(i)) != b.end(), true));
+  }
+  return {c.result()};
+}
+
 }  // namespace rules
 }  // namespace api
 }  // namespace maliput

--- a/src/api/rules/compare.cc
+++ b/src/api/rules/compare.cc
@@ -234,7 +234,124 @@ common::ComparisonResult<DirectionUsageRule> IsEqual(const DirectionUsageRule& a
   }
   return {c.result()};
 }
+
+common::ComparisonResult<rules::RightOfWayRule::ZoneType> IsEqual(rules::RightOfWayRule::ZoneType a,
+                                                                  rules::RightOfWayRule::ZoneType b) {
+  if (a != b) {
+    return {"RightOfWayRule::ZoneType are different"};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<rules::RightOfWayRule::State::Type> IsEqual(rules::RightOfWayRule::State::Type a,
+                                                                     rules::RightOfWayRule::State::Type b) {
+  if (a != b) {
+    return {"RightOfWayRule::State::Type are different"};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<std::vector<rules::RightOfWayRule::Id>> IsEqual(
+    const std::vector<rules::RightOfWayRule::Id>& a, const std::vector<rules::RightOfWayRule::Id>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  const int smallest = std::min(a.size(), b.size());
+  for (int i = 0; i < smallest; ++i) {
+    MALIPUT_ADD_RESULT(c, IsEqual("a.at(i)", "b.at(i)", a.at(i), b.at(i)));
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<rules::RightOfWayRule::State> IsEqual(const rules::RightOfWayRule::State& a,
+                                                               const rules::RightOfWayRule::State& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.type(), b.type()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.yield_to(), b.yield_to()));
+  return {c.result()};
+}
+
+common::ComparisonResult<std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>> IsEqual(
+    const std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>& a,
+    const std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  const std::unordered_map<rules::RightOfWayRule::State::Id, rules::RightOfWayRule::State>& largest =
+      (a.size() < b.size()) ? b : a;
+  for (const auto& pair : largest) {
+    const rules::RightOfWayRule::State::Id& key = pair.first;
+    auto a_it = a.find(key);
+    auto b_it = b.find(key);
+    MALIPUT_ADD_RESULT(c, api::IsEqual("(a_it != a.cend())", "true", (a_it != a.cend()), true));
+    MALIPUT_ADD_RESULT(c, api::IsEqual("(b_it != b.cend())", "true", (b_it != b.cend()), true));
+    if ((a_it != a.cend()) && (b_it != b.cend())) {
+      MALIPUT_ADD_RESULT(c, IsEqual(a_it->second, b_it->second));
+    }
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<rules::RightOfWayRule> IsEqual(const rules::RightOfWayRule& a,
+                                                        const rules::RightOfWayRule& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual(a.zone(), b.zone()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.zone_type(), b.zone_type()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.is_static()", "b.is_static()", a.is_static(), b.is_static()));
+  if (a.is_static() && b.is_static()) {
+    MALIPUT_ADD_RESULT(c, IsEqual(a.static_state(), b.static_state()));
+  } else {
+    MALIPUT_ADD_RESULT(c, IsEqual(a.states(), b.states()));
+  }
+  MALIPUT_ADD_RESULT(c, IsEqual(a.related_bulb_groups(), b.related_bulb_groups()));
+  return {c.result()};
+}
+
+common::ComparisonResult<rules::RightOfWayRuleStateProvider::RightOfWayResult> IsEqual(
+    const rules::RightOfWayRuleStateProvider::RightOfWayResult& a,
+    const rules::RightOfWayRuleStateProvider::RightOfWayResult& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.state", "b.state", a.state, b.state));
+  MALIPUT_ADD_RESULT(c,
+                     api::IsEqual("a.next.has_value()", "b.next.has_value()", a.next.has_value(), b.next.has_value()));
+  if (a.next.has_value() && b.next.has_value()) {
+    MALIPUT_ADD_RESULT(c, api::IsEqual("a.next->state", "b.next->state", a.next->state, b.next->state));
+    MALIPUT_ADD_RESULT(c, api::IsEqual("a.next->duration_until.has_value()", "b.next->duration_until.has_value()",
+                                       a.next->duration_until.has_value(), b.next->duration_until.has_value()));
+    if (a.next->duration_until.has_value() && b.next->duration_until.has_value()) {
+      MALIPUT_ADD_RESULT(c, api::IsEqual("a.next->duration_until.value()", "b.next->duration_until.value()",
+                                         a.next->duration_until.value(), b.next->duration_until.value()));
+    }
+  }
+  return {c.result()};
+}
+
 #pragma GCC diagnostic pop
+
+common::ComparisonResult<std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>> IsEqual(
+    const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& a,
+    const std::unordered_map<TrafficLight::Id, std::vector<BulbGroup::Id>>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  if (a.size() == b.size()) {
+    for (const auto& traffic_light_bulb_group : a) {
+      const auto& b_it = b.find(traffic_light_bulb_group.first);
+      MALIPUT_ADD_RESULT(c, api::IsEqual("(b_it != b.cend())", "true", (b_it != b.cend()), true));
+      if (b_it == b.cend()) {
+        break;
+      }
+      for (const BulbGroup::Id& bulb_group_id : traffic_light_bulb_group.second) {
+        const auto& b_bulb_group_id_it = std::find(b_it->second.cbegin(), b_it->second.cend(), bulb_group_id);
+        MALIPUT_ADD_RESULT(c, api::IsEqual("(b_bulb_group_id_it != b_it->second.cend())", "true",
+                                           (b_bulb_group_id_it != b_it->second.cend()), true));
+        if (b_bulb_group_id_it == b_it->second.cend()) {
+          break;
+        }
+      }
+    }
+  }
+  return {c.result()};
+}
 
 }  // namespace rules
 }  // namespace api

--- a/src/api/rules/compare.cc
+++ b/src/api/rules/compare.cc
@@ -1,0 +1,128 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "maliput/api/rules/compare.h"
+
+#include <optional>
+#include <unordered_map>
+
+#include "maliput/api/compare.h"
+
+namespace maliput {
+namespace api {
+namespace rules {
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+common::ComparisonResult<RuleStates> IsEqual(const RuleStates& a, const RuleStates& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  return {c.result()};
+}
+
+#pragma GCC diagnostic pop
+
+common::ComparisonResult<DiscreteValueRule::DiscreteValue> IsEqual(const DiscreteValueRule::DiscreteValue& a,
+                                                                   const DiscreteValueRule::DiscreteValue& b) {
+  if (a.value != b.value) {
+    return {"DiscreteValues are different: " + a.value + " != " + b.value};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>> IsEqual(
+    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& a,
+    const std::unordered_map<Rule::Id, DiscreteValueRule::DiscreteValue>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  for (const auto& discrete_value_rule_state : a) {
+    MALIPUT_ADD_RESULT(c, IsEqual(b.at(discrete_value_rule_state.first), discrete_value_rule_state.second));
+  }
+  return {c.result()};
+}
+common::ComparisonResult<BulbState> IsEqual(const BulbState& a, const BulbState& b) {
+  if (a != b) {
+    return {"BulbStates are different: " + std::string(BulbStateMapper().at(a)) +
+            " != " + std::string(BulbStateMapper().at(b))};
+  }
+  return {std::nullopt};
+}
+
+common::ComparisonResult<std::optional<BulbStates>> IsEqual(const std::optional<BulbStates>& a,
+                                                            const std::optional<BulbStates>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.has_value()", "b.has_value()", a.has_value(), b.has_value()));
+  if (a.has_value()) {
+    MALIPUT_ADD_RESULT(c, api::IsEqual("a->size()", "b->size()", a->size(), b->size()));
+    for (const auto& bulb_state : *a) {
+      MALIPUT_ADD_RESULT(c, IsEqual(b->at(bulb_state.first), bulb_state.second));
+    }
+  }
+  return {c.result()};
+}
+
+common::ComparisonResult<Phase> IsEqual(const Phase& a, const Phase& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id()", "b.id()", a.id(), b.id()));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  MALIPUT_ADD_RESULT(c, IsEqual(a.rule_states(), b.rule_states()));
+#pragma GCC diagnostic pop
+  MALIPUT_ADD_RESULT(c, IsEqual(a.discrete_value_rule_states(), b.discrete_value_rule_states()));
+  MALIPUT_ADD_RESULT(c, IsEqual(a.bulb_states(), b.bulb_states()));
+  return {c.result()};
+}
+
+common::ComparisonResult<PhaseRing::NextPhase> IsEqual(const PhaseRing::NextPhase& a, const PhaseRing::NextPhase& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.id", "b.id", a.id, b.id));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.duration_until.has_value()", "b.duration_until.has_value()",
+                                     a.duration_until.has_value(), b.duration_until.has_value()));
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.duration_until.value()", "b.duration_until.value()", a.duration_until.value(),
+                                     b.duration_until.value()));
+  return {c.result()};
+}
+
+common::ComparisonResult<std::vector<PhaseRing::NextPhase>> IsEqual(const std::vector<PhaseRing::NextPhase>& a,
+                                                                    const std::vector<PhaseRing::NextPhase>& b) {
+  common::ComparisonResultCollector c;
+  MALIPUT_ADD_RESULT(c, api::IsEqual("a.size()", "b.size()", a.size(), b.size()));
+  if (a.size() == b.size()) {
+    for (size_t i = 0; i < a.size(); ++i) {
+      MALIPUT_ADD_RESULT(c, IsEqual(a[i], b[i]));
+    }
+  }
+  return {c.result()};
+}
+
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

Related to #593 

## Summary
  ✔ Provide an alternative for the `AssertionResultCollector` -> `ComparisonResultCollector` that is gtest agnostic.
  ✔ check id index 
  ✔ region test compare
  ✔ phases_compare 
  ✔ rules compare 
  ✔ rules direction usage 
  ✔ rules right of way compare
  ✔ rules speed limit compare 
  ✔ traffic lights compare 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
