### PR TITLE
Prepare for release 1.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,41 @@
 Changelog for package maliput
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1.3.0 (2024-04-29)
------------
-* Add fresnel functions (`#629 <https://github.com/ToyotaResearchInstitute/maliput/issues/629>`_)
-
+1.3.1 (2024-10-26)
+------------------
+* hash: include <cstdint> (`#640 <https://github.com/maliput/maliput/issues/640>`_)
+  The <cstddef> doesn't imply <cstdint> and the hashing modules use
+  uint8_t which is provided by <cstdint>. This commit adds includes
+  to <cstdint> to the maliput_hash.h file and the drake hash.h file
+  to ensure that fixed-width integers like uint8_t are available.
+* Provides another function to include route signaling in DOT graphs when adding routes (`#639 <https://github.com/maliput/maliput/issues/639>`_)
+  * Provides another function to include route signaling in graphs when serialized via DOT streams.
+* Adds the filter to remove routes with lane changes when RoutingConstraints::allow_lane_switch is false. (`#638 <https://github.com/maliput/maliput/issues/638>`_)
+* Adds a function that allows to export a routing::graph::Graph as a dot file. (`#637 <https://github.com/maliput/maliput/issues/637>`_)
+* Modifies the DistanceRouter to consume the graph and provide multi-Lane routes. (`#636 <https://github.com/maliput/maliput/issues/636>`_)
+* Graph tools to perform route queries with Segments. (`#635 <https://github.com/maliput/maliput/issues/635>`_)
+  * Graph tools to perform route queries with Segments.
+  Router implementations will be able to use this tools such that
+  they can get the set of of Lanes per Phase in Routes that connect
+  point A with point B.
+* Route part four - DistanceRouter (`#619 <https://github.com/maliput/maliput/issues/619>`_)
+  * Provides an implementation for Router.
+  - The router is based on a distance cost function.
+  - Inflation of the routes to embrace lateral lanes is a TODO.
+* Adds validation of end to end connectivity to Routes (`#628 <https://github.com/maliput/maliput/issues/628>`_)
+* Fix typos in routing. (`#634 <https://github.com/maliput/maliput/issues/634>`_)
+* Update github action versions. (`#633 <https://github.com/maliput/maliput/issues/633>`_)
+* Adds bazel version to the matrix to avoid presubmit checks to fail. (`#631 <https://github.com/maliput/maliput/issues/631>`_)
+  Example: https://buildkite.com/bazel/bcr-presubmit/`builds/5047#018 <https://github.com/builds/5047/issues/018>`_f2e0c-4d57-4a32-a0d4-b787aa479da9
+* Fix scan_build errors. (`#632 <https://github.com/maliput/maliput/issues/632>`_)
+  * Fix scan_build errors.
+  * Fix format.
   ---------
+* Contributors: Agustin Alba Chicar, Viktor Kronvall
+
+1.3.0 (2024-04-29)
+------------------
+* Add fresnel functions (`#629 <https://github.com/ToyotaResearchInstitute/maliput/issues/629>`_)
 * Contributors: Agustin Alba Chicar
 
 1.2.0 (2024-01-03)
@@ -60,8 +90,6 @@ Changelog for package maliput
 * Adds codecov. (`#552 <https://github.com/maliput/maliput/issues/552>`_)
 * Routing constraints implementation (`#549 <https://github.com/maliput/maliput/issues/549>`_)
 * [Routing] Initial public API proposal. (`#546 <https://github.com/maliput/maliput/issues/546>`_)
-
-  ---------
   Co-authored-by: Franco Cipollone <53065142+francocipollone@users.noreply.github.com>
 * Contributors: Agustin Alba Chicar, Daniel Stonier, Franco Cipollone
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##############################################################################
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(maliput LANGUAGES C CXX VERSION 1.3.0)
+project(maliput LANGUAGES C CXX VERSION 1.3.1)
 
 ##############################################################################
 # Find 3rd Party Packages

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ Welcome to Maliput!
 module(
     name = "maliput",
     compatibility_level = 1,
-    version = "1.3.0",
+    version = "1.3.1",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>maliput</name>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <description>Maliput</description>
+  <maintainer email="franco.c@ekumenlabs.com">Franco Cipollone</maintainer>
   <maintainer email="daniel.stonier@tri.global">Daniel Stonier</maintainer>
   <license file="LICENSE">BSD Clause 3</license>
 


### PR DESCRIPTION
### Summary

Prepare for 1.3.1 release.

After it is merged I will push the tag 1.3.1