### PR TITLE
Adds FindLaneSequence() overload that removes sequences with U-turns.

### DIFF
--- a/include/maliput/routing/find_lane_sequences.h
+++ b/include/maliput/routing/find_lane_sequences.h
@@ -57,10 +57,12 @@ std::vector<std::vector<const maliput::api::Lane*>> FindLaneSequences(const mali
                                                                       double max_length_m);
 
 /// Overload to @ref FindLaneSequences() that removes from the result those
-/// sequences presenting U-turns when @p remove_u_turns is true. Otherwise,
+/// sequences presenting U-turns when @p no_u_turns is true. Otherwise,
 /// the function behaves exactly the same.
+/// In this context, a U-turn is when the route backtracks against itself within
+/// the same lane.
 std::vector<std::vector<const maliput::api::Lane*>> FindLaneSequences(const maliput::api::Lane* start,
                                                                       const maliput::api::Lane* end,
-                                                                      double max_length_m, bool remove_u_turns);
+                                                                      double max_length_m, bool no_u_turns);
 }  // namespace routing
 }  // namespace maliput

--- a/include/maliput/routing/find_lane_sequences.h
+++ b/include/maliput/routing/find_lane_sequences.h
@@ -56,5 +56,11 @@ std::vector<std::vector<const maliput::api::Lane*>> FindLaneSequences(const mali
                                                                       const maliput::api::Lane* end,
                                                                       double max_length_m);
 
+/// Overload to @ref FindLaneSequences() that removes from the result those
+/// sequences presenting U-turns when @p remove_u_turns is true. Otherwise,
+/// the function behaves exactly the same.
+std::vector<std::vector<const maliput::api::Lane*>> FindLaneSequences(const maliput::api::Lane* start,
+                                                                      const maliput::api::Lane* end,
+                                                                      double max_length_m, bool remove_u_turns);
 }  // namespace routing
 }  // namespace maliput

--- a/src/maliput/routing/find_lane_sequences.cc
+++ b/src/maliput/routing/find_lane_sequences.cc
@@ -29,6 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput/routing/find_lane_sequences.h"
 
+#include <algorithm>
+
 #include "maliput/api/branch_point.h"
 #include "maliput/api/lane_data.h"
 #include "maliput/common/profiler.h"
@@ -81,6 +83,83 @@ std::vector<std::vector<const Lane*>> FindLaneSequencesHelper(const Lane* start,
   return result;
 }
 
+// Convenient struct to hold both incoming and ongoing LaneEnds.
+// It will be used in HasUTurn to identify when a sequence of Lanes implies a U-turn.
+struct ConnectionSet {
+  LaneEnd incoming;
+  LaneEnd ongoing;
+};
+
+// Builds a ConnectionSet from two adjancent Lanes.
+//
+// The method will look for the LaneEnd::kStart end of @p incoming_lane first for ongoing_lane.
+// Then, it will look for @p ongoing_lane in the LaneEnd::kFinish end. This sets a precendence
+// order in case of two Lanes that are connected in both ends, typically building a roundabout
+// or similar geometry. This is a known behavior from FindLaneSequences() which can work with
+// roundabouts, given that the same Lane cannot be twice in the sequence.
+//
+// @param incoming_lane The incoming Lane. It must not be nullptr.
+// @param ongoing_lane The ongoing Lane. It must not be nullptr.
+// @return A ConnectionSet.
+// @throws common::assertion_error When @p incoming_lane or @p ongoing_lane are nullptr.
+// @throws common::assertion_error When no ConnectionSet could be built.
+ConnectionSet BuildConnectionSet(const Lane* incoming_lane, const Lane* ongoing_lane) {
+  MALIPUT_THROW_UNLESS(incoming_lane != nullptr);
+  MALIPUT_THROW_UNLESS(ongoing_lane != nullptr);
+  // Analize the start end.
+  const LaneEndSet* start_ongoing_branches = incoming_lane->GetOngoingBranches(LaneEnd::kStart);
+  for (int i = 0; i < start_ongoing_branches->size(); ++i) {
+    const LaneEnd ongoing = start_ongoing_branches->get(i);
+    if (ongoing.lane == ongoing_lane) {
+      return ConnectionSet{LaneEnd(incoming_lane, LaneEnd::kStart), ongoing};
+    }
+  }
+  // Analize the finish end.
+  const LaneEndSet* finish_ongoing_branches = incoming_lane->GetOngoingBranches(LaneEnd::kFinish);
+  for (int i = 0; i < finish_ongoing_branches->size(); ++i) {
+    const LaneEnd ongoing = finish_ongoing_branches->get(i);
+    if (ongoing.lane == ongoing_lane) {
+      return ConnectionSet{LaneEnd(incoming_lane, LaneEnd::kFinish), ongoing};
+    }
+  }
+  // It was impossible to find a connection between the two lanes, an error has occured somewhere else.
+  MALIPUT_THROW_MESSAGE("maliput::routing::BuildConnectionSet(): code must not reach here.");
+}
+
+// Determines whether @p lane_sequence has a U-turn by analyzing the LaneEnd sequences.
+// @param lane_sequence The sequence of Lanes to analyze for U-turns. It must not be empty.
+// @return true When @p lane_sequence has a U-turn.
+// @throws common::assertion_error When @p lane_sequence is empty.
+bool HasUTurn(const std::vector<const Lane*>& lane_sequence) {
+  // Analize preconditions.
+  MALIPUT_THROW_UNLESS(!lane_sequence.empty());
+  // Escape condition: when lane_sequence has one or two elements, we have no U turn.
+  if (lane_sequence.size() <= 2u) {
+    return false;
+  }
+  // Obtain the first connection_set.
+  ConnectionSet connection_set = BuildConnectionSet(lane_sequence[0], lane_sequence[1]);
+  for (size_t i = 1; i < lane_sequence.size() - 1u; ++i) {
+    // Obtain the following connection_set.
+    const ConnectionSet next_connection_set = BuildConnectionSet(lane_sequence[i], lane_sequence[i + 1]);
+    // Evaluate if there is a U turn.
+    if (next_connection_set.ongoing.end == connection_set.incoming.end) {
+      return true;
+    }
+    connection_set = next_connection_set;
+  }
+  return false;
+}
+
+/// Remove sequences with U-turns from @p lane_sequences.
+/// @param lane_sequences A sequence of Lanes. It is expected to be the result of FindLaneSequences.
+/// @return A filtered copy of @p lane_sequences without those sequences that present a U-turn.
+std::vector<std::vector<const Lane*>> RemoveUTurns(const std::vector<std::vector<const Lane*>>& lane_sequences) {
+  std::vector<std::vector<const Lane*>> result;
+  std::copy_if(lane_sequences.begin(), lane_sequences.end(), std::back_inserter(result), std::not_fn(HasUTurn));
+  return result;
+}
+
 }  // namespace
 
 std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane* start, const Lane* end, double max_length_m) {
@@ -89,6 +168,13 @@ std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane* start, const
     return {{start}};
   }
   return FindLaneSequencesHelper(start, end, {start}, max_length_m, 0);
+}
+
+std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane* start, const Lane* end, double max_length_m,
+                                                        bool remove_u_turns) {
+  MALIPUT_PROFILE_FUNC();
+  const std::vector<std::vector<const Lane*>> unfiltered_result = FindLaneSequences(start, end, max_length_m);
+  return remove_u_turns ? RemoveUTurns(unfiltered_result) : unfiltered_result;
 }
 
 }  // namespace routing

--- a/src/maliput/routing/find_lane_sequences.cc
+++ b/src/maliput/routing/find_lane_sequences.cc
@@ -171,10 +171,10 @@ std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane* start, const
 }
 
 std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane* start, const Lane* end, double max_length_m,
-                                                        bool remove_u_turns) {
+                                                        bool no_u_turns) {
   MALIPUT_PROFILE_FUNC();
   const std::vector<std::vector<const Lane*>> unfiltered_result = FindLaneSequences(start, end, max_length_m);
-  return remove_u_turns ? RemoveUTurns(unfiltered_result) : unfiltered_result;
+  return no_u_turns ? RemoveUTurns(unfiltered_result) : unfiltered_result;
 }
 
 }  // namespace routing


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #614

## Summary

Provides an overload to `maliput::routing::FindLaneSequences()` that allows to remove sequences with U-turns.

Tests have been created in maliput_integration_tests to provide coverage to this new feature. We should accept worse coverage results in this PR due to the split decision we made for this.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

