### PR TITLE
Route part four - DistanceRouter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -62,6 +62,7 @@ cc_library(
     deps = [
         ":api",
         ":common",
+        ":routing",
         "@yaml-cpp",
     ],
 )

--- a/include/maliput/base/distance_router.h
+++ b/include/maliput/base/distance_router.h
@@ -39,12 +39,14 @@
 
 namespace maliput {
 
-/// Basic implementation of a Router which only looks at the travelled distance
+/// Basic implementation of a Router which only looks at the traveled distance
 /// to provide solutions.
 ///
 /// The routing algorithm will consider the minimum length of api::LaneSRanges within
 /// a routing::Phase as its cost. The accumulation of all routing::Phases' costs along
 /// a routing::Route determines its cost.
+/// Moreover, the router operates at lane-level granularity. When using `start` and `end`
+/// positions to compute feasible routing::Routes, the `r` and `h` coordinates are ignored.
 // TODO: provide solutions that rely on segment-to-segment connectivity and enable
 // the use of api::Lane switches in results.
 class DistanceRouter : public routing::Router {

--- a/include/maliput/base/distance_router.h
+++ b/include/maliput/base/distance_router.h
@@ -1,6 +1,6 @@
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+// Copyright (c) 2024, Woven by Toyota. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -46,24 +46,21 @@ namespace maliput {
 /// a routing::Route determines its cost.
 // TODO: provide solutions that rely on segment-to-segment connectivity and enable
 // the use of api::Lane switches in results.
-// TODO: provide solutions that rely on segment-to-segment connectivity and enable
-// the use of api::Lane switches in results.
 class DistanceRouter : public routing::Router {
  public:
   MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(DistanceRouter);
 
   /// Constructs a DistanceRouter.
-  /// @param road_network The api::RoadNetwork to compute routing::Routes on. It must not be nullptr.
+  /// @param road_network The api::RoadNetwork to compute routing::Routes on.
   /// @param lane_s_range_tolerance The tolerance to consider when evaluating api::LaneSRanges. It must not be negative.
-  /// @throws common::assertion_error When @p road_network is nullptr.
   /// @throws common::assertion_error When @p lane_s_range_tolerance is negative.
-  DistanceRouter(const api::RoadNetwork* road_network, double lane_s_range_tolerance);
+  DistanceRouter(const api::RoadNetwork& road_network, double lane_s_range_tolerance);
 
  private:
   std::vector<routing::Route> DoComputeRoutes(const api::RoadPosition& start, const api::RoadPosition& end,
                                               const routing::RoutingConstraints& routing_constraints) const override;
 
-  const api::RoadNetwork* road_network_{};
+  const api::RoadNetwork& road_network_;
   const double lane_s_range_tolerance_{};
 };
 

--- a/include/maliput/base/distance_router.h
+++ b/include/maliput/base/distance_router.h
@@ -51,7 +51,8 @@ class DistanceRouter : public routing::Router {
   MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(DistanceRouter);
 
   /// Constructs a DistanceRouter.
-  /// @param road_network The api::RoadNetwork to compute routing::Routes on.
+  /// @param road_network The api::RoadNetwork to compute routing::Routes on. It must remain valid for the lifetime
+  /// of the constructed object.
   /// @param lane_s_range_tolerance The tolerance to consider when evaluating api::LaneSRanges. It must not be negative.
   /// @throws common::assertion_error When @p lane_s_range_tolerance is negative.
   DistanceRouter(const api::RoadNetwork& road_network, double lane_s_range_tolerance);

--- a/include/maliput/base/distance_router.h
+++ b/include/maliput/base/distance_router.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "maliput/api/lane_data.h"
+#include "maliput/api/road_network.h"
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/routing/route.h"
 #include "maliput/routing/router.h"
@@ -51,6 +52,7 @@ class DistanceRouter : public routing::Router {
   MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(DistanceRouter);
 
   /// Constructs a DistanceRouter.
+  ///
   /// @param road_network The api::RoadNetwork to compute routing::Routes on. It must remain valid for the lifetime
   /// of the constructed object.
   /// @param lane_s_range_tolerance The tolerance to consider when evaluating api::LaneSRanges. It must not be negative.

--- a/include/maliput/base/distance_router.h
+++ b/include/maliput/base/distance_router.h
@@ -1,0 +1,70 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <vector>
+
+#include "maliput/api/lane_data.h"
+#include "maliput/common/maliput_copyable.h"
+#include "maliput/routing/route.h"
+#include "maliput/routing/router.h"
+#include "maliput/routing/routing_constraints.h"
+
+namespace maliput {
+
+/// Basic implementation of a Router which only looks at the travelled distance
+/// to provide solutions.
+///
+/// The routing algorithm will consider the minimum length of api::LaneSRanges within
+/// a routing::Phase as its cost. The accumulation of all routing::Phases' costs along
+/// a routing::Route determines its cost.
+// TODO: provide solutions that rely on segment-to-segment connectivity and enable
+// the use of api::Lane switches in results.
+// TODO: provide solutions that rely on segment-to-segment connectivity and enable
+// the use of api::Lane switches in results.
+class DistanceRouter : public routing::Router {
+ public:
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(DistanceRouter);
+
+  /// Constructs a DistanceRouter.
+  /// @param road_network The api::RoadNetwork to compute routing::Routes on. It must not be nullptr.
+  /// @param lane_s_range_tolerance The tolerance to consider when evaluating api::LaneSRanges. It must not be negative.
+  /// @throws common::assertion_error When @p road_network is nullptr.
+  /// @throws common::assertion_error When @p lane_s_range_tolerance is negative.
+  DistanceRouter(const api::RoadNetwork* road_network, double lane_s_range_tolerance);
+
+ private:
+  std::vector<routing::Route> DoComputeRoutes(const api::RoadPosition& start, const api::RoadPosition& end,
+                                              const routing::RoutingConstraints& routing_constraints) const override;
+
+  const api::RoadNetwork* road_network_{};
+  const double lane_s_range_tolerance_{};
+};
+
+}  // namespace maliput

--- a/include/maliput/routing/derive_lane_s_routes.h
+++ b/include/maliput/routing/derive_lane_s_routes.h
@@ -37,6 +37,12 @@
 namespace maliput {
 namespace routing {
 
+/// Returns the S coordinate in @p lane that is on the border with @p next_lane.
+/// When @p lane is not connected to @p next_lane , std::nullopt is returned.
+/// @throws maliput::common::assertion_error When @p lane is nullptr.
+/// @throws maliput::common::assertion_error When @p next_lane is nullptr.
+std::optional<double> DetermineEdgeS(const api::Lane* lane, const api::Lane* next_lane);
+
 /// Derives and returns a set of LaneSRoute objects that go from @p start to
 /// @p end. If no routes are found, a vector of length zero is returned.
 /// Parameter @p max_length_m is the maximum length of the intermediate lanes

--- a/include/maliput/routing/derive_lane_s_routes.h
+++ b/include/maliput/routing/derive_lane_s_routes.h
@@ -29,8 +29,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <optional>
 #include <vector>
 
+#include "maliput/api/lane.h"
 #include "maliput/api/lane_data.h"
 #include "maliput/api/regions.h"
 
@@ -39,9 +41,7 @@ namespace routing {
 
 /// Returns the S coordinate in @p lane that is on the border with @p next_lane.
 /// When @p lane is not connected to @p next_lane , std::nullopt is returned.
-/// @throws maliput::common::assertion_error When @p lane is nullptr.
-/// @throws maliput::common::assertion_error When @p next_lane is nullptr.
-std::optional<double> DetermineEdgeS(const api::Lane* lane, const api::Lane* next_lane);
+std::optional<double> DetermineEdgeS(const api::Lane& lane, const api::Lane& next_lane);
 
 /// Derives and returns a set of LaneSRoute objects that go from @p start to
 /// @p end. If no routes are found, a vector of length zero is returned.

--- a/include/maliput/routing/route.h
+++ b/include/maliput/routing/route.h
@@ -233,6 +233,9 @@ class Route final {
   /// @throws common::assertion_error When @p start_position is not valid.
   api::LaneSRoute ComputeLaneSRoute(const api::RoadPosition& start_position) const;
 
+  // TODO(maliput#628): Implement me.
+  std::vector<std::string> ValidateEndToEndConnectivity() const { return {}; }
+
  private:
   // @{
 

--- a/include/maliput/routing/router.h
+++ b/include/maliput/routing/router.h
@@ -35,7 +35,6 @@
 #include "maliput/common/maliput_copyable.h"
 #include "maliput/common/maliput_throw.h"
 #include "maliput/routing/route.h"
-#include "maliput/routing/route_phase.h"
 #include "maliput/routing/routing_constraints.h"
 
 namespace maliput {
@@ -53,6 +52,8 @@ namespace routing {
 class Router {
  public:
   MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(Router);
+
+  virtual ~Router() = default;
 
   /// Computes Routes that joins @p start to @p end under
   /// @p routing_constraints.

--- a/src/maliput/base/CMakeLists.txt
+++ b/src/maliput/base/CMakeLists.txt
@@ -3,6 +3,7 @@
 ##############################################################################
 
 set(BASE_SOURCES
+  distance_router.cc
   intersection.cc
   intersection_book.cc
   intersection_book_loader.cc
@@ -45,6 +46,7 @@ target_link_libraries(base
   PUBLIC
     maliput::api
     maliput::common
+    maliput::routing
     yaml-cpp
 )
 

--- a/src/maliput/base/distance_router.cc
+++ b/src/maliput/base/distance_router.cc
@@ -84,10 +84,11 @@ double MaxPhaseCostInRoute(const routing::Route& route) {
   return cost;
 }
 
-// Filters routing::Routes from @p routes based on @p routing_constraints.
+// Filters @p routes based on @p routing_constraints.
 // @param routing_constraints The constraints to evaluate over @p routes.
 // @param routes The collection of routing::Routes that connect the start and end.
-// @return A subset of @p routes that comply with @p routing_constraints.
+// @return A subset of @p routes that comply with @p routing_constraints. The relative order in the returned
+// routes is the same as @p routes.
 std::vector<routing::Route> FilterRoutes(const routing::RoutingConstraints& routing_constraints,
                                          const std::vector<routing::Route>& routes) {
   // TODO: evaluate routing_constraints.allow_lane_switch.
@@ -122,7 +123,7 @@ std::string AggregateRouteConnectivityErrors(const std::vector<std::string>& err
   return result;
 }
 
-// Iterates over @p routes and validates none has end to end connectivity errors.
+// Iterates over @p routes and validates none have end to end connectivity errors.
 // @param routes Vector of Routes to validate.
 // @throws common::assertion_error When one of the Routes in @p routes has end to end connectivity errors.
 void ValidateEndToEndConnectivityInRoutes(const std::vector<routing::Route>& routes) {

--- a/src/maliput/base/distance_router.cc
+++ b/src/maliput/base/distance_router.cc
@@ -1,0 +1,178 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput/base/distance_router.h"
+
+#include <algorithm>
+#include <limits>
+#include <optional>
+#include <utility>
+
+#include "maliput/api/lane.h"
+#include "maliput/api/regions.h"
+#include "maliput/routing/derive_lane_s_routes.h"
+#include "maliput/routing/find_lane_sequences.h"
+#include "maliput/routing/phase.h"
+
+namespace maliput {
+namespace {
+
+// Computes the cost of a routing::Phase.
+// @param phase The routing::Phase to compute the cost.
+// @return The minimum length across all api::LaneSRanges in the routing::Phase.
+double ComputeCost(const routing::Phase& phase) {
+  double cost{std::numeric_limits<double>::max()};
+  for (const api::LaneSRange& lane_s_range : phase.lane_s_ranges()) {
+    cost = std::min(cost, lane_s_range.length());
+  }
+  return cost;
+}
+
+// Computes the cost of a routing::Route.
+// @param route The routing::Route to compute the cost.
+// @return The accumulated cost of all the routing::Phases in @p route.
+double ComputeCost(const routing::Route& route) {
+  double cost{0.};
+  for (int i = 0; i < route.size(); ++i) {
+    cost += ComputeCost(route.Get(i));
+  }
+  return cost;
+}
+
+/// Determines the maximum cost of all routing::Phases in @p route.
+/// @param route The routing::Route to look for the maximum routing::Phase's cost.
+/// @return The maximum cost of all routing::Phases in @p route.
+double MaxPhaseCostInRoute(const routing::Route& route) {
+  double cost{0.};
+  for (int i = 0; i < route.size(); ++i) {
+    cost = std::max(ComputeCost(route.Get(i)), cost);
+  }
+  return cost;
+}
+
+// Filters routing::Routes from @p routes based on @p routing_constraints.
+// @param routing_constraints The constraints to evaluate over @p routes.
+// @param routes The collection of routing::Routes that connect the start and end.
+// @return A subset of @p routes that comply with @p routing_constraints.
+std::vector<routing::Route> FilterRoutes(const routing::RoutingConstraints& routing_constraints,
+                                         const std::vector<routing::Route>& routes) {
+  // TODO: evaluate routing_constraints.allow_lane_switch.
+  auto filter = [routing_constraints](const routing::Route& route) -> bool {
+    if (routing_constraints.max_phase_cost.has_value() &&
+        routing_constraints.max_phase_cost.value() < MaxPhaseCostInRoute(route)) {
+      return false;
+    }
+    if (routing_constraints.max_route_cost.has_value() &&
+        routing_constraints.max_route_cost.value() < ComputeCost(route)) {
+      return false;
+    }
+    return true;
+  };
+  std::vector<routing::Route> filtered_routes;
+  std::copy_if(routes.begin(), routes.end(), std::back_inserter(filtered_routes), filter);
+  return filtered_routes;
+}
+
+}  // namespace
+
+DistanceRouter::DistanceRouter(const api::RoadNetwork* road_network, double lane_s_range_tolerance)
+    : Router(), road_network_(road_network), lane_s_range_tolerance_(lane_s_range_tolerance) {
+  MALIPUT_THROW_UNLESS(road_network_ != nullptr);
+  MALIPUT_THROW_UNLESS(lane_s_range_tolerance_ >= 0.0);
+}
+
+std::vector<routing::Route> DistanceRouter::DoComputeRoutes(
+    const api::RoadPosition& start, const api::RoadPosition& end,
+    const routing::RoutingConstraints& routing_constraints) const {
+  // Validate input parameters.
+  MALIPUT_THROW_UNLESS(start.lane != nullptr);
+  MALIPUT_THROW_UNLESS(road_network_->road_geometry()->ById().GetLane(start.lane->id()) == start.lane);
+  MALIPUT_THROW_UNLESS(end.lane != nullptr);
+  MALIPUT_THROW_UNLESS(road_network_->road_geometry()->ById().GetLane(end.lane->id()) == end.lane);
+  routing::ValidateRoutingConstraints(routing_constraints);
+  static constexpr bool kRemoveUTurns{true};
+
+  // Obtain the lane sequences that connect the start with end.
+  const std::vector<std::vector<const api::Lane*>> lane_sequences =
+      routing::FindLaneSequences(start.lane, end.lane, std::numeric_limits<double>::max(), kRemoveUTurns);
+
+  // Construct the routes.
+  // TODO: lateral routing::Phase inflation.
+  const double start_s = start.pos.s();
+  const double end_s = end.pos.s();
+  std::vector<routing::Route> routes;
+  for (const std::vector<const api::Lane*>& lane_sequence : lane_sequences) {
+    if (lane_sequence.size() == 1u) {
+      const routing::Phase phase(0, lane_s_range_tolerance_, {start}, {end},
+                                 {api::LaneSRange(start.lane->id(), api::SRange(start_s, end_s))}, road_network_);
+      routes.emplace_back(std::vector<routing::Phase>{phase}, road_network_);
+      continue;
+    }
+
+    // Handles the case when lane_sequence has a length greater than 1.
+    std::vector<routing::Phase> phases;
+    for (int i = 0; i < static_cast<int>(lane_sequence.size()); ++i) {
+      const api::Lane* lane = lane_sequence[i];
+      if (i == 0) {
+        const std::optional<double> first_end_s = routing::DetermineEdgeS(lane, lane_sequence[1]);
+        MALIPUT_THROW_UNLESS(first_end_s.has_value());
+        phases.emplace_back(
+            i, lane_s_range_tolerance_, std::vector<api::RoadPosition>{start},
+            std::vector<api::RoadPosition>{api::RoadPosition(lane, api::LanePosition(*first_end_s, 0., 0.))},
+            std::vector<api::LaneSRange>{api::LaneSRange(lane->id(), api::SRange(start_s, *first_end_s))},
+            road_network_);
+      } else if (i + 1 == static_cast<int>(lane_sequence.size())) {
+        MALIPUT_THROW_UNLESS(lane->id() == end.lane->id());
+        MALIPUT_THROW_UNLESS(i > 0);
+        const std::optional<double> last_start_s = routing::DetermineEdgeS(lane, lane_sequence[i - 1]);
+        MALIPUT_THROW_UNLESS(last_start_s.has_value());
+        phases.emplace_back(
+            i, lane_s_range_tolerance_,
+            std::vector<api::RoadPosition>{api::RoadPosition(lane, api::LanePosition(*last_start_s, 0., 0.))},
+            std::vector<api::RoadPosition>{api::RoadPosition(lane, api::LanePosition(end_s, 0., 0.))},
+            std::vector<api::LaneSRange>{api::LaneSRange(lane->id(), api::SRange(*last_start_s, end_s))},
+            road_network_);
+      } else {
+        const std::optional<double> middle_start_s = routing::DetermineEdgeS(lane, lane_sequence[i - 1]);
+        const std::optional<double> middle_end_s = routing::DetermineEdgeS(lane, lane_sequence[i + 1]);
+        MALIPUT_THROW_UNLESS(middle_start_s.has_value() && middle_end_s.has_value());
+        phases.emplace_back(
+            i, lane_s_range_tolerance_,
+            std::vector<api::RoadPosition>{api::RoadPosition(lane, api::LanePosition(*middle_start_s, 0., 0.))},
+            std::vector<api::RoadPosition>{api::RoadPosition(lane, api::LanePosition(*middle_end_s, 0., 0.))},
+            std::vector<api::LaneSRange>{api::LaneSRange(lane->id(), api::SRange(*middle_start_s, *middle_end_s))},
+            road_network_);
+      }
+    }
+    routes.emplace_back(phases, road_network_);
+  }
+
+  return FilterRoutes(routing_constraints, routes);
+}
+
+}  // namespace maliput

--- a/src/maliput/base/distance_router.cc
+++ b/src/maliput/base/distance_router.cc
@@ -63,6 +63,7 @@ double ComputeCost(const routing::Phase& phase) {
 }
 
 // Computes the cost of a routing::Route.
+//
 // @param route The routing::Route to compute the cost.
 // @return The accumulated cost of all the routing::Phases in @p route.
 double ComputeCost(const routing::Route& route) {
@@ -74,6 +75,7 @@ double ComputeCost(const routing::Route& route) {
 }
 
 // Determines the maximum cost of all routing::Phases in @p route.
+//
 // @param route The routing::Route to look for the maximum routing::Phase's cost.
 // @return The maximum cost of all routing::Phases in @p route.
 double MaxPhaseCostInRoute(const routing::Route& route) {
@@ -85,6 +87,7 @@ double MaxPhaseCostInRoute(const routing::Route& route) {
 }
 
 // Filters @p routes based on @p routing_constraints.
+//
 // @param routing_constraints The constraints to evaluate over @p routes.
 // @param routes The collection of routing::Routes that connect the start and end.
 // @return A subset of @p routes that comply with @p routing_constraints. The relative order in the returned
@@ -110,7 +113,7 @@ std::vector<routing::Route> FilterRoutes(const routing::RoutingConstraints& rout
 
 // Concatenates items in @p errors into just one string.
 //
-// When @p errors is empty an empty string computed.
+// When @p errors is empty an empty string is computed.
 // Otherwise, the "Route has connectivity errors: <error> | <error> | ... |" formula to concatenate items from @p errors
 // is used.
 // @param errors A vector of error strings.
@@ -124,6 +127,7 @@ std::string AggregateRouteConnectivityErrors(const std::vector<std::string>& err
 }
 
 // Iterates over @p routes and validates none have end to end connectivity errors.
+//
 // @param routes Vector of Routes to validate.
 // @throws common::assertion_error When one of the Routes in @p routes has end to end connectivity errors.
 void ValidateEndToEndConnectivityInRoutes(const std::vector<routing::Route>& routes) {
@@ -156,11 +160,13 @@ std::vector<routing::Route> DistanceRouter::DoComputeRoutes(
       routing::FindLaneSequences(start.lane, end.lane, std::numeric_limits<double>::max(), kRemoveUTurns);
 
   // Construct the routing::Routes and routing::Phases.
-  // TODO: lateral routing::Phase inflation.
+  // TODO: Add support for lateral routing::Phase inflation by considering alternative lanes from within the same
+  // segment besides those returned by routing::FindLaneSequences().
   const double start_s = start.pos.s();
   const double end_s = end.pos.s();
   std::vector<routing::Route> routes;
   for (const std::vector<const api::Lane*>& lane_sequence : lane_sequences) {
+    // Handles the case when lane_sequence has a length of 1. This implies the route only has one phase.
     if (lane_sequence.size() == 1u) {
       const routing::Phase phase(0, lane_s_range_tolerance_, {start}, {end},
                                  {api::LaneSRange(start.lane->id(), api::SRange(start_s, end_s))}, &road_network_);
@@ -168,7 +174,7 @@ std::vector<routing::Route> DistanceRouter::DoComputeRoutes(
       continue;
     }
 
-    // Handles the case when lane_sequence has a length greater than 1.
+    // Handles the case when lane_sequence has a length greater than 1. This implies the route has more than one phase.
     std::vector<routing::Phase> phases;
     for (int i = 0; i < static_cast<int>(lane_sequence.size()); ++i) {
       const api::Lane* lane = lane_sequence[i];

--- a/src/maliput/routing/derive_lane_s_routes.cc
+++ b/src/maliput/routing/derive_lane_s_routes.cc
@@ -33,7 +33,7 @@
 
 #include "maliput/api/branch_point.h"
 #include "maliput/api/lane.h"
-#include "maliput/common/maliput_abort.h"
+#include "maliput/common/maliput_throw.h"
 #include "maliput/common/profiler.h"
 #include "maliput/routing/find_lane_sequences.h"
 
@@ -43,7 +43,7 @@ namespace {
 
 // Returns true iff @p lane is in @p set.
 bool LaneExistsInSet(const api::LaneEndSet* set, const api::Lane* lane) {
-  MALIPUT_DEMAND(set != nullptr);
+  MALIPUT_THROW_UNLESS(set != nullptr);
   for (int i = 0; i < set->size(); ++i) {
     if (set->get(i).lane == lane) {
       return true;
@@ -52,10 +52,12 @@ bool LaneExistsInSet(const api::LaneEndSet* set, const api::Lane* lane) {
   return false;
 }
 
+}  // namespace
+
 // Returns the S coordinate in @p lane that is on the border with @p next_lane.
 std::optional<double> DetermineEdgeS(const api::Lane* lane, const api::Lane* next_lane) {
-  MALIPUT_DEMAND(lane != nullptr);
-  MALIPUT_DEMAND(next_lane != nullptr);
+  MALIPUT_THROW_UNLESS(lane != nullptr);
+  MALIPUT_THROW_UNLESS(next_lane != nullptr);
   if (LaneExistsInSet(lane->GetOngoingBranches(api::LaneEnd::kFinish), next_lane)) {
     return lane->length();
   }
@@ -65,25 +67,23 @@ std::optional<double> DetermineEdgeS(const api::Lane* lane, const api::Lane* nex
   return std::nullopt;
 }
 
-}  // namespace
-
 std::vector<api::LaneSRoute> DeriveLaneSRoutes(const api::RoadPosition& start, const api::RoadPosition& end,
                                                double max_length_m) {
   MALIPUT_PROFILE_FUNC();
-  MALIPUT_DEMAND(start.lane != nullptr);
-  MALIPUT_DEMAND(end.lane != nullptr);
+  MALIPUT_THROW_UNLESS(start.lane != nullptr);
+  MALIPUT_THROW_UNLESS(end.lane != nullptr);
   const double start_s = start.pos.s();
   const double end_s = end.pos.s();
   std::vector<api::LaneSRoute> result;
 
   for (const auto& lane_sequence : FindLaneSequences(start.lane, end.lane, max_length_m)) {
-    MALIPUT_DEMAND(!lane_sequence.empty());
+    MALIPUT_THROW_UNLESS(!lane_sequence.empty());
     std::vector<api::LaneSRange> ranges;
 
     // Handles the case when lane_sequence has a length of 1. This occurs when
     // start and end are in the same lane.
     if (lane_sequence.size() == 1) {
-      MALIPUT_DEMAND(start.lane == end.lane);
+      MALIPUT_THROW_UNLESS(start.lane == end.lane);
       const std::vector<api::LaneSRange> lane_s_ranges = {
           api::LaneSRange(start.lane->id(), api::SRange(start_s, end_s))};
       result.emplace_back(lane_s_ranges);
@@ -93,22 +93,22 @@ std::vector<api::LaneSRoute> DeriveLaneSRoutes(const api::RoadPosition& start, c
     // Handles the case when lane_sequence has a length greater than 1.
     for (size_t i = 0; i < lane_sequence.size(); ++i) {
       const api::Lane* lane = lane_sequence.at(i);
-      MALIPUT_DEMAND(lane != nullptr);
+      MALIPUT_THROW_UNLESS(lane != nullptr);
       if (i == 0) {
-        MALIPUT_DEMAND(lane->id() == start.lane->id());
+        MALIPUT_THROW_UNLESS(lane->id() == start.lane->id());
         const std::optional<double> first_end_s = DetermineEdgeS(lane, lane_sequence.at(1));
-        MALIPUT_DEMAND(first_end_s.has_value());
+        MALIPUT_THROW_UNLESS(first_end_s.has_value());
         ranges.emplace_back(lane->id(), api::SRange(start_s, first_end_s.value()));
       } else if (i + 1 == lane_sequence.size()) {
-        MALIPUT_DEMAND(lane->id() == end.lane->id());
-        MALIPUT_DEMAND(i > 0);
+        MALIPUT_THROW_UNLESS(lane->id() == end.lane->id());
+        MALIPUT_THROW_UNLESS(i > 0);
         const std::optional<double> last_start_s = DetermineEdgeS(lane, lane_sequence.at(i - 1));
-        MALIPUT_DEMAND(last_start_s.has_value());
+        MALIPUT_THROW_UNLESS(last_start_s.has_value());
         ranges.emplace_back(lane->id(), api::SRange(last_start_s.value(), end_s));
       } else {
         const std::optional<double> middle_start_s = DetermineEdgeS(lane, lane_sequence.at(i - 1));
         const std::optional<double> middle_end_s = DetermineEdgeS(lane, lane_sequence.at(i + 1));
-        MALIPUT_DEMAND(middle_start_s && middle_end_s);
+        MALIPUT_THROW_UNLESS(middle_start_s && middle_end_s);
         ranges.emplace_back(lane->id(), api::SRange(middle_start_s.value(), middle_end_s.value()));
       }
     }

--- a/src/maliput/routing/derive_lane_s_routes.cc
+++ b/src/maliput/routing/derive_lane_s_routes.cc
@@ -54,7 +54,6 @@ bool LaneExistsInSet(const api::LaneEndSet* set, const api::Lane& lane) {
 
 }  // namespace
 
-// Returns the S coordinate in @p lane that is on the border with @p next_lane.
 std::optional<double> DetermineEdgeS(const api::Lane& lane, const api::Lane& next_lane) {
   if (LaneExistsInSet(lane.GetOngoingBranches(api::LaneEnd::kFinish), next_lane)) {
     return lane.length();
@@ -114,5 +113,6 @@ std::vector<api::LaneSRoute> DeriveLaneSRoutes(const api::RoadPosition& start, c
   }
   return result;
 }
+
 }  // namespace routing
 }  // namespace maliput

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,4 +1,5 @@
 ament_add_gtest(base_rule_registry_test rule_registry_test.cc)
+ament_add_gmock(distance_router_test distance_router_test.cc)
 ament_add_gtest(intersection_test intersection_test.cc)
 ament_add_gtest(intersection_book_test intersection_book_test.cc)
 ament_add_gtest(manual_phase_provider_test manual_phase_provider_test.cc)
@@ -28,6 +29,8 @@ macro(add_dependencies_to_test target)
       target_link_libraries(${target}
           maliput::api
           maliput::base
+          maliput::common
+          maliput::routing
           test_utilities
       )
 
@@ -35,6 +38,7 @@ macro(add_dependencies_to_test target)
 endmacro()
 
 add_dependencies_to_test(base_rule_registry_test)
+add_dependencies_to_test(distance_router_test)
 add_dependencies_to_test(intersection_test)
 add_dependencies_to_test(intersection_book_test)
 add_dependencies_to_test(manual_phase_provider_test)

--- a/test/base/distance_router_test.cc
+++ b/test/base/distance_router_test.cc
@@ -1,6 +1,6 @@
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+// Copyright (c) 2024, Woven by Toyota. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -56,20 +56,16 @@ class DistanceRouterTest : public ::testing::Test {
   static constexpr double kLaneSRangeTolerance{1e-12};
 };
 
-TEST_F(DistanceRouterTest, NullptrRoadNetworkInConstructorThrows) {
-  EXPECT_THROW({ DistanceRouter(nullptr, kLaneSRangeTolerance); }, common::assertion_error);
-}
-
 TEST_F(DistanceRouterTest, NegativeLaneSRangeToleranceInConstructorThrows) {
   auto road_network = MakeMockedRoadNetwork();
 
-  EXPECT_THROW({ DistanceRouter(road_network.get(), -1.0); }, common::assertion_error);
+  EXPECT_THROW({ DistanceRouter(*road_network, -1.0); }, common::assertion_error);
 }
 
 TEST_F(DistanceRouterTest, CorrectConstruction) {
   auto road_network = MakeMockedRoadNetwork();
 
-  EXPECT_NO_THROW({ DistanceRouter(road_network.get(), kLaneSRangeTolerance); });
+  EXPECT_NO_THROW({ DistanceRouter(*road_network, kLaneSRangeTolerance); });
 }
 
 class DistanceRouterComputeRoutesTest : public DistanceRouterTest {
@@ -100,7 +96,7 @@ TEST_F(DistanceRouterComputeRoutesTest, InvalidStartLaneInComputeRoutesThrows) {
   const api::RoadPosition start_with_non_null_lane(&start_lane_, api::LanePosition(1., 2., 3.));
   const api::RoadPosition end(&end_lane_, api::LanePosition(4., 5., 6.));
 
-  const DistanceRouter dut(road_network_.get(), kLaneSRangeTolerance);
+  const DistanceRouter dut(*road_network_, kLaneSRangeTolerance);
 
   EXPECT_THROW({ dut.ComputeRoutes(start_with_null_lane, end, kConstraints); }, common::assertion_error);
   EXPECT_THROW({ dut.ComputeRoutes(start_with_non_null_lane, end, kConstraints); }, common::assertion_error);
@@ -113,7 +109,7 @@ TEST_F(DistanceRouterComputeRoutesTest, InvalidEndLaneInComputeRoutesThrows) {
   const api::RoadPosition end_with_null_lane;
   const api::RoadPosition end_with_non_null_lane(&end_lane_, api::LanePosition(4., 5., 6.));
 
-  const DistanceRouter dut(road_network_.get(), kLaneSRangeTolerance);
+  const DistanceRouter dut(*road_network_, kLaneSRangeTolerance);
 
   EXPECT_THROW({ dut.ComputeRoutes(start, end_with_null_lane, kConstraints); }, common::assertion_error);
   EXPECT_THROW({ dut.ComputeRoutes(start, end_with_non_null_lane, kConstraints); }, common::assertion_error);
@@ -126,7 +122,7 @@ TEST_F(DistanceRouterComputeRoutesTest, InvalidConstraintsInComputeRoutesThrows)
   const api::RoadPosition end(&end_lane_, api::LanePosition(4., 5., 6.));
   const routing::RoutingConstraints kInvalidConstraints{true, {-1.}, {}};
 
-  const DistanceRouter dut(road_network_.get(), kLaneSRangeTolerance);
+  const DistanceRouter dut(*road_network_, kLaneSRangeTolerance);
 
   EXPECT_THROW({ dut.ComputeRoutes(start, end, kInvalidConstraints); }, common::assertion_error);
 }

--- a/test/base/distance_router_test.cc
+++ b/test/base/distance_router_test.cc
@@ -1,0 +1,136 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput/base/distance_router.h"
+
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "maliput/api/lane_data.h"
+#include "maliput/api/road_geometry.h"
+#include "maliput/api/road_network.h"
+#include "maliput/common/assertion_error.h"
+#include "maliput/routing/phase.h"
+#include "maliput/routing/route.h"
+#include "maliput/routing/routing_constraints.h"
+#include "road_network_mocks.h"
+
+namespace maliput {
+namespace test {
+namespace {
+
+using maliput::test::IdIndexMock;
+using maliput::test::LaneMock;
+using maliput::test::RoadGeometryMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+class DistanceRouterTest : public ::testing::Test {
+ public:
+  static constexpr double kLaneSRangeTolerance{1e-12};
+};
+
+TEST_F(DistanceRouterTest, NullptrRoadNetworkInConstructorThrows) {
+  EXPECT_THROW({ DistanceRouter(nullptr, kLaneSRangeTolerance); }, common::assertion_error);
+}
+
+TEST_F(DistanceRouterTest, NegativeLaneSRangeToleranceInConstructorThrows) {
+  auto road_network = MakeMockedRoadNetwork();
+
+  EXPECT_THROW({ DistanceRouter(road_network.get(), -1.0); }, common::assertion_error);
+}
+
+TEST_F(DistanceRouterTest, CorrectConstruction) {
+  auto road_network = MakeMockedRoadNetwork();
+
+  EXPECT_NO_THROW({ DistanceRouter(road_network.get(), kLaneSRangeTolerance); });
+}
+
+class DistanceRouterComputeRoutesTest : public DistanceRouterTest {
+ public:
+  const api::LaneId kStartLaneId{"start_lane"};
+  const api::LaneId kEndLaneId{"end_lane"};
+  const routing::RoutingConstraints kConstraints{};
+
+  void SetUp() override {
+    road_network_ = MakeMockedRoadNetwork();
+    RoadGeometryMock* road_geometry =
+        static_cast<RoadGeometryMock*>(const_cast<api::RoadGeometry*>(road_network_->road_geometry()));
+    EXPECT_CALL(*road_geometry, DoById()).WillRepeatedly(ReturnRef(id_index_));
+    EXPECT_CALL(start_lane_, do_id()).WillRepeatedly(Return(kStartLaneId));
+    EXPECT_CALL(end_lane_, do_id()).WillRepeatedly(Return(kEndLaneId));
+  }
+
+  std::unique_ptr<api::RoadNetwork> road_network_;
+  LaneMock start_lane_;
+  LaneMock end_lane_;
+  IdIndexMock id_index_;
+};
+
+TEST_F(DistanceRouterComputeRoutesTest, InvalidStartLaneInComputeRoutesThrows) {
+  EXPECT_CALL(id_index_, DoGetLane(kStartLaneId)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(id_index_, DoGetLane(kEndLaneId)).WillRepeatedly(Return(&end_lane_));
+  const api::RoadPosition start_with_null_lane;
+  const api::RoadPosition start_with_non_null_lane(&start_lane_, api::LanePosition(1., 2., 3.));
+  const api::RoadPosition end(&end_lane_, api::LanePosition(4., 5., 6.));
+
+  const DistanceRouter dut(road_network_.get(), kLaneSRangeTolerance);
+
+  EXPECT_THROW({ dut.ComputeRoutes(start_with_null_lane, end, kConstraints); }, common::assertion_error);
+  EXPECT_THROW({ dut.ComputeRoutes(start_with_non_null_lane, end, kConstraints); }, common::assertion_error);
+}
+
+TEST_F(DistanceRouterComputeRoutesTest, InvalidEndLaneInComputeRoutesThrows) {
+  EXPECT_CALL(id_index_, DoGetLane(kStartLaneId)).WillRepeatedly(Return(&start_lane_));
+  EXPECT_CALL(id_index_, DoGetLane(kEndLaneId)).WillRepeatedly(Return(nullptr));
+  const api::RoadPosition start(&start_lane_, api::LanePosition(1., 2., 3.));
+  const api::RoadPosition end_with_null_lane;
+  const api::RoadPosition end_with_non_null_lane(&end_lane_, api::LanePosition(4., 5., 6.));
+
+  const DistanceRouter dut(road_network_.get(), kLaneSRangeTolerance);
+
+  EXPECT_THROW({ dut.ComputeRoutes(start, end_with_null_lane, kConstraints); }, common::assertion_error);
+  EXPECT_THROW({ dut.ComputeRoutes(start, end_with_non_null_lane, kConstraints); }, common::assertion_error);
+}
+
+TEST_F(DistanceRouterComputeRoutesTest, InvalidConstraintsInComputeRoutesThrows) {
+  EXPECT_CALL(id_index_, DoGetLane(kStartLaneId)).WillRepeatedly(Return(&start_lane_));
+  EXPECT_CALL(id_index_, DoGetLane(kEndLaneId)).WillRepeatedly(Return(&end_lane_));
+  const api::RoadPosition start(&start_lane_, api::LanePosition(1., 2., 3.));
+  const api::RoadPosition end(&end_lane_, api::LanePosition(4., 5., 6.));
+  const routing::RoutingConstraints kInvalidConstraints{true, {-1.}, {}};
+
+  const DistanceRouter dut(road_network_.get(), kLaneSRangeTolerance);
+
+  EXPECT_THROW({ dut.ComputeRoutes(start, end, kInvalidConstraints); }, common::assertion_error);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace maliput

--- a/test/road_network_mocks.h
+++ b/test/road_network_mocks.h
@@ -54,7 +54,6 @@
 #include <maliput/api/segment.h>
 
 namespace maliput {
-namespace routing {
 namespace test {
 
 /// @brief Google mock api::RoadGeometry.
@@ -99,6 +98,12 @@ class LaneMock final : public api::Lane {
   MOCK_METHOD(api::LanePositionResult, DoToSegmentPosition, (const api::InertialPosition&), (const));
   MOCK_METHOD(const api::LaneEndSet*, DoGetConfluentBranches, (const api::LaneEnd::Which), (const));
   MOCK_METHOD(const api::LaneEndSet*, DoGetOngoingBranches, (const api::LaneEnd::Which), (const));
+};
+
+class LaneEndSetMock final : public api::LaneEndSet {
+ public:
+  MOCK_METHOD(int, do_size, (), (const));
+  MOCK_METHOD(const api::LaneEnd&, do_get, (int), (const));
 };
 
 /// @brief Google mock api::RoadGeometry::IdIndex.
@@ -204,5 +209,4 @@ inline std::unique_ptr<api::RoadNetwork> MakeMockedRoadNetwork() {
 }
 
 }  // namespace test
-}  // namespace routing
 }  // namespace maliput

--- a/test/routing/CMakeLists.txt
+++ b/test/routing/CMakeLists.txt
@@ -1,3 +1,4 @@
+ament_add_gmock(derive_lane_s_routes_test derive_lane_s_routes_test.cc)
 ament_add_gmock(route_test route_test.cc)
 ament_add_gtest(routing_compare_test compare_test.cc)
 ament_add_gmock(routing_phase_test phase_test.cc)
@@ -9,7 +10,6 @@ macro(add_dependencies_to_test target)
       target_include_directories(${target}
         PRIVATE
           ${PROJECT_SOURCE_DIR}/include
-          ${CMAKE_CURRENT_SOURCE_DIR}
           ${PROJECT_SOURCE_DIR}/test
       )
 
@@ -23,6 +23,7 @@ macro(add_dependencies_to_test target)
     endif()
 endmacro()
 
+add_dependencies_to_test(derive_lane_s_routes_test)
 add_dependencies_to_test(route_test)
 add_dependencies_to_test(routing_compare_test)
 add_dependencies_to_test(routing_phase_test)

--- a/test/routing/derive_lane_s_routes_test.cc
+++ b/test/routing/derive_lane_s_routes_test.cc
@@ -1,0 +1,106 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput/routing/derive_lane_s_routes.h"
+
+#include <optional>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "maliput/api/lane.h"
+#include "maliput/api/lane_data.h"
+#include "maliput/common/assertion_error.h"
+#include "road_network_mocks.h"
+
+namespace maliput {
+namespace routing {
+namespace test {
+namespace {
+
+using maliput::test::LaneEndSetMock;
+using maliput::test::LaneMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+class DetermineEdgeSTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    EXPECT_CALL(lane_, DoGetOngoingBranches(api::LaneEnd::kFinish)).WillRepeatedly(Return(&finish_lane_end_set_));
+    EXPECT_CALL(lane_, DoGetOngoingBranches(api::LaneEnd::kStart)).WillRepeatedly(Return(&start_lane_end_set_));
+  }
+
+  LaneMock lane_;
+  LaneMock next_lane_;
+  LaneEndSetMock finish_lane_end_set_;
+  LaneEndSetMock start_lane_end_set_;
+};
+
+TEST_F(DetermineEdgeSTest, EvaluatePrerequisites) {
+  EXPECT_THROW({ DetermineEdgeS(nullptr, &next_lane_); }, common::assertion_error);
+  EXPECT_THROW({ DetermineEdgeS(&lane_, nullptr); }, common::assertion_error);
+}
+
+TEST_F(DetermineEdgeSTest, NextLaneIsInOngoingBranchesAtFinishReturnsLaneLength) {
+  constexpr double kLaneLength{100.};
+  const api::LaneEnd lane_end(&next_lane_, api::LaneEnd::kStart);
+  EXPECT_CALL(lane_, do_length()).WillRepeatedly(Return(kLaneLength));
+  EXPECT_CALL(finish_lane_end_set_, do_size()).WillRepeatedly(Return(1));
+  EXPECT_CALL(finish_lane_end_set_, do_get(0)).WillRepeatedly(ReturnRef(lane_end));
+
+  std::optional<double> result = DetermineEdgeS(&lane_, &next_lane_);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(kLaneLength, result.value());
+}
+
+TEST_F(DetermineEdgeSTest, NextLaneIsInOngoingBranchesAtStartReturnsZero) {
+  const api::LaneEnd lane_end(&next_lane_, api::LaneEnd::kStart);
+  EXPECT_CALL(finish_lane_end_set_, do_size()).WillRepeatedly(Return(0));
+  EXPECT_CALL(start_lane_end_set_, do_size()).WillRepeatedly(Return(1));
+  EXPECT_CALL(start_lane_end_set_, do_get(0)).WillRepeatedly(ReturnRef(lane_end));
+
+  std::optional<double> result = DetermineEdgeS(&lane_, &next_lane_);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(0., result.value());
+}
+
+TEST_F(DetermineEdgeSTest, NextLaneIsNotInOngoingBranchesReturnsNullopt) {
+  EXPECT_CALL(finish_lane_end_set_, do_size()).WillRepeatedly(Return(0));
+  EXPECT_CALL(start_lane_end_set_, do_size()).WillRepeatedly(Return(0));
+
+  std::optional<double> result = DetermineEdgeS(&lane_, &next_lane_);
+
+  ASSERT_FALSE(result.has_value());
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace routing
+}  // namespace maliput

--- a/test/routing/derive_lane_s_routes_test.cc
+++ b/test/routing/derive_lane_s_routes_test.cc
@@ -1,6 +1,6 @@
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+// Copyright (c) 2024, Woven by Toyota. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -61,11 +61,6 @@ class DetermineEdgeSTest : public ::testing::Test {
   LaneEndSetMock start_lane_end_set_;
 };
 
-TEST_F(DetermineEdgeSTest, EvaluatePrerequisites) {
-  EXPECT_THROW({ DetermineEdgeS(nullptr, &next_lane_); }, common::assertion_error);
-  EXPECT_THROW({ DetermineEdgeS(&lane_, nullptr); }, common::assertion_error);
-}
-
 TEST_F(DetermineEdgeSTest, NextLaneIsInOngoingBranchesAtFinishReturnsLaneLength) {
   constexpr double kLaneLength{100.};
   const api::LaneEnd lane_end(&next_lane_, api::LaneEnd::kStart);
@@ -73,7 +68,7 @@ TEST_F(DetermineEdgeSTest, NextLaneIsInOngoingBranchesAtFinishReturnsLaneLength)
   EXPECT_CALL(finish_lane_end_set_, do_size()).WillRepeatedly(Return(1));
   EXPECT_CALL(finish_lane_end_set_, do_get(0)).WillRepeatedly(ReturnRef(lane_end));
 
-  std::optional<double> result = DetermineEdgeS(&lane_, &next_lane_);
+  std::optional<double> result = DetermineEdgeS(lane_, next_lane_);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(kLaneLength, result.value());
@@ -85,7 +80,7 @@ TEST_F(DetermineEdgeSTest, NextLaneIsInOngoingBranchesAtStartReturnsZero) {
   EXPECT_CALL(start_lane_end_set_, do_size()).WillRepeatedly(Return(1));
   EXPECT_CALL(start_lane_end_set_, do_get(0)).WillRepeatedly(ReturnRef(lane_end));
 
-  std::optional<double> result = DetermineEdgeS(&lane_, &next_lane_);
+  std::optional<double> result = DetermineEdgeS(lane_, next_lane_);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(0., result.value());
@@ -95,7 +90,7 @@ TEST_F(DetermineEdgeSTest, NextLaneIsNotInOngoingBranchesReturnsNullopt) {
   EXPECT_CALL(finish_lane_end_set_, do_size()).WillRepeatedly(Return(0));
   EXPECT_CALL(start_lane_end_set_, do_size()).WillRepeatedly(Return(0));
 
-  std::optional<double> result = DetermineEdgeS(&lane_, &next_lane_);
+  std::optional<double> result = DetermineEdgeS(lane_, next_lane_);
 
   ASSERT_FALSE(result.has_value());
 }

--- a/test/routing/phase_test.cc
+++ b/test/routing/phase_test.cc
@@ -40,7 +40,7 @@
 #include "maliput/api/regions.h"
 #include "maliput/common/assertion_error.h"
 #include "maliput/routing/compare.h"
-#include "routing/road_network_mocks.h"
+#include "road_network_mocks.h"
 
 namespace maliput {
 namespace routing {
@@ -48,6 +48,11 @@ namespace test {
 namespace {
 
 using maliput::test::AssertCompare;
+using maliput::test::IdIndexMock;
+using maliput::test::LaneMock;
+using maliput::test::MakeMockedRoadNetwork;
+using maliput::test::RoadGeometryMock;
+using maliput::test::SegmentMock;
 using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;

--- a/test/routing/route_test.cc
+++ b/test/routing/route_test.cc
@@ -45,7 +45,7 @@
 #include "maliput/routing/lane_s_range_relation.h"
 #include "maliput/routing/phase.h"
 #include "maliput/routing/route_position_result.h"
-#include "routing/road_network_mocks.h"
+#include "road_network_mocks.h"
 
 namespace maliput {
 namespace routing {
@@ -53,6 +53,11 @@ namespace test {
 namespace {
 
 using maliput::test::AssertCompare;
+using maliput::test::IdIndexMock;
+using maliput::test::LaneMock;
+using maliput::test::MakeMockedRoadNetwork;
+using maliput::test::RoadGeometryMock;
+using maliput::test::SegmentMock;
 using ::testing::_;
 using ::testing::Matcher;
 using ::testing::MatcherInterface;


### PR DESCRIPTION
# 🎉 New feature

Part of #543
Goes on top of #586 and #618
Goes hand in hand with:
- https://github.com/maliput/maliput_integration_tests/pull/80
- https://github.com/maliput/maliput_integration/pull/136

## Summary
Provides a basic `Router` implementation.

This router is implemented using FindLaneSequences() method and does not have any notion of direction of travel, yet. However, it uses the feature implemented in #618 to avoid U-turns in the available paths.
This first implementation does not provide support for:
- paths that require `lane` switch (not provided via FindLaneSequences()).
- `lane` inflation within a `phase`.
Those features will be added in future pull requests.

## Test it

Partially tested within maliput, other PRs with integration support provide full coverage.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
