### PR TITLE
Adds bazel version to the matrix to avoid presubmit checks to fail.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,11 +1,13 @@
 bcr_test_module:
   module_path: "."
   matrix:
+    bazel: [6.x]
     platform: ["ubuntu2004"]  # "debian10", "macos", "windows"
   tasks:
     verify_targets:
       name: Verify Build Targets
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       build_targets:
         - '@maliput//:common'
         - '@maliput//:math'


### PR DESCRIPTION
# 🦟 Bug fix

Aims to fix: https://buildkite.com/bazel/bcr-presubmit/builds/5047#018f2e0c-4d57-4a32-a0d4-b787aa479da9

## Summary
Adds the bazel version field to the matrix to avoid presubmit errors when releasing to bcr.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

