### PR TITLE
[infra] templates for bcr release automation

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/maliput/maliput",
+    "maintainers": [
+      {
+        "name": "Daniel Stonier",
+        "email": "d.stonier@gmail.com",
+        "github": "stonier"
+      }
+    ],
+    "repository": [
+      "github:maliput/maliput"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+  }

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,25 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "ubuntu2004"]
+  tasks:
+    verify_targets:
+      name: Verify Build Targets
+      platform: ${{ platform }}
+      build_targets:
+        - '@maliput//:common'
+        - '@maliput//:math'
+        - '@maliput//:base'
+        - '@maliput//:geometry_base'
+        - '@maliput//:api'
+        - '@maliput//:plugin'
+        - '@maliput//:routing'
+        - '@maliput//:utility'
+        - '@maliput//:drake'
+        - '@maliput//:test_utilities'
+    # TODO(stonier): no tests yet...
+    # run_tests:
+    #   name: "Run test module"
+    #   platform: ${{ platform }}
+    #   test_targets:
+    #     - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "",
+    "strip_prefix": "{REPO}-{VERSION}",
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}


### PR DESCRIPTION
# 🎉 New feature

Template configuration for the [BCR release github application](https://github.com/bazel-contrib/publish-to-bcr).

## Summary

* I've added the BCR app to the maliput org, you can configure which repos it works on via [org app settings](https://github.com/maliput/maliput/settings/installations).
* Uses the release download url (more stable than tag urls)
* Not tested yet - guess it will be trial and error

## Questions

Do we have a maliput email / github user account?