### PR TITLE
[bazel] yaml-cpp from the bcr instead of the fork

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,12 @@
 # use --enable_bzlmod on the command line.
 common --enable_bzlmod
 
-# TODO(daniel.stonier) Delete once 'yaml-cpp' has made it into the official BCR
-build --registry=https://raw.githubusercontent.com/stonier/bazel-central-registry/maliput_releases/
+# A local fork of the registry:
+# common --registry=file://%workspace%/../bazel-central-registry
+
+# Central Registry
+build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
+
 
 ########################################
 # Bazel Configuration

--- a/.devcontainer/bazel-zen/devcontainer.json
+++ b/.devcontainer/bazel-zen/devcontainer.json
@@ -18,5 +18,15 @@
                 "yzhang.markdown-all-in-one"
             ]
         }
-    }
+    },
+    // Mount for local co-development with a registry fork
+    // 1. Uncomment the local registry argument in .bazelrc
+    // 2. Patch the path below and uncomment
+    // "mounts": [
+	// 	{
+    //         "source": "/path/to/bazel-central-registry",
+    //         "target": "/workspaces/bazel-central-registry",
+    //         "type": "bind"
+    //     }
+	// ]
 }


### PR DESCRIPTION
# BCR

Uses the bazel central registry for yaml-cpp.

## Summary

No longer needs the fork.

## Test it

```
bazel clean
bazel build //...
```
