### PR TITLE
Builds test_utilities no matter BUILD_TESTING flag.

### DIFF
--- a/src/test_utilities/CMakeLists.txt
+++ b/src/test_utilities/CMakeLists.txt
@@ -1,8 +1,6 @@
 ##############################################################################
 # Sources
 ##############################################################################
-if(BUILD_TESTING)
-
 
 set(TEST_UTILS_SOURCES
   mock.cc
@@ -40,5 +38,3 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
-
-endif()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
After making `maliput::test_utilities` agnostic of gtest there is no need to keep this guard
to avoid building this if not necessary

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
