### PR TITLE
KdTree Strategy: Register points at boundaries

### DIFF
--- a/include/maliput/geometry_base/kd_tree_strategy.h
+++ b/include/maliput/geometry_base/kd_tree_strategy.h
@@ -91,6 +91,9 @@ class KDTreeStrategy final : public StrategyBase {
   // The region is an axis-aligned box with the point as center and the distance as half of the box's edge length.
   std::deque<const api::Lane*> ClosestLanes(const api::InertialPosition& point, double half_edge_length) const;
 
+  void RegisterPointAtSrh(double s, double r, double h, const api::Lane* lane,
+                          std::deque<KDTreeStrategy::MaliputPoint>& points);
+  void RegisterTransversalPointsAtS(double s, const api::Lane* lane, std::deque<KDTreeStrategy::MaliputPoint>& points);
   std::unique_ptr<math::KDTree3D<MaliputPoint>> kd_tree_;
 
   const double sampling_step_;


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput/issues/516

## Summary
 - Improves the registration of the points in the kdtree by guaranteeing that the points at the boundaries are registered.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
