### PR TITLE
Builds test_utilities with bazel.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -124,3 +124,18 @@ cc_library(
         "@eigen",
     ],
 )
+
+cc_library(
+    name = "test_utilities",
+    srcs = glob(["src/test_utilities/**/*.cc"]),
+    hdrs = glob(["include/maliput/test_utilities/**/*.h"]),
+    copts = ["-std=c++17"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":api",
+        ":common",
+        ":geometry_base",
+        ":math",
+    ],
+)

--- a/src/test_utilities/CMakeLists.txt
+++ b/src/test_utilities/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(test_utilities
   maliput::common
   maliput::geometry_base
   maliput::math
-  maliput::routing
 )
 
 install(


### PR DESCRIPTION
# 🎉 New feature

## Summary

 - Now that `test_utilities` is gtest agnostic (#591) we can ship it.
 - Needed at https://github.com/maliput/maliput_malidrive/pull/246

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
