### PR TITLE
Bazel: Bumps eigen to 3.4.0.bcr.1.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,5 +9,5 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "eigen", version = "3.4.0")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.1.1")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")


### PR DESCRIPTION
# 🦟 Bug fix

Related to #645 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)


