### PR TITLE
Fix scan_build errors.

### DIFF
--- a/test/drake/arc_length_integrator_test.cc
+++ b/test/drake/arc_length_integrator_test.cc
@@ -142,7 +142,7 @@ TEST_F(ArcLengthIntegratorTest, ThrowsWhenIndependentVariableIsOutOfRange) {
   // Integrable function that returns the tangent vector norm of a function.
   // In this case, it could be a straight line. A vector whose norm is 2.0 in
   // any direction multiplied by `p`.
-  const auto integrable_function = [&expected_k = k](const double& p, const math::Vector2& k) -> double {
+  const auto integrable_function = [ /* &expected_k = k */ ](const double& p, const math::Vector2& k) -> double {
     maliput::common::unused(p);
     maliput::common::unused(k);
     return 2.0;

--- a/test/drake/arc_length_integrator_test.cc
+++ b/test/drake/arc_length_integrator_test.cc
@@ -142,7 +142,7 @@ TEST_F(ArcLengthIntegratorTest, ThrowsWhenIndependentVariableIsOutOfRange) {
   // Integrable function that returns the tangent vector norm of a function.
   // In this case, it could be a straight line. A vector whose norm is 2.0 in
   // any direction multiplied by `p`.
-  const auto integrable_function = [ /* &expected_k = k */ ](const double& p, const math::Vector2& k) -> double {
+  const auto integrable_function = [](const double& p, const math::Vector2& k) -> double {
     maliput::common::unused(p);
     maliput::common::unused(k);
     return 2.0;

--- a/test/routing/route_test.cc
+++ b/test/routing/route_test.cc
@@ -737,7 +737,7 @@ class LanePositionMatcher : public MatcherInterface<const api::LanePosition&> {
  public:
   explicit LanePositionMatcher(const api::LanePosition& lane_position) : lane_position_(lane_position) {}
 
-  bool MatchAndExplain(const api::LanePosition& other_lane_position, MatchResultListener*) const {
+  bool MatchAndExplain(const api::LanePosition& other_lane_position, MatchResultListener*) const override {
     return lane_position_.srh() == other_lane_position.srh();
   }
 

--- a/tools/scan_build.supp
+++ b/tools/scan_build.supp
@@ -1,2 +1,2 @@
 /usr/include/eigen3
-src/maliput/include/maliput/drake
+src/maliput/src/maliput/drake


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #617

## Summary
Fixes two tests with scan_build errors and revisits the suppression list to exclude drake files.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
