### PR TITLE
[infra] create a release archive with a stable url

### DIFF
--- a/.github/workflows/release_archive.yaml
+++ b/.github/workflows/release_archive.yaml
@@ -1,0 +1,20 @@
+name: Release Archive
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  # Attach tarballs to releases with stable release url's
+  #   NB: tag url's aren't guaranteed to be persistent
+  #   See: https://blog.bazel.build/2023/02/15/github-archive-checksum.html
+  release-archive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - run: git archive $GITHUB_REF -o "maliput-${GITHUB_REF:10}.tar.gz"
+      - run: gh release upload ${GITHUB_REF:10} "maliput-${GITHUB_REF:10}.tar.gz"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# 🎉 New feature

Tag archive url's aren't guaranteed to be stable. See https://blog.bazel.build/2023/02/15/github-archive-checksum.html. 

This action creates a release archive and uploads it. This is particularly important for bazel central registry releases which make use of these archives.

## Summary

This I got from https://github.com/jbeder/yaml-cpp/pull/1230. 

## Test it

TBD - I don't know if it works or not yet.