### PR TITLE
hash: include <cstdint>

### DIFF
--- a/include/maliput/common/maliput_hash.h
+++ b/include/maliput/common/maliput_hash.h
@@ -69,6 +69,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>

--- a/src/maliput/drake/common/hash.h
+++ b/src/maliput/drake/common/hash.h
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>


### PR DESCRIPTION


<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://maliput.readthedocs.io/en/latest/contributing.html
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

When building maliput-sdk-1.3.0 via cargo I came across compile errors like the following:
```
  In file included from external/maliput~1.3.0/src/maliput/drake/common/hash.cc:1:
  bazel-out/k8-fastbuild/bin/external/maliput~1.3.0/_virtual_includes/drake_private_common/maliput/drake/common/hash.h:201:27: error: 'uint8_t' has not been declared
    201 |   constexpr void add_byte(uint8_t byte) noexcept { hash_ = (hash_ ^ byte) * kFnvPrime; }
        |                           ^~~~~~~
```

Command:
```
/nix/store/r6k305g2rn0qqkvdxfvzqg7mhh7rw679-gcc-wrapper-13.2.0/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++14' -MD -MF bazel-out/k8-fastbuild/bin/external/maliput~1.3.0/_objs/drake_private_common/hash.pic.d '-frandom-seed=bazel-out/k8-fastbuild/bin/external/maliput~1.3.0/_objs/drake_private_common/hash.pic.o' -fPIC '-DBAZEL_CURRENT_REPOSITORY="maliput~1.3.0"' -iquote external/maliput~1.3.0 -iquote bazel-out/k8-fastbuild/bin/external/maliput~1.3.0 -iquote external/eigen~3.4.0 -iquote bazel-out/k8-fastbuild/bin/external/eigen~3.4.0 -isystem external/maliput~1.3.0 -isystem bazel-out/k8-fastbuild/bin/external/maliput~1.3.0 -isystem bazel-out/k8-fastbuild/bin/external/maliput~1.3.0/_virtual_includes/drake_private_common -isystem external/eigen~3.4.0 -isystem bazel-out/k8-fastbuild/bin/external/eigen~3.4.0 '-std=c++17' -Werror '-std=c++17' -Wno-builtin-macro-redefined -Wno-missing-field-initializers -Wno-unused-const-variable -O2 -w -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c external/maliput~1.3.0/src/maliput/drake/common/hash.cc -o bazel-out/k8-fastbuild/bin/external/maliput~1.3.0/_objs/drake_private_common/hash.pic.o
```

This PR includes the `<cstdint>` such that compile errors due to undeclared fixed-width integer types aren't raised.

Reproducer (sorry for the implicit workflow):
- depend on `maliput = { version = "0.1" }` or `maliput-sdk = { version = "0.1.3"}` in a Cargo.toml file
- Run `cargo build`
- Observe compile errors
- Apply this patch to the sources in the temporary build folder
- Run `cargo build` again
- Observe that the `maliput-sdk` crate now builds

Versions:
```
$  bazel --version
bazel 6.5.0- (@non-git)
$ bazelisk --version
bazel 7.3.2
$ gcc --version
gcc (GCC) 13.2.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

The `<cstddef>` doesn't imply `<cstdint>` and the hashing modules use uint8_t which is provided by `<cstdint>`. This commit adds includes to `<cstdint>` to the maliput_hash.h file and the drake hash.h file to ensure that fixed-width integers like uint8_t are available.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.