### PR TITLE
Create API to obtain Geo Reference info.

### DIFF
--- a/include/maliput/api/road_geometry.h
+++ b/include/maliput/api/road_geometry.h
@@ -221,6 +221,11 @@ class RoadGeometry {
   /// @throws maliput::assertion_error When the requested command can't be resolved.
   std::string BackendCustomCommand(const std::string& command) const { return DoBackendCustomCommand(command); }
 
+  /// Returns the Geo Reference info of this RoadGeometry.
+  ///
+  /// @returns A string containing the Geo Reference projection, if any.
+  std::string GeoReferenceInfo() const { return DoGeoReferenceInfo(); }
+
   // TODO(#400): Add RollPitchYaw inertial_to_backend_frame_rotation() const.
 
  protected:
@@ -261,6 +266,8 @@ class RoadGeometry {
   virtual math::Vector3 do_inertial_to_backend_frame_translation() const = 0;
 
   virtual std::string DoBackendCustomCommand(const std::string& command) const = 0;
+
+  virtual std::string DoGeoReferenceInfo() const = 0;
   ///@}
 };
 

--- a/include/maliput/geometry_base/road_geometry.h
+++ b/include/maliput/geometry_base/road_geometry.h
@@ -162,6 +162,17 @@ class RoadGeometry : public api::RoadGeometry {
     strategy_ = std::make_unique<StrategyT>(this, std::forward<Args>(args)...);
   }
 
+  /// Returns the Geo Reference info of this RoadGeometry.
+  ///
+  /// The returned info will contain at most one of the projections described in
+  /// https://proj.org/en/stable/operations/projections/index.html under the "data" key.
+  /// Other key values may be present as well to complement the projection's values.
+  ///
+  /// @returns A map containing the Geo Reference projection, if any.
+  std::map<std::string, std::string> GeoReferenceInfo() const {
+    return std::map<std::string, std::string>();
+  }
+
   ~RoadGeometry() override = default;
 
  private:

--- a/include/maliput/geometry_base/road_geometry.h
+++ b/include/maliput/geometry_base/road_geometry.h
@@ -204,7 +204,7 @@ class RoadGeometry : public api::RoadGeometry {
     MALIPUT_THROW_MESSAGE("Method not implemented.");
   }
 
-  std::string DoGeoReferenceInfo() const override { return std::string(); }
+  std::string DoGeoReferenceInfo() const override { return {}; }
 
   api::RoadGeometryId id_;
   double linear_tolerance_{};

--- a/include/maliput/geometry_base/road_geometry.h
+++ b/include/maliput/geometry_base/road_geometry.h
@@ -162,17 +162,6 @@ class RoadGeometry : public api::RoadGeometry {
     strategy_ = std::make_unique<StrategyT>(this, std::forward<Args>(args)...);
   }
 
-  /// Returns the Geo Reference info of this RoadGeometry.
-  ///
-  /// The returned info will contain at most one of the projections described in
-  /// https://proj.org/en/stable/operations/projections/index.html under the "data" key.
-  /// Other key values may be present as well to complement the projection's values.
-  ///
-  /// @returns A map containing the Geo Reference projection, if any.
-  std::map<std::string, std::string> GeoReferenceInfo() const {
-    return std::map<std::string, std::string>();
-  }
-
   ~RoadGeometry() override = default;
 
  private:
@@ -214,6 +203,8 @@ class RoadGeometry : public api::RoadGeometry {
   std::string DoBackendCustomCommand(const std::string& command) const override {
     MALIPUT_THROW_MESSAGE("Method not implemented.");
   }
+
+  std::string DoGeoReferenceInfo() const override { return std::string(); }
 
   api::RoadGeometryId id_;
   double linear_tolerance_{};

--- a/include/maliput/test_utilities/mock.h
+++ b/include/maliput/test_utilities/mock.h
@@ -31,6 +31,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "maliput/api/intersection_book.h"
 #include "maliput/api/regions.h"
@@ -381,7 +382,8 @@ class MockRoadGeometry : public RoadGeometry {
   math::Vector3 do_inertial_to_backend_frame_translation() const override {
     return inertial_to_backend_frame_translation_;
   }
-  std::string DoBackendCustomCommand(const std::string& command) const override { return std::string(); }
+  std::string DoBackendCustomCommand(const std::string& command) const override { return {}; }
+  std::string DoGeoReferenceInfo() const override { return {}; }
 
   MockIdIndex mock_id_index_;
   RoadGeometryId id_;

--- a/include/maliput/test_utilities/mock_geometry.h
+++ b/include/maliput/test_utilities/mock_geometry.h
@@ -30,6 +30,8 @@
 #pragma once
 
 #include <optional>
+#include <string>
+#include <vector>
 
 #include "maliput/api/lane_data.h"
 #include "maliput/common/maliput_copyable.h"
@@ -90,6 +92,8 @@ class MockRoadGeometry : public geometry_base::RoadGeometry {
 
   std::vector<api::RoadPositionResult> DoFindRoadPositions(const api::InertialPosition& inertial_position,
                                                            double radius) const override;
+
+  std::string DoGeoReferenceInfo() const override;
 };
 
 /// Mock api::BranchPoint implementation; see mock_geometry.h.

--- a/src/maliput/test_utilities/mock.cc
+++ b/src/maliput/test_utilities/mock.cc
@@ -103,7 +103,8 @@ class MockOneLaneRoadGeometry final : public RoadGeometry {
   double do_angular_tolerance() const override { return 0; }
   double do_scale_length() const override { return 0; }
   math::Vector3 do_inertial_to_backend_frame_translation() const override { return math::Vector3{0., 0., 0.}; }
-  std::string DoBackendCustomCommand(const std::string& command) const override { return std::string(); }
+  std::string DoBackendCustomCommand(const std::string& command) const override { return {}; }
+  std::string DoGeoReferenceInfo() const override { return {}; }
 
   MockOneLaneIdIndex mock_id_index_;
 };

--- a/src/maliput/test_utilities/mock_geometry.cc
+++ b/src/maliput/test_utilities/mock_geometry.cc
@@ -29,10 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput/test_utilities/mock_geometry.h"
 
-#include <optional>
-#include <string>
-#include <vector>
-
 #include "maliput/common/maliput_abort.h"
 #include "maliput/common/maliput_throw.h"
 

--- a/src/maliput/test_utilities/mock_geometry.cc
+++ b/src/maliput/test_utilities/mock_geometry.cc
@@ -29,6 +29,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput/test_utilities/mock_geometry.h"
 
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "maliput/common/maliput_abort.h"
 #include "maliput/common/maliput_throw.h"
 
@@ -43,6 +47,11 @@ api::RoadPositionResult MockRoadGeometry::DoToRoadPosition(const api::InertialPo
 }
 
 std::vector<api::RoadPositionResult> MockRoadGeometry::DoFindRoadPositions(const api::InertialPosition&, double) const {
+  MALIPUT_THROW_UNLESS(false);
+  MALIPUT_ABORT_MESSAGE("Not implemented.");
+}
+
+std::string MockRoadGeometry::DoGeoReferenceInfo() const {
   MALIPUT_THROW_UNLESS(false);
   MALIPUT_ABORT_MESSAGE("Not implemented.");
 }

--- a/test/api/branch_point_test.cc
+++ b/test/api/branch_point_test.cc
@@ -29,6 +29,7 @@
 #include "maliput/api/branch_point.h"
 
 #include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -83,6 +84,7 @@ class MockRoadGeometry : public RoadGeometry {
                      std::vector<InertialPosition>(const LaneSRoute&, double path_length_sampling_rate));
   MOCK_CONST_METHOD0(do_inertial_to_backend_frame_translation, math::Vector3());
   MOCK_CONST_METHOD1(DoBackendCustomCommand, std::string(const std::string& command));
+  MOCK_CONST_METHOD0(DoGeoReferenceInfo, std::string());
 };
 
 // Test cases for LaneEndSet

--- a/test/road_network_mocks.h
+++ b/test/road_network_mocks.h
@@ -76,6 +76,7 @@ class RoadGeometryMock final : public api::RoadGeometry {
   MOCK_METHOD(std::vector<api::InertialPosition>, DoSampleAheadWaypoints, (const api::LaneSRoute&, double), (const));
   MOCK_METHOD(math::Vector3, do_inertial_to_backend_frame_translation, (), (const));
   MOCK_METHOD(std::string, DoBackendCustomCommand, (const std::string&), (const));
+  MOCK_METHOD(std::string, DoGeoReferenceInfo, (), (const));
 };
 
 /// @brief Google mock api::Lane.


### PR DESCRIPTION
# 🎉 New feature

Closes #660 

## Summary
API to obtain geo reference info.
Returns an empty string by default.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
