### PR TITLE
[infra] bugfix release action till working

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: stonier
+  email: d.stonier@gmail.com

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Env Variables
+      - name: Set Variables
         shell: bash
+        run: echo "ARCHIVE_NAME=${{ github.event.repository.name }}-${GITHUB_REF_NAME}" >> $GITHUB_ENV
+      - name: Variables
         run: |
-          echo "ARCHIVE_NAME=${{ github.event.repository.name }}-${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          echo "Repository Name: ${{ github.event.repository.name }}"
+          echo "GITHUB_REF: ${GITHUB_REF}"
+          echo "GITUB_REF_NAME: ${GITHUB_REF_NAME}"
+          echo "ARCHIVE_NAME: ${{ env.ARCHIVE_NAME }}"
       - name: Create Release Asset
+        shell: bash
         run: git archive $GITHUB_REF --prefix=${{ env.ARCHIVE_NAME }}/ -o "${{ env.ARCHIVE_NAME }}.tar.gz"
       - name: Cut a Release
         uses: softprops/action-gh-release@v1
         with:
+          draft: false
           prerelease: false
           files: ${{ env.ARCHIVE_NAME }}.tar.gz


### PR DESCRIPTION
# 🎉 New feature

This PR (and 952b6716) create a release from a newly created tag and additionally uploads a stable archive with the release.

## Summary

:warning:  I accidentally committed my first attempt to main in 952b6716 (we need to disable admins being able to push to main). This PR simply bugfixes the original commit so that the BCR app kicks in and works.

* Logs for the BCR app run come in the form of emails
* The BCR app and the Release Archive workflow we originally used trigger in parallel and create a race condition. The BCR app job fails upon not finding the uploaded release archive.
* The BCR app creates branches on [maliput/bazel-central-registry](https://github.com/maliput/bazel-central-registry) and submits PR's to https://github.com/bazelbuild/bazel-central-registry
* Maliput 1.2.0 PR on the BCR is [here](https://github.com/bazelbuild/bazel-central-registry/pull/1260)

## Test it

* Create a tag from this PR branch
* Check that a new release was cut here with the tag name
* Check that a branch was made on our BCR fork
* Check that a PR was made on the bazel central registry
