### PR TITLE
[infra] do not test bcr releases on debian

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "."
   matrix:
-    platform: ["debian10", "ubuntu2004"]
+    platform: ["ubuntu2004"]  # "debian10", "macos", "windows"
   tasks:
     verify_targets:
       name: Verify Build Targets


### PR DESCRIPTION
Maliput fails with some compiler errors. Not essential to support for now.

https://buildkite.com/bazel/bcr-presubmit/builds/2925#018cd55f-ce85-412d-92e5-10adb87d3665
