### PR TITLE
Always `PickGridUnit` in favor of using `linear_tolerance`.

### DIFF
--- a/src/maliput/utility/generate_obj.cc
+++ b/src/maliput/utility/generate_obj.cc
@@ -668,9 +668,7 @@ void RenderSegment(const api::Segment* segment, const ObjFeatures& features, Geo
   }
   const double linear_tolerance = segment->junction()->road_geometry()->linear_tolerance();
   const double base_grid_unit =
-      features.off_grid_mesh_generation
-          ? linear_tolerance
-          : PickGridUnit(segment->lane(0), features.max_grid_unit, features.min_grid_resolution, linear_tolerance);
+      PickGridUnit(segment->lane(0), features.max_grid_unit, features.min_grid_resolution, linear_tolerance);
   {
     // Lane 0 should be as good as any other for segment-bounds.
     GeoMesh segment_mesh;
@@ -799,9 +797,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
   const api::Segment* segment = lane->segment();
   const double linear_tolerance = segment->junction()->road_geometry()->linear_tolerance();
   const double base_grid_unit =
-      features.off_grid_mesh_generation
-          ? linear_tolerance
-          : PickGridUnit(lane, features.max_grid_unit, features.min_grid_resolution, linear_tolerance);
+      PickGridUnit(lane, features.max_grid_unit, features.min_grid_resolution, linear_tolerance);
 
   switch (mesh_material) {
     case MaterialType::Asphalt:
@@ -907,9 +903,7 @@ std::pair<mesh::GeoMesh, Material> BuildMesh(const api::RoadGeometry* rg, const 
   const api::Segment* segment = road_index.GetSegment(segment_id);
   const double linear_tolerance = segment->junction()->road_geometry()->linear_tolerance();
   const double base_grid_unit =
-      features.off_grid_mesh_generation
-          ? linear_tolerance
-          : PickGridUnit(segment->lane(0), features.max_grid_unit, features.min_grid_resolution, linear_tolerance);
+      PickGridUnit(segment->lane(0), features.max_grid_unit, features.min_grid_resolution, linear_tolerance);
 
   GeoMesh segment_mesh;
   // clang-format off


### PR DESCRIPTION
# 🎉 New feature

## Summary
We want to have more control over the `min_grid_resolution` and `max_grid_unit` for all generated meshes.

This allows us to have lower quality maps with faster build times (if desired) while also enabling the `off_grid_mesh_generation` flag.

## Test it
```
maliput_to_obj --maliput_backend=malidrive --xodr_file_path=src/maliput_malidrive/resources/Town07.xodr --build_policy=parallel --linear_tolerance=0.05 --max_linear_tolerance=0.05 --log_level=info --dirpath=src/maliput/obj/ --off_grid_mesh_generation=True --draw_elevation_bounds=False --min_grid_resolution=5. --max_grid_unit=1 --file_name_root=Town07
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
