### PR TITLE
Adds buid flags as in maliput_malidrive to pair builds.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,13 @@
+###############################################################################
+# Loaders
+###############################################################################
+
+load("//:bazel/variables.bzl", "COPTS")
+
+
+###############################################################################
+# Libraries
+###############################################################################
 
 # TODO(stonier): dig into the cflags maliput sets in cmake/DefaultCFlags.cmake
 # and verify they all work in a bazel environment. Be a little cautious and
@@ -10,7 +20,7 @@ cc_library(
     name = "common",
     srcs = glob(["src/common/*.cc"]),
     hdrs = glob(["include/maliput/common/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
@@ -21,7 +31,7 @@ cc_library(
     name = "math",
     srcs = glob(["src/math/*.cc"]),
     hdrs = glob(["include/maliput/math/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
@@ -33,7 +43,7 @@ cc_library(
     name = "api",
     srcs = glob(["src/api/**/*.cc"]),
     hdrs = glob(["include/maliput/api/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
@@ -46,7 +56,7 @@ cc_library(
     name = "base",
     srcs = glob(["src/base/**/*.cc"]),
     hdrs = glob(["include/maliput/base/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
@@ -60,7 +70,7 @@ cc_library(
     name = "geometry_base",
     srcs = glob(["src/geometry_base/**/*.cc"]),
     hdrs = glob(["include/maliput/geometry_base/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
@@ -72,7 +82,7 @@ cc_library(
     name = "routing",
     srcs = glob(["src/routing/**/*.cc"]),
     hdrs = glob(["include/maliput/routing/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
@@ -86,7 +96,7 @@ cc_library(
     name = "utility",
     srcs = glob(["src/utility/**/*.cc"]),
     hdrs = glob(["include/maliput/utility/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     linkopts = ["-lstdc++fs"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
@@ -101,7 +111,7 @@ cc_library(
     name = "plugin",
     srcs = glob(["src/plugin/**/*.cc"]),
     hdrs = glob(["include/maliput/plugin/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     linkopts = ['-ldl'],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
@@ -117,7 +127,7 @@ cc_library(
     name = "drake",
     srcs = glob(["src/drake/**/*.cc"]),
     hdrs = glob(["include/maliput/drake/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
@@ -129,7 +139,7 @@ cc_library(
     name = "test_utilities",
     srcs = glob(["src/test_utilities/**/*.cc"]),
     hdrs = glob(["include/maliput/test_utilities/**/*.h"]),
-    copts = ["-std=c++17"],
+    copts = COPTS,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [

--- a/bazel/variables.bzl
+++ b/bazel/variables.bzl
@@ -1,0 +1,38 @@
+###############################################################################
+# Build Variables
+###############################################################################
+
+# TODO(daniel.stonier): revise these, get in sync with cmake/DefaultCFlags.cmake.
+# Be aware though that many do not work across platforms, e.g. there is no
+# cross-platform mechanism for setting std=c++17 in bazel
+
+COPTS = [
+    "-std=c++17",
+    "-Wno-builtin-macro-redefined",
+    "-Wno-missing-field-initializers",
+    "-Wno-unused-const-variable",
+    "-O2",
+
+    # Others from cmake/DefaultCFlags.cmake
+    # "-fdata-sections",
+    # "-fdiagnostics-color=always"
+    # "-ffunction-sections"
+    # "-fopenmp"
+    # "-fPIC"
+    # "-fstack-protector"
+    # "-fno-omit-frame-pointer"
+    # "-no-canonical-prefixes"
+    # "-Wall"
+    # "-Wregister"
+    # "-Wstrict-overflow"
+
+    # Some flags that were used in the TRI build
+    # "-Wno-unused-parameter",
+    # "-Wno-missing-braces",
+    # "-Wno-pessimizing-move",
+    # "-Wno-self-assign",
+    # "-Wno-deprecated-declarations",
+    # "-Wno-unused-private-field",
+    # "-Wno-maybe-uninitialized",
+    # "-Wno-deprecated-register",
+]


### PR DESCRIPTION

# 🎉 New feature

Pairs with https://github.com/maliput/maliput_malidrive/pull/255

## Summary

Uses build flags variables and applies it to all cc_* targets. Note that we are currently using a subset of all the flags that should  be used (see [cmake/DefaultCFlags.cmake](https://github.com/maliput/maliput/blob/main/cmake/DefaultCFlags.cmake)). 

## Test it

It should simply improve builds and parity against cmake builds.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
