### PR TITLE
Rules related errors.

### DIFF
--- a/include/maliput/api/rules/direction_usage_rule.h
+++ b/include/maliput/api/rules/direction_usage_rule.h
@@ -134,12 +134,14 @@ class MALIPUT_DEPRECATED("DirectionUsageRule will be deprecated", "DiscreteValue
   /// @throws maliput::common::rulebook_error if size of states is not exactly
   ///         1.
   DirectionUsageRule(const Id& id, const LaneSRange& zone, std::vector<State> states) : id_(id), zone_(zone) {
-    MALIPUT_RULES_VALIDATE(states.size() >= 1, "DirectionUsageRule(" + id_.string() + ") must have at least one state.",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(states.size() >= 1, "DirectionUsageRule(" + id_.string() + ") must have at least one state.",
+                     maliput::common::rulebook_error);
     for (const State& state : states) {
       // Construct index of states by ID, ensuring uniqueness of ID's.
       auto result = states_.emplace(state.id(), state);
-      MALIPUT_THROW_RULES_UNLESS(result.second, maliput::common::rulebook_error);
+      MALIPUT_VALIDATE(result.second,
+                       "State with ID '" + state.id().string() + "' is not unique when creating DirectionUsageRule.",
+                       maliput::common::rulebook_error);
     }
   }
 
@@ -162,9 +164,9 @@ class MALIPUT_DEPRECATED("DirectionUsageRule will be deprecated", "DiscreteValue
   ///
   /// @throws maliput::common::rulebook_error if `is_static()` is false.
   const State& static_state() const {
-    MALIPUT_RULES_VALIDATE(
-        is_static(), "Calling DirectionUsageRule(" + id_.string() + ")::static_state() but the state is not static.",
-        maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(is_static(),
+                     "Calling DirectionUsageRule(" + id_.string() + ")::static_state() but the state is not static.",
+                     maliput::common::rulebook_error);
     return states_.begin()->second;
   }
 

--- a/include/maliput/api/rules/direction_usage_rule.h
+++ b/include/maliput/api/rules/direction_usage_rule.h
@@ -131,14 +131,15 @@ class MALIPUT_DEPRECATED("DirectionUsageRule will be deprecated", "DiscreteValue
   /// @param id the unique ID of this rule (in the RoadRulebook)
   /// @param zone LaneSRange to which this rule applies
   /// @param states a vector of valid states for the rule
-  /// @throws maliput::common::assertion_error if size of states is not exactly
+  /// @throws maliput::common::rulebook_error if size of states is not exactly
   ///         1.
   DirectionUsageRule(const Id& id, const LaneSRange& zone, std::vector<State> states) : id_(id), zone_(zone) {
-    MALIPUT_VALIDATE(states.size() >= 1, "DirectionUsageRule(" + id_.string() + ") must have at least one state.");
+    MALIPUT_RULES_VALIDATE(states.size() >= 1, "DirectionUsageRule(" + id_.string() + ") must have at least one state.",
+                           maliput::common::rulebook_error);
     for (const State& state : states) {
       // Construct index of states by ID, ensuring uniqueness of ID's.
       auto result = states_.emplace(state.id(), state);
-      MALIPUT_THROW_UNLESS(result.second);
+      MALIPUT_THROW_RULES_UNLESS(result.second, maliput::common::rulebook_error);
     }
   }
 
@@ -159,10 +160,11 @@ class MALIPUT_DEPRECATED("DirectionUsageRule will be deprecated", "DiscreteValue
   ///
   /// This is a convenience function for returning a static rule's single state.
   ///
-  /// @throws maliput::common::assertion_error if `is_static()` is false.
+  /// @throws maliput::common::rulebook_error if `is_static()` is false.
   const State& static_state() const {
-    MALIPUT_VALIDATE(is_static(),
-                     "Calling DirectionUsageRule(" + id_.string() + ")::static_state() but the state is not static.");
+    MALIPUT_RULES_VALIDATE(
+        is_static(), "Calling DirectionUsageRule(" + id_.string() + ")::static_state() but the state is not static.",
+        maliput::common::rulebook_error);
     return states_.begin()->second;
   }
 

--- a/include/maliput/api/rules/discrete_value_rule.h
+++ b/include/maliput/api/rules/discrete_value_rule.h
@@ -83,8 +83,8 @@ class DiscreteValueRule : public Rule {
   ///               in. The actual value that's enforced at any given time is
   ///               determined by a DiscreteValueRuleStateProvider.  It must
   ///               have at least one value; each value must be unique.
-  /// @throws maliput::common::assertion_error When `values` is empty.
-  /// @throws maliput::common::assertion_error When there are duplicated values
+  /// @throws maliput::common::rulebook_error When `values` is empty.
+  /// @throws maliput::common::rulebook_error When there are duplicated values
   ///         in `values`.
   DiscreteValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                     const std::vector<DiscreteValue>& values);

--- a/include/maliput/api/rules/range_value_rule.h
+++ b/include/maliput/api/rules/range_value_rule.h
@@ -97,10 +97,10 @@ class RangeValueRule : public Rule {
   ///               determined by a RangeValueRuleStateProvider. This vector
   ///               must have at least one Range, and each Range must respect
   ///               that its min <= max and be unique.
-  /// @throws maliput::common::assertion_error When `ranges` is empty.
-  /// @throws maliput::common::assertion_error When any Range within `ranges`
+  /// @throws maliput::common::rulebook_error When `ranges` is empty.
+  /// @throws maliput::common::rulebook_error When any Range within `ranges`
   ///         violates `min <= max` condition.
-  /// @throws maliput::common::assertion_error When there are duplicated Range
+  /// @throws maliput::common::rulebook_error When there are duplicated Range
   ///         in `ranges`.
   RangeValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                  const std::vector<Range>& ranges);

--- a/include/maliput/api/rules/right_of_way_rule.h
+++ b/include/maliput/api/rules/right_of_way_rule.h
@@ -166,16 +166,18 @@ class MALIPUT_DEPRECATED("RightOfWayRule class will be deprecated", "DiscreteVal
   RightOfWayRule(const Id& id, const LaneSRoute& zone, ZoneType zone_type, const std::vector<State>& states,
                  const RelatedBulbGroups& related_bulb_groups)
       : id_(id), zone_(zone), zone_type_(zone_type), related_bulb_groups_(related_bulb_groups) {
-    MALIPUT_RULES_VALIDATE(states.size() >= 1, "RightOfWayRule(" + id_.string() + ") must have at least one state.",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(states.size() >= 1, "RightOfWayRule(" + id_.string() + ") must have at least one state.",
+                     maliput::common::rulebook_error);
     for (const State& state : states) {
       // Construct index of states by ID, ensuring uniqueness of ID's.
       auto result = states_.emplace(state.id(), state);
-      MALIPUT_THROW_RULES_UNLESS(result.second, maliput::common::rulebook_error);
+      MALIPUT_VALIDATE(result.second,
+                       "State with ID '" + state.id().string() + "' is not unique when creating RightOfWayRule.",
+                       maliput::common::rulebook_error);
     }
     for (const auto& traffic_light_bulb_group : related_bulb_groups) {
       for (const BulbGroup::Id& bulb_group_id : traffic_light_bulb_group.second) {
-        MALIPUT_RULES_VALIDATE(
+        MALIPUT_VALIDATE(
             std::count(traffic_light_bulb_group.second.begin(), traffic_light_bulb_group.second.end(), bulb_group_id) ==
                 1,
             "Trying to build RightOfWayRule(" + id_.string() +
@@ -210,9 +212,9 @@ class MALIPUT_DEPRECATED("RightOfWayRule class will be deprecated", "DiscreteVal
   ///
   /// @throws maliput::common::rulebook_error if `is_static()` is false.
   const State& static_state() const {
-    MALIPUT_RULES_VALIDATE(is_static(),
-                           "Calling RightOfWayRule(" + id_.string() + ")::static_state() but the state is not static.",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(is_static(),
+                     "Calling RightOfWayRule(" + id_.string() + ")::static_state() but the state is not static.",
+                     maliput::common::rulebook_error);
     return states_.begin()->second;
   }
 

--- a/include/maliput/api/rules/right_of_way_rule.h
+++ b/include/maliput/api/rules/right_of_way_rule.h
@@ -159,27 +159,29 @@ class MALIPUT_DEPRECATED("RightOfWayRule class will be deprecated", "DiscreteVal
   /// @param related_bulb_groups The related bulb groups. All IDs present within the
   ///        supplied map are assumed to be valid.
   ///
-  /// @throws maliput::common::assertion_error if `states` is empty or if
+  /// @throws maliput::common::rulebook_error if `states` is empty or if
   ///         `states` contains duplicate State::Id's.
-  /// @throws maliput::common::assertion_error if any duplicate BulbGroup::Id is
+  /// @throws maliput::common::rulebook_error if any duplicate BulbGroup::Id is
   ///         found.
   RightOfWayRule(const Id& id, const LaneSRoute& zone, ZoneType zone_type, const std::vector<State>& states,
                  const RelatedBulbGroups& related_bulb_groups)
       : id_(id), zone_(zone), zone_type_(zone_type), related_bulb_groups_(related_bulb_groups) {
-    MALIPUT_VALIDATE(states.size() >= 1, "RightOfWayRule(" + id_.string() + ") must have at least one state.");
+    MALIPUT_RULES_VALIDATE(states.size() >= 1, "RightOfWayRule(" + id_.string() + ") must have at least one state.",
+                           maliput::common::rulebook_error);
     for (const State& state : states) {
       // Construct index of states by ID, ensuring uniqueness of ID's.
       auto result = states_.emplace(state.id(), state);
-      MALIPUT_THROW_UNLESS(result.second);
+      MALIPUT_THROW_RULES_UNLESS(result.second, maliput::common::rulebook_error);
     }
     for (const auto& traffic_light_bulb_group : related_bulb_groups) {
       for (const BulbGroup::Id& bulb_group_id : traffic_light_bulb_group.second) {
-        MALIPUT_VALIDATE(
+        MALIPUT_RULES_VALIDATE(
             std::count(traffic_light_bulb_group.second.begin(), traffic_light_bulb_group.second.end(), bulb_group_id) ==
                 1,
             "Trying to build RightOfWayRule(" + id_.string() +
                 ") with related_bulb_groups that contains a duplicate BulbGroup::Id(" + bulb_group_id.string() +
-                ") at TrafficLight::Id(" + traffic_light_bulb_group.first.string() + ")");
+                ") at TrafficLight::Id(" + traffic_light_bulb_group.first.string() + ")",
+            maliput::common::rulebook_error);
       }
     }
   }
@@ -206,10 +208,11 @@ class MALIPUT_DEPRECATED("RightOfWayRule class will be deprecated", "DiscreteVal
   ///
   /// This is a convenience function for returning a static rule's single state.
   ///
-  /// @throws maliput::common::assertion_error if `is_static()` is false.
+  /// @throws maliput::common::rulebook_error if `is_static()` is false.
   const State& static_state() const {
-    MALIPUT_VALIDATE(is_static(),
-                     "Calling RightOfWayRule(" + id_.string() + ")::static_state() but the state is not static.");
+    MALIPUT_RULES_VALIDATE(is_static(),
+                           "Calling RightOfWayRule(" + id_.string() + ")::static_state() but the state is not static.",
+                           maliput::common::rulebook_error);
     return states_.begin()->second;
   }
 

--- a/include/maliput/api/rules/road_rulebook.h
+++ b/include/maliput/api/rules/road_rulebook.h
@@ -83,7 +83,7 @@ class RoadRulebook {
   ///
   /// @throws maliput::common::rulebook_error if `tolerance` is negative.
   QueryResults FindRules(const std::vector<LaneSRange>& ranges, double tolerance) const {
-    MALIPUT_THROW_RULES_UNLESS(tolerance >= 0., maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(tolerance >= 0., "Tolerance is negative.", maliput::common::rulebook_error);
     return DoFindRules(ranges, tolerance);
   }
 

--- a/include/maliput/api/rules/road_rulebook.h
+++ b/include/maliput/api/rules/road_rulebook.h
@@ -81,9 +81,9 @@ class RoadRulebook {
   /// `tolerance` does not permit matching across BranchPoints (past the
   /// s-bounds of a Lane).
   ///
-  /// @throws maliput::common::assertion_error if `tolerance` is negative.
+  /// @throws maliput::common::rulebook_error if `tolerance` is negative.
   QueryResults FindRules(const std::vector<LaneSRange>& ranges, double tolerance) const {
-    MALIPUT_THROW_UNLESS(tolerance >= 0.);
+    MALIPUT_THROW_RULES_UNLESS(tolerance >= 0., maliput::common::rulebook_error);
     return DoFindRules(ranges, tolerance);
   }
 

--- a/include/maliput/api/rules/rule.h
+++ b/include/maliput/api/rules/rule.h
@@ -128,7 +128,7 @@ class Rule {
   /// @param type_id The Rule Type ID.
   /// @param zone LaneSRoute to which this rule applies.
   ///
-  /// @throws maliput::common::assertion_error When any Rule::Id within
+  /// @throws maliput::common::rulebook_error When any Rule::Id within
   ///         `related_rules` is duplicated.
   Rule(const Id& id, const TypeId& type_id, const LaneSRoute& zone) : id_(id), type_id_(type_id), zone_(zone) {}
 
@@ -143,18 +143,18 @@ class Rule {
  protected:
   // Validates that `related_rules` requirements are met.
   // @see RelatedRules alias definition for full type requirements.
-  // @throws maliput::assertion_error When any of the requirements in
+  // @throws maliput::rulebook_error When any of the requirements in
   //         `RelatedRules` are not met.
   void ValidateRelatedRules(const RelatedRules& related_rules) const;
 
   // Validates that `related_unique_ids` requirements are met.
   // @see RelatedUniqueIds alias definition for full type requirements.
-  // @throws maliput::assertion_error When any of the requirements in
+  // @throws maliput::rulebook_error When any of the requirements in
   //         `RelatedUniqueIds` are not met.
   void ValidateRelatedUniqueIds(const RelatedUniqueIds& related_unique_ids) const;
 
   // Validates that `severity` is a non-negative quantity.
-  // @throws maliput::assertion_error When `severity` is negative.
+  // @throws maliput::rulebook_error When `severity` is negative.
   void ValidateSeverity(int severity) const;
 
  private:

--- a/include/maliput/api/rules/rule_registry.h
+++ b/include/maliput/api/rules/rule_registry.h
@@ -80,11 +80,11 @@ class RuleRegistry {
   ///        this type could be in. It must have at least one value; each value
   ///        must be unique.
   /// @see RangeValueRule
-  /// @throws maliput::common::assertion_error When `type_id` is already
+  /// @throws maliput::common::rule_registry_error When `type_id` is already
   ///         registered.
-  /// @throws maliput::common::assertion_error When `all_possible_ranges` is
+  /// @throws maliput::common::rule_registry_error When `all_possible_ranges` is
   ///         empty.
-  /// @throws maliput::common::assertion_error When there are duplicated items
+  /// @throws maliput::common::rule_registry_error When there are duplicated items
   ///         in `all_possible_ranges`.
   void RegisterRangeValueRule(const Rule::TypeId& type_id,
                               const std::vector<RangeValueRule::Range>& all_possible_ranges);
@@ -96,11 +96,11 @@ class RuleRegistry {
   ///        this type could be in. It must have at least one value; each value
   ///        must be unique.
   /// @see DiscreteValueRule.
-  /// @throws maliput::common::assertion_error When `type_id` is already
+  /// @throws maliput::common::rule_registry_error When `type_id` is already
   ///         registered.
-  /// @throws maliput::common::assertion_error When `all_possible_values` is
+  /// @throws maliput::common::rule_registry_error When `all_possible_values` is
   ///         empty.
-  /// @throws maliput::common::assertion_error When there are duplicated items
+  /// @throws maliput::common::rule_registry_error When there are duplicated items
   ///         in `all_possible_values`.
   void RegisterDiscreteValueRule(const Rule::TypeId& type_id,
                                  const std::vector<DiscreteValueRule::DiscreteValue>& all_possible_values);
@@ -123,9 +123,9 @@ class RuleRegistry {
   /// Builds a RangeValueRule.
   ///
   /// @see RangeValueRule constructor for parameter documentation.
-  /// @throws maliput::common::assertion_error When `type_id` is not a
+  /// @throws maliput::common::rule_registry_error When `type_id` is not a
   ///         registered RangeValueRule type.
-  /// @throws maliput::common::assertion_error When an element in `ranges` is
+  /// @throws maliput::common::rule_registry_error When an element in `ranges` is
   ///         not a possible range of a RangeValueRule of type `type_id`.
   RangeValueRule BuildRangeValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                      const std::vector<RangeValueRule::Range>& ranges) const;
@@ -133,9 +133,9 @@ class RuleRegistry {
   /// Builds a DiscreteValueRule.
   ///
   /// @see DiscreteValueRule constructor for parameter documentation.
-  /// @throws maliput::common::assertion_error When `type_id` is not a
+  /// @throws maliput::common::rule_registry_error When `type_id` is not a
   ///         registered DiscreteValueRule type.
-  /// @throws maliput::common::assertion_error When an element in `values` is
+  /// @throws maliput::common::rule_registry_error When an element in `values` is
   ///         not a possible value of a DiscreteValueRule of type `type_id`.
   DiscreteValueRule BuildDiscreteValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                            const std::vector<DiscreteValueRule::DiscreteValue>& values) const;

--- a/include/maliput/api/rules/speed_limit_rule.h
+++ b/include/maliput/api/rules/speed_limit_rule.h
@@ -71,12 +71,15 @@ class MALIPUT_DEPRECATED("next release", "Use RangeValueRule instead.") SpeedLim
   /// @param max maximum speed
   ///
   /// `min` and `max` must be non-negative, and `min` must be less than
-  /// or equal to `max`, otherwise a maliput::common::assertion_error is thrown.
+  /// or equal to `max`, otherwise a maliput::common::rulebook_error is thrown.
   SpeedLimitRule(const Id& id, const LaneSRange& zone, Severity severity, double min, double max)
       : id_(id), zone_(zone), severity_(severity), min_(min), max_(max) {
-    MALIPUT_VALIDATE(min >= 0., "SpeedLimitRule(" + id_.string() + ") min is negative.");
-    MALIPUT_VALIDATE(max >= 0., "SpeedLimitRule(" + id_.string() + ") max is negative.");
-    MALIPUT_VALIDATE(min <= max, "SpeedLimitRule(" + id_.string() + ") min is greater than max");
+    MALIPUT_RULES_VALIDATE(min >= 0., "SpeedLimitRule(" + id_.string() + ") min is negative.",
+                           maliput::common::rulebook_error);
+    MALIPUT_RULES_VALIDATE(max >= 0., "SpeedLimitRule(" + id_.string() + ") max is negative.",
+                           maliput::common::rulebook_error);
+    MALIPUT_RULES_VALIDATE(min <= max, "SpeedLimitRule(" + id_.string() + ") min is greater than max",
+                           maliput::common::rulebook_error);
   }
 
   /// Returns the persistent identifier.

--- a/include/maliput/api/rules/speed_limit_rule.h
+++ b/include/maliput/api/rules/speed_limit_rule.h
@@ -74,12 +74,12 @@ class MALIPUT_DEPRECATED("next release", "Use RangeValueRule instead.") SpeedLim
   /// or equal to `max`, otherwise a maliput::common::rulebook_error is thrown.
   SpeedLimitRule(const Id& id, const LaneSRange& zone, Severity severity, double min, double max)
       : id_(id), zone_(zone), severity_(severity), min_(min), max_(max) {
-    MALIPUT_RULES_VALIDATE(min >= 0., "SpeedLimitRule(" + id_.string() + ") min is negative.",
-                           maliput::common::rulebook_error);
-    MALIPUT_RULES_VALIDATE(max >= 0., "SpeedLimitRule(" + id_.string() + ") max is negative.",
-                           maliput::common::rulebook_error);
-    MALIPUT_RULES_VALIDATE(min <= max, "SpeedLimitRule(" + id_.string() + ") min is greater than max",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(min >= 0., "SpeedLimitRule(" + id_.string() + ") min is negative.",
+                     maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(max >= 0., "SpeedLimitRule(" + id_.string() + ") max is negative.",
+                     maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(min <= max, "SpeedLimitRule(" + id_.string() + ") min is greater than max",
+                     maliput::common::rulebook_error);
   }
 
   /// Returns the persistent identifier.

--- a/include/maliput/api/rules/traffic_lights.h
+++ b/include/maliput/api/rules/traffic_lights.h
@@ -212,7 +212,7 @@ class Bulb final {
   ///
   /// @throws common::traffic_light_book_error When @p bulb_group is nullptr.
   void SetBulbGroup(common::Passkey<BulbGroup>, const BulbGroup* bulb_group) {
-    MALIPUT_THROW_RULES_UNLESS(bulb_group != nullptr, common::traffic_light_book_error);
+    MALIPUT_VALIDATE(bulb_group != nullptr, "BulbGroup is null.", common::traffic_light_book_error);
     bulb_group_ = bulb_group;
   }
 
@@ -307,7 +307,7 @@ class BulbGroup final {
   ///
   /// @throws common::traffic_light_book_error When @p traffic_light is nullptr.
   void SetTrafficLight(common::Passkey<TrafficLight>, const TrafficLight* traffic_light) {
-    MALIPUT_THROW_RULES_UNLESS(traffic_light != nullptr, common::traffic_light_book_error);
+    MALIPUT_VALIDATE(traffic_light != nullptr, "TrafficLight is null.", common::traffic_light_book_error);
     traffic_light_ = traffic_light;
   }
 

--- a/include/maliput/api/rules/traffic_lights.h
+++ b/include/maliput/api/rules/traffic_lights.h
@@ -149,7 +149,7 @@ class Bulb final {
   /// @param bounding_box The bounding box of the bulb. See BoundingBox for
   /// details about the default value.
   ///
-  /// @throws common::assertion_error When `unique_id.bulb_id != id`.
+  /// @throws common::traffic_light_book_error When `unique_id.bulb_id != id`.
   Bulb(const Id& id, const InertialPosition& position_bulb_group, const Rotation& orientation_bulb_group,
        const BulbColor& color, const BulbType& type, const std::optional<double>& arrow_orientation_rad = std::nullopt,
        const std::optional<std::vector<BulbState>>& states = std::nullopt, BoundingBox bounding_box = BoundingBox());
@@ -159,7 +159,7 @@ class Bulb final {
 
   /// Returns this Bulb instance's unique identifier.
   ///
-  /// @throws common::assertion_error When the parent BulbGroup and
+  /// @throws common::traffic_light_book_error When the parent BulbGroup and
   /// TrafficLight have not been registered. @see SetBulbGroup() and @see
   /// BulbGroup::SetTrafficLight().
   UniqueBulbId unique_id() const;
@@ -210,9 +210,9 @@ class Bulb final {
   /// This method is thought to be called once by @p bulb_group at
   /// its construct time.
   ///
-  /// @throws common::assertion_error When @p bulb_group is nullptr.
+  /// @throws common::traffic_light_book_error When @p bulb_group is nullptr.
   void SetBulbGroup(common::Passkey<BulbGroup>, const BulbGroup* bulb_group) {
-    MALIPUT_THROW_UNLESS(bulb_group != nullptr);
+    MALIPUT_THROW_RULES_UNLESS(bulb_group != nullptr, common::traffic_light_book_error);
     bulb_group_ = bulb_group;
   }
 
@@ -265,9 +265,9 @@ class BulbGroup final {
   /// least one bulb within this group. There must not be Bulbs with the same
   /// Bulb::Id. Null bulbs are not allowed.
   ///
-  /// @throws common::assertion_error When there are Bulbs with the same
+  /// @throws common::traffic_light_book_error When there are Bulbs with the same
   /// Bulb::Id in @p bulbs.
-  /// @throws common::assertion_error When any of the Bulbs in @p bulbs is
+  /// @throws common::traffic_light_book_error When any of the Bulbs in @p bulbs is
   /// nullptr.
   BulbGroup(const Id& id, const InertialPosition& position_traffic_light, const Rotation& orientation_traffic_light,
             std::vector<std::unique_ptr<Bulb>> bulbs);
@@ -277,7 +277,7 @@ class BulbGroup final {
 
   /// Returns this BulbGroup instance's unique identifier.
   ///
-  /// @throws common::assertion_error When the parent TrafficLight has not been
+  /// @throws common::traffic_light_book_error When the parent TrafficLight has not been
   /// registered. @see SetTrafficLight().
   UniqueBulbGroupId unique_id() const;
 
@@ -305,9 +305,9 @@ class BulbGroup final {
   /// This method is thought to be called once by @p traffic_light at
   /// its construct time.
   ///
-  /// @throws common::assertion_error When @p traffic_light is nullptr.
+  /// @throws common::traffic_light_book_error When @p traffic_light is nullptr.
   void SetTrafficLight(common::Passkey<TrafficLight>, const TrafficLight* traffic_light) {
-    MALIPUT_THROW_UNLESS(traffic_light != nullptr);
+    MALIPUT_THROW_RULES_UNLESS(traffic_light != nullptr, common::traffic_light_book_error);
     traffic_light_ = traffic_light;
   }
 
@@ -361,9 +361,9 @@ class TrafficLight final {
   /// There must not be BulbGroups with the same BulbGroup::Ids. Null bulb
   /// groups are not allowed.
   ///
-  /// @throws common::assertion_error When there are BulbGroups with the same
+  /// @throws common::traffic_light_book_error When there are BulbGroups with the same
   /// BulbGroup::Id in @p bulb_groups.
-  /// @throws common::assertion_error When any of the BulbGroup in
+  /// @throws common::traffic_light_book_error When any of the BulbGroup in
   /// @p bulb_groups is nullptr.
   TrafficLight(const Id& id, const InertialPosition& position_road_network, const Rotation& orientation_road_network,
                std::vector<std::unique_ptr<BulbGroup>> bulb_groups);

--- a/include/maliput/common/error.h
+++ b/include/maliput/common/error.h
@@ -100,5 +100,40 @@ class road_geometry_construction_error : public maliput_error {
   explicit road_geometry_construction_error(const std::string& what_arg) : maliput_error(what_arg) {}
 };
 
+/// Errors involing the Road Rulebook.
+class rulebook_error : public maliput_error {
+ public:
+  /// Constructs a rulebook_error with @p what_arg as description.
+  explicit rulebook_error(const std::string& what_arg) : maliput_error(what_arg) {}
+};
+
+/// Errors involing the RuleRegistry.
+class rule_registry_error : public maliput_error {
+ public:
+  /// Constructs a rule_registry_error with @p what_arg as description.
+  explicit rule_registry_error(const std::string& what_arg) : maliput_error(what_arg) {}
+};
+
+/// Errors involing the TrafficLightBook.
+class traffic_light_book_error : public maliput_error {
+ public:
+  /// Constructs a traffic_light_book_error with @p what_arg as description.
+  explicit traffic_light_book_error(const std::string& what_arg) : maliput_error(what_arg) {}
+};
+
+/// Errors involing the PhaseBook.
+class phase_book_error : public maliput_error {
+ public:
+  /// Constructs a phase_book_error with @p what_arg as description.
+  explicit phase_book_error(const std::string& what_arg) : maliput_error(what_arg) {}
+};
+
+/// Errors involing the StateProvider.
+class state_provider_error : public maliput_error {
+ public:
+  /// Constructs a state_provider_error with @p what_arg as description.
+  explicit state_provider_error(const std::string& what_arg) : maliput_error(what_arg) {}
+};
+
 }  // namespace common
 }  // namespace maliput

--- a/include/maliput/common/maliput_throw.h
+++ b/include/maliput/common/maliput_throw.h
@@ -103,104 +103,93 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
 }  // namespace common
 }  // namespace maliput
 
-/// Evaluates @p condition and iff the value is false will throw an exception
-/// with a message showing at least the condition text, function name, file,
-/// and line.
-#define MALIPUT_THROW_UNLESS(condition)                                                                               \
+// Helper macros to choose the correct implementation
+#define GET_4TH_ARG(_1, _2, _3, NAME, ...) NAME
+#define GET_3RD_ARG(_1, _2, NAME, ...) NAME
+#define MALIPUT_VALIDATE_MACRO_CHOOSER(...) GET_4TH_ARG(__VA_ARGS__, MALIPUT_VALIDATE_3, MALIPUT_VALIDATE_2)
+#define MALIPUT_THROW_MESSAGE_MACRO_CHOOSER(...) \
+  GET_3RD_ARG(__VA_ARGS__, MALIPUT_THROW_MESSAGE_3, MALIPUT_THROW_MESSAGE_2)
+#define MALIPUT_THROW_UNLESS_MACRO_CHOOSER(...) GET_3RD_ARG(__VA_ARGS__, MALIPUT_THROW_UNLESS_3, MALIPUT_THROW_UNLESS_2)
+
+/// @def MALIPUT_THROW_UNLESS
+/// Evaluates @p condition and iff the value is false will throw a
+/// maliput::common::assertion_error exception with a message showing at least
+/// the condition text, function name, file, and line.
+#define MALIPUT_THROW_UNLESS_2(condition)                                                                             \
   do {                                                                                                                \
     if (!(condition)) {                                                                                               \
       ::maliput::common::internal::Throw<maliput::common::assertion_error>(#condition, __func__, __FILE__, __LINE__); \
     }                                                                                                                 \
   } while (0)
 
-/// Throws an exception with a message showing at least the condition text,
-/// function name, file, and line.
-#define MALIPUT_THROW_MESSAGE(msg)                                                                                  \
-  do {                                                                                                              \
-    const std::string error_message(msg);                                                                           \
-    ::maliput::common::internal::Throw<maliput::common::assertion_error>(error_message.c_str(), __func__, __FILE__, \
-                                                                         __LINE__);                                 \
-  } while (0)
-
-/// @def MALIPUT_VALIDATE
-/// Used to validate that a @p pred-icate passed into a function or method is
-/// true; if not, an exception with @p message is thrown.
-#define MALIPUT_VALIDATE(pred, message)                                                                            \
-  do {                                                                                                             \
-    if (!(pred)) {                                                                                                 \
-      ::maliput::common::internal::Throw<maliput::common::assertion_error>(std::string(message).c_str(), __func__, \
-                                                                           __FILE__, __LINE__);                    \
-    }                                                                                                              \
-  } while (0)
-
-/// Evaluates @p condition and iff the value is false will throw a
-/// road_network_description_parser_error with a message showing at least the
-/// condition text, function name, file, and line.
-#define MALIPUT_THROW_ROAD_NETWORK_DESCRIPTION_PARSER_UNLESS(condition)                                                \
-  do {                                                                                                                 \
-    if (!(condition)) {                                                                                                \
-      ::maliput::common::internal::Throw<maliput::common::road_network_description_parser_error>(#condition, __func__, \
-                                                                                                 __FILE__, __LINE__);  \
-    }                                                                                                                  \
-  } while (0)
-
-/// Throws a road_network_description_parser_error with a message showing at
-/// least the condition text, function name, file, and line.
-#define MALIPUT_THROW_ROAD_NETWORK_DESCRIPTION_PARSER_MESSAGE(msg)                              \
-  do {                                                                                          \
-    const std::string error_message(msg);                                                       \
-    ::maliput::common::internal::Throw<maliput::common::road_network_description_parser_error>( \
-        error_message.c_str(), __func__, __FILE__, __LINE__);                                   \
-  } while (0)
-
-/// Evaluates @p condition and iff the value is false will throw a
-/// road_geometry_construction_error with a message showing at least the
-/// condition text, function name, file, and line.
-#define MALIPUT_THROW_ROAD_GEOMETRY_CONSTRUCTION_UNLESS(condition)                                                \
-  do {                                                                                                            \
-    if (!(condition)) {                                                                                           \
-      ::maliput::common::internal::Throw<maliput::common::road_geometry_construction_error>(#condition, __func__, \
-                                                                                            __FILE__, __LINE__);  \
-    }                                                                                                             \
-  } while (0)
-
-/// Throws a road_geometry_construction_error with a message showing at
-/// least the condition text, function name, file, and line.
-#define MALIPUT_THROW_ROAD_GEOMETRY_CONSTRUCTION_MESSAGE(msg)                              \
-  do {                                                                                     \
-    const std::string error_message(msg);                                                  \
-    ::maliput::common::internal::Throw<maliput::common::road_geometry_construction_error>( \
-        error_message.c_str(), __func__, __FILE__, __LINE__);                              \
-  } while (0)
-
-/// Evaluates @p condition and iff the value is false will throw an
-/// @p err_type with a message showing at least the
-/// condition text, function name, file, and line.
-#define MALIPUT_THROW_RULES_UNLESS(condition, err_type)                                       \
+/// @def MALIPUT_THROW_UNLESS
+/// Evaluates @p condition and iff the value is false will throw an @p err_type
+/// exception with a message showing at least the condition text, function name,
+/// file, and line.
+#define MALIPUT_THROW_UNLESS_3(condition, err_type)                                           \
   do {                                                                                        \
     if (!(condition)) {                                                                       \
       ::maliput::common::internal::Throw<err_type>(#condition, __func__, __FILE__, __LINE__); \
     }                                                                                         \
   } while (0)
 
-/// Throws an @p err_type with a message showing at
-/// least the condition text, function name, file, and line.
-#define MALIPUT_THROW_RULES_MESSAGE(msg, err_type)                                                     \
+/// Evaluates @p condition and iff the value is false will throw an exception
+/// with a message showing at least the condition text, function name, file,
+/// and line. It can throw either maliput::common::assertion_error or the
+/// provided exception type.
+// TODO(Santoi): Deprecate this in favor of MALIPUT_VALIDATE. We prefer throwing exceptions with descriptive messages
+// rather than just failed conditions.
+#define MALIPUT_THROW_UNLESS(...) MALIPUT_THROW_UNLESS_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+
+/// @def MALIPUT_THROW_MESSAGE
+/// Throws a maliput::common::assertion_error exception with a message showing
+/// at least the condition text, function name, file, and line.
+#define MALIPUT_THROW_MESSAGE_2(msg)                                                                                \
+  do {                                                                                                              \
+    const std::string error_message(msg);                                                                           \
+    ::maliput::common::internal::Throw<maliput::common::assertion_error>(error_message.c_str(), __func__, __FILE__, \
+                                                                         __LINE__);                                 \
+  } while (0)
+
+/// @def MALIPUT_THROW_MESSAGE
+/// Throws an exception of type @p err_type with a message.
+#define MALIPUT_THROW_MESSAGE_3(msg, err_type)                                                         \
   do {                                                                                                 \
     const std::string error_message(msg);                                                              \
     ::maliput::common::internal::Throw<err_type>(error_message.c_str(), __func__, __FILE__, __LINE__); \
   } while (0)
 
-/// @def MALIPUT_RULEBOOK_VALIDATE
-/// Evaluates the @p condition and iff the value is false will throw an
-/// @p err_type with a @p message showing at least the
+/// Throws an exception of type maliput::common::assertion_error or @p err_type
+/// (if it's specified) with a message.
+/// @see MALIPUT_THROW_MESSAGE_3.
+#define MALIPUT_THROW_MESSAGE(...) MALIPUT_THROW_MESSAGE_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+
+/// @def MALIPUT_VALIDATE
+/// Evaluates @p condition and iff the value is false will throw a
+/// @p err_type exception with a @p message showing at least the
 /// condition text, function name, file, and line.
-#define MALIPUT_RULES_VALIDATE(condition, message, err_type)                                                    \
-  do {                                                                                                          \
-    if (!(condition)) {                                                                                         \
-      ::maliput::common::internal::Throw<err_type>(std::string(message).c_str(), __func__, __FILE__, __LINE__); \
-    }                                                                                                           \
+#define MALIPUT_VALIDATE_3(pred, message, error_type)                                                             \
+  do {                                                                                                            \
+    if (!(pred)) {                                                                                                \
+      ::maliput::common::internal::Throw<error_type>(std::string(message).c_str(), __func__, __FILE__, __LINE__); \
+    }                                                                                                             \
   } while (0)
+
+/// @def MALIPUT_VALIDATE
+/// Used to validate that a @p pred-icate passed into a function or method is
+/// true; if not, an exception with @p message is thrown.
+#define MALIPUT_VALIDATE_2(pred, message)                                                                            \
+  do {                                                                                                               \
+    if (!(pred)) {                                                                                                   \
+      ::maliput::common::internal::Throw<::maliput::common::assertion_error>(std::string(message).c_str(), __func__, \
+                                                                             __FILE__, __LINE__);                    \
+    }                                                                                                                \
+  } while (0)
+
+/// @def MALIPUT_VALIDATE
+/// Used to validate that a @p pred-icate passed into a function or method is
+/// true; if not, an exception with @p message is thrown.
+#define MALIPUT_VALIDATE(...) MALIPUT_VALIDATE_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
 /// @def MALIPUT_IS_IN_RANGE
 /// Throws if `value` is within [`min_value`; `max_value`]. It forwards the call

--- a/include/maliput/common/maliput_throw.h
+++ b/include/maliput/common/maliput_throw.h
@@ -103,6 +103,7 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
 }  // namespace common
 }  // namespace maliput
 
+namespace {
 // Helper macros to choose the correct implementation
 #define GET_4TH_ARG(_1, _2, _3, NAME, ...) NAME
 #define GET_3RD_ARG(_1, _2, NAME, ...) NAME
@@ -133,14 +134,6 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
     }                                                                                         \
   } while (0)
 
-/// Evaluates @p condition and iff the value is false will throw an exception
-/// with a message showing at least the condition text, function name, file,
-/// and line. It can throw either maliput::common::assertion_error or the
-/// provided exception type.
-// TODO(Santoi): Deprecate this in favor of MALIPUT_VALIDATE. We prefer throwing exceptions with descriptive messages
-// rather than just failed conditions.
-#define MALIPUT_THROW_UNLESS(...) MALIPUT_THROW_UNLESS_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-
 /// @def MALIPUT_THROW_MESSAGE
 /// Throws a maliput::common::assertion_error exception with a message showing
 /// at least the condition text, function name, file, and line.
@@ -159,6 +152,41 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
     ::maliput::common::internal::Throw<err_type>(error_message.c_str(), __func__, __FILE__, __LINE__); \
   } while (0)
 
+/// @def MALIPUT_VALIDATE
+/// Evaluates @p condition and iff the value is false will throw a
+/// @p err_type exception with a @p message showing at least the
+/// condition text, function name, file, and line.
+#define MALIPUT_VALIDATE_3(condition, message, error_type)                                                        \
+  do {                                                                                                            \
+    if (!(condition)) {                                                                                           \
+      ::maliput::common::internal::Throw<error_type>(std::string(message).c_str(), __func__, __FILE__, __LINE__); \
+    }                                                                                                             \
+  } while (0)
+
+/// @def MALIPUT_VALIDATE
+/// Evaluates @p condition and iff the value is false will throw a
+/// maliput::common::assertion_error with a @p message showing at least the
+/// condition text, function name, file, and line.
+#define MALIPUT_VALIDATE_2(condition, message)                                                                       \
+  do {                                                                                                               \
+    if (!(condition)) {                                                                                              \
+      ::maliput::common::internal::Throw<::maliput::common::assertion_error>(std::string(message).c_str(), __func__, \
+                                                                             __FILE__, __LINE__);                    \
+    }                                                                                                                \
+  } while (0)
+
+}  // namespace
+
+/// @def MALIPUT_THROW_UNLESS
+/// Evaluates @p condition and iff the value is false will throw an exception
+/// with a message showing at least the condition text, function name, file,
+/// and line. It can throw either maliput::common::assertion_error or the
+/// provided exception type.
+// TODO(Santoi): Deprecate this in favor of MALIPUT_VALIDATE. We prefer throwing exceptions with descriptive messages
+// rather than just failed conditions.
+#define MALIPUT_THROW_UNLESS(...) MALIPUT_THROW_UNLESS_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+
+/// @def MALIPUT_THROW_MESSAGE
 /// Throws an exception of type maliput::common::assertion_error or @p err_type
 /// (if it's specified) with a message.
 /// @see MALIPUT_THROW_MESSAGE_3.
@@ -166,29 +194,8 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
 
 /// @def MALIPUT_VALIDATE
 /// Evaluates @p condition and iff the value is false will throw a
-/// @p err_type exception with a @p message showing at least the
+/// maliput::common::assertion_error with a @p message showing at least the
 /// condition text, function name, file, and line.
-#define MALIPUT_VALIDATE_3(pred, message, error_type)                                                             \
-  do {                                                                                                            \
-    if (!(pred)) {                                                                                                \
-      ::maliput::common::internal::Throw<error_type>(std::string(message).c_str(), __func__, __FILE__, __LINE__); \
-    }                                                                                                             \
-  } while (0)
-
-/// @def MALIPUT_VALIDATE
-/// Used to validate that a @p pred-icate passed into a function or method is
-/// true; if not, an exception with @p message is thrown.
-#define MALIPUT_VALIDATE_2(pred, message)                                                                            \
-  do {                                                                                                               \
-    if (!(pred)) {                                                                                                   \
-      ::maliput::common::internal::Throw<::maliput::common::assertion_error>(std::string(message).c_str(), __func__, \
-                                                                             __FILE__, __LINE__);                    \
-    }                                                                                                                \
-  } while (0)
-
-/// @def MALIPUT_VALIDATE
-/// Used to validate that a @p pred-icate passed into a function or method is
-/// true; if not, an exception with @p message is thrown.
 #define MALIPUT_VALIDATE(...) MALIPUT_VALIDATE_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
 /// @def MALIPUT_IS_IN_RANGE

--- a/include/maliput/common/maliput_throw.h
+++ b/include/maliput/common/maliput_throw.h
@@ -75,7 +75,6 @@
 namespace maliput {
 namespace common {
 namespace internal {
-namespace {
 
 // Stream into @p out the given failure details; only @p condition may be null.
 inline void PrintFailureDetailTo(std::ostream* out, const char* condition, const char* func, const char* file,
@@ -88,8 +87,6 @@ inline void PrintFailureDetailTo(std::ostream* out, const char* condition, const
   }
 }
 
-}  // namespace
-
 // Throw an error message.
 template <typename ExceptionType>
 __attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
@@ -99,75 +96,69 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
   throw ExceptionType(what.str());
 }
 
-}  // namespace internal
-}  // namespace common
-}  // namespace maliput
+// Helper macros to choose the correct implementation.
+// These macros are not intended for direct use.
+// They are defined inside the `internal` namespace to signal that they are
+// not part of the public API.
+#define MALIPUT_INTERNAL_GET_4TH_ARG(_1, _2, _3, NAME, ...) NAME
+#define MALIPUT_INTERNAL_GET_3RD_ARG(_1, _2, NAME, ...) NAME
+#define MALIPUT_INTERNAL_VALIDATE_MACRO_CHOOSER(...) \
+  MALIPUT_INTERNAL_GET_4TH_ARG(__VA_ARGS__, MALIPUT_INTERNAL_VALIDATE_3, MALIPUT_INTERNAL_VALIDATE_2)
+#define MALIPUT_INTERNAL_THROW_MESSAGE_MACRO_CHOOSER(...) \
+  MALIPUT_INTERNAL_GET_3RD_ARG(__VA_ARGS__, MALIPUT_INTERNAL_THROW_MESSAGE_3, MALIPUT_INTERNAL_THROW_MESSAGE_2)
+#define MALIPUT_INTERNAL_THROW_UNLESS_MACRO_CHOOSER(...) \
+  MALIPUT_INTERNAL_GET_3RD_ARG(__VA_ARGS__, MALIPUT_INTERNAL_THROW_UNLESS_3, MALIPUT_INTERNAL_THROW_UNLESS_2)
 
-namespace {
-// Helper macros to choose the correct implementation
-#define GET_4TH_ARG(_1, _2, _3, NAME, ...) NAME
-#define GET_3RD_ARG(_1, _2, NAME, ...) NAME
-#define MALIPUT_VALIDATE_MACRO_CHOOSER(...) GET_4TH_ARG(__VA_ARGS__, MALIPUT_VALIDATE_3, MALIPUT_VALIDATE_2)
-#define MALIPUT_THROW_MESSAGE_MACRO_CHOOSER(...) \
-  GET_3RD_ARG(__VA_ARGS__, MALIPUT_THROW_MESSAGE_3, MALIPUT_THROW_MESSAGE_2)
-#define MALIPUT_THROW_UNLESS_MACRO_CHOOSER(...) GET_3RD_ARG(__VA_ARGS__, MALIPUT_THROW_UNLESS_3, MALIPUT_THROW_UNLESS_2)
-
-/// @def MALIPUT_THROW_UNLESS
-/// Evaluates @p condition and iff the value is false will throw a
-/// maliput::common::assertion_error exception with a message showing at least
-/// the condition text, function name, file, and line.
-#define MALIPUT_THROW_UNLESS_2(condition)                                                                             \
+// Evaluates @p condition and iff the value is false will throw a
+// maliput::common::assertion_error exception with a message showing at least
+// the condition text, function name, file, and line.
+#define MALIPUT_INTERNAL_THROW_UNLESS_2(condition)                                                                    \
   do {                                                                                                                \
     if (!(condition)) {                                                                                               \
       ::maliput::common::internal::Throw<maliput::common::assertion_error>(#condition, __func__, __FILE__, __LINE__); \
     }                                                                                                                 \
   } while (0)
 
-/// @def MALIPUT_THROW_UNLESS
-/// Evaluates @p condition and iff the value is false will throw an @p err_type
-/// exception with a message showing at least the condition text, function name,
-/// file, and line.
-#define MALIPUT_THROW_UNLESS_3(condition, err_type)                                           \
+// Evaluates @p condition and iff the value is false will throw an @p err_type
+// exception with a message showing at least the condition text, function name,
+// file, and line.
+#define MALIPUT_INTERNAL_THROW_UNLESS_3(condition, err_type)                                  \
   do {                                                                                        \
     if (!(condition)) {                                                                       \
       ::maliput::common::internal::Throw<err_type>(#condition, __func__, __FILE__, __LINE__); \
     }                                                                                         \
   } while (0)
 
-/// @def MALIPUT_THROW_MESSAGE
-/// Throws a maliput::common::assertion_error exception with a message showing
-/// at least the condition text, function name, file, and line.
-#define MALIPUT_THROW_MESSAGE_2(msg)                                                                                \
+// Throws a maliput::common::assertion_error exception with a message showing
+// at least the condition text, function name, file, and line.
+#define MALIPUT_INTERNAL_THROW_MESSAGE_2(msg)                                                                       \
   do {                                                                                                              \
     const std::string error_message(msg);                                                                           \
     ::maliput::common::internal::Throw<maliput::common::assertion_error>(error_message.c_str(), __func__, __FILE__, \
                                                                          __LINE__);                                 \
   } while (0)
 
-/// @def MALIPUT_THROW_MESSAGE
-/// Throws an exception of type @p err_type with a message.
-#define MALIPUT_THROW_MESSAGE_3(msg, err_type)                                                         \
+// Throws an exception of type @p err_type with a message.
+#define MALIPUT_INTERNAL_THROW_MESSAGE_3(msg, err_type)                                                \
   do {                                                                                                 \
     const std::string error_message(msg);                                                              \
     ::maliput::common::internal::Throw<err_type>(error_message.c_str(), __func__, __FILE__, __LINE__); \
   } while (0)
 
-/// @def MALIPUT_VALIDATE
-/// Evaluates @p condition and iff the value is false will throw a
-/// @p err_type exception with a @p message showing at least the
-/// condition text, function name, file, and line.
-#define MALIPUT_VALIDATE_3(condition, message, error_type)                                                        \
+// Evaluates @p condition and iff the value is false will throw a
+// @p err_type exception with a @p message showing at least the
+// condition text, function name, file, and line.
+#define MALIPUT_INTERNAL_VALIDATE_3(condition, message, error_type)                                               \
   do {                                                                                                            \
     if (!(condition)) {                                                                                           \
       ::maliput::common::internal::Throw<error_type>(std::string(message).c_str(), __func__, __FILE__, __LINE__); \
     }                                                                                                             \
   } while (0)
 
-/// @def MALIPUT_VALIDATE
-/// Evaluates @p condition and iff the value is false will throw a
-/// maliput::common::assertion_error with a @p message showing at least the
-/// condition text, function name, file, and line.
-#define MALIPUT_VALIDATE_2(condition, message)                                                                       \
+// Evaluates @p condition and iff the value is false will throw a
+// maliput::common::assertion_error with a @p message showing at least the
+// condition text, function name, file, and line.
+#define MALIPUT_INTERNAL_VALIDATE_2(condition, message)                                                              \
   do {                                                                                                               \
     if (!(condition)) {                                                                                              \
       ::maliput::common::internal::Throw<::maliput::common::assertion_error>(std::string(message).c_str(), __func__, \
@@ -175,7 +166,9 @@ namespace {
     }                                                                                                                \
   } while (0)
 
-}  // namespace
+}  // namespace internal
+}  // namespace common
+}  // namespace maliput
 
 /// @def MALIPUT_THROW_UNLESS
 /// Evaluates @p condition and iff the value is false will throw an exception
@@ -184,19 +177,19 @@ namespace {
 /// provided exception type.
 // TODO(Santoi): Deprecate this in favor of MALIPUT_VALIDATE. We prefer throwing exceptions with descriptive messages
 // rather than just failed conditions.
-#define MALIPUT_THROW_UNLESS(...) MALIPUT_THROW_UNLESS_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+#define MALIPUT_THROW_UNLESS(...) MALIPUT_INTERNAL_THROW_UNLESS_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
 /// @def MALIPUT_THROW_MESSAGE
 /// Throws an exception of type maliput::common::assertion_error or @p err_type
 /// (if it's specified) with a message.
-/// @see MALIPUT_THROW_MESSAGE_3.
-#define MALIPUT_THROW_MESSAGE(...) MALIPUT_THROW_MESSAGE_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+/// @see MALIPUT_INTERNAL_THROW_MESSAGE_3.
+#define MALIPUT_THROW_MESSAGE(...) MALIPUT_INTERNAL_THROW_MESSAGE_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
 /// @def MALIPUT_VALIDATE
 /// Evaluates @p condition and iff the value is false will throw a
 /// maliput::common::assertion_error with a @p message showing at least the
 /// condition text, function name, file, and line.
-#define MALIPUT_VALIDATE(...) MALIPUT_VALIDATE_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+#define MALIPUT_VALIDATE(...) MALIPUT_INTERNAL_VALIDATE_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
 /// @def MALIPUT_IS_IN_RANGE
 /// Throws if `value` is within [`min_value`; `max_value`]. It forwards the call

--- a/include/maliput/common/maliput_throw.h
+++ b/include/maliput/common/maliput_throw.h
@@ -122,6 +122,17 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
                                                                          __LINE__);                                 \
   } while (0)
 
+/// @def MALIPUT_VALIDATE
+/// Used to validate that a @p pred-icate passed into a function or method is
+/// true; if not, an exception with @p message is thrown.
+#define MALIPUT_VALIDATE(pred, message)                                                                            \
+  do {                                                                                                             \
+    if (!(pred)) {                                                                                                 \
+      ::maliput::common::internal::Throw<maliput::common::assertion_error>(std::string(message).c_str(), __func__, \
+                                                                           __FILE__, __LINE__);                    \
+    }                                                                                                              \
+  } while (0)
+
 /// Evaluates @p condition and iff the value is false will throw a
 /// road_network_description_parser_error with a message showing at least the
 /// condition text, function name, file, and line.
@@ -162,15 +173,33 @@ void Throw(const char* condition, const char* func, const char* file, int line) 
         error_message.c_str(), __func__, __FILE__, __LINE__);                              \
   } while (0)
 
-/// @def MALIPUT_VALIDATE
-/// Used to validate that a @p pred-icate passed into a function or method is
-/// true; if not, an exception with @p message is thrown.
-#define MALIPUT_VALIDATE(pred, message)                                                                            \
-  do {                                                                                                             \
-    if (!(pred)) {                                                                                                 \
-      ::maliput::common::internal::Throw<maliput::common::assertion_error>(std::string(message).c_str(), __func__, \
-                                                                           __FILE__, __LINE__);                    \
-    }                                                                                                              \
+/// Evaluates @p condition and iff the value is false will throw an
+/// @p err_type with a message showing at least the
+/// condition text, function name, file, and line.
+#define MALIPUT_THROW_RULES_UNLESS(condition, err_type)                                       \
+  do {                                                                                        \
+    if (!(condition)) {                                                                       \
+      ::maliput::common::internal::Throw<err_type>(#condition, __func__, __FILE__, __LINE__); \
+    }                                                                                         \
+  } while (0)
+
+/// Throws an @p err_type with a message showing at
+/// least the condition text, function name, file, and line.
+#define MALIPUT_THROW_RULES_MESSAGE(msg, err_type)                                                     \
+  do {                                                                                                 \
+    const std::string error_message(msg);                                                              \
+    ::maliput::common::internal::Throw<err_type>(error_message.c_str(), __func__, __FILE__, __LINE__); \
+  } while (0)
+
+/// @def MALIPUT_RULEBOOK_VALIDATE
+/// Evaluates the @p condition and iff the value is false will throw an
+/// @p err_type with a @p message showing at least the
+/// condition text, function name, file, and line.
+#define MALIPUT_RULES_VALIDATE(condition, message, err_type)                                                    \
+  do {                                                                                                          \
+    if (!(condition)) {                                                                                         \
+      ::maliput::common::internal::Throw<err_type>(std::string(message).c_str(), __func__, __FILE__, __LINE__); \
+    }                                                                                                           \
   } while (0)
 
 /// @def MALIPUT_IS_IN_RANGE

--- a/src/maliput/api/rules/discrete_value_rule.cc
+++ b/src/maliput/api/rules/discrete_value_rule.cc
@@ -40,16 +40,15 @@ namespace rules {
 DiscreteValueRule::DiscreteValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                      const std::vector<DiscreteValue>& values)
     : Rule(id, type_id, zone), states_(values) {
-  MALIPUT_RULES_VALIDATE(!states_.empty(),
-                         "DiscreteValueRule(" + id.string() + ") has no DiscreteValueRule::DiscreteValues.",
-                         maliput::common::rulebook_error);
+  MALIPUT_VALIDATE(!states_.empty(), "DiscreteValueRule(" + id.string() + ") has no DiscreteValueRule::DiscreteValues.",
+                   maliput::common::rulebook_error);
   for (const DiscreteValue& value : states_) {
     ValidateRelatedRules(value.related_rules);
     ValidateRelatedUniqueIds(value.related_unique_ids);
     ValidateSeverity(value.severity);
-    MALIPUT_RULES_VALIDATE(std::count(states_.begin(), states_.end(), value) == 1,
-                           "DiscreteValueRule(" + id.string() + ") has duplicated DiscreteValueRule::DiscreteValues.",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(std::count(states_.begin(), states_.end(), value) == 1,
+                     "DiscreteValueRule(" + id.string() + ") has duplicated DiscreteValueRule::DiscreteValues.",
+                     maliput::common::rulebook_error);
   }
 }
 

--- a/src/maliput/api/rules/discrete_value_rule.cc
+++ b/src/maliput/api/rules/discrete_value_rule.cc
@@ -40,14 +40,16 @@ namespace rules {
 DiscreteValueRule::DiscreteValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                      const std::vector<DiscreteValue>& values)
     : Rule(id, type_id, zone), states_(values) {
-  MALIPUT_VALIDATE(!states_.empty(),
-                   "DiscreteValueRule(" + id.string() + ") has no DiscreteValueRule::DiscreteValues.");
+  MALIPUT_RULES_VALIDATE(!states_.empty(),
+                         "DiscreteValueRule(" + id.string() + ") has no DiscreteValueRule::DiscreteValues.",
+                         maliput::common::rulebook_error);
   for (const DiscreteValue& value : states_) {
     ValidateRelatedRules(value.related_rules);
     ValidateRelatedUniqueIds(value.related_unique_ids);
     ValidateSeverity(value.severity);
-    MALIPUT_VALIDATE(std::count(states_.begin(), states_.end(), value) == 1,
-                     "DiscreteValueRule(" + id.string() + ") has duplicated DiscreteValueRule::DiscreteValues.");
+    MALIPUT_RULES_VALIDATE(std::count(states_.begin(), states_.end(), value) == 1,
+                           "DiscreteValueRule(" + id.string() + ") has duplicated DiscreteValueRule::DiscreteValues.",
+                           maliput::common::rulebook_error);
   }
 }
 

--- a/src/maliput/api/rules/phase_ring.cc
+++ b/src/maliput/api/rules/phase_ring.cc
@@ -44,35 +44,43 @@ namespace {
 /// This is because every phase must specify the complete state of all the rules
 /// and bulb states mentioned by the ring.
 void VerifyAllPhasesHaveSameCoverage(const PhaseRing::Id& id, const std::vector<Phase>& phases) {
-  MALIPUT_VALIDATE(phases.size() >= 1, "PhaseRing(" + id.string() + ") must have at least one phase.");
+  MALIPUT_RULES_VALIDATE(phases.size() >= 1, "PhaseRing(" + id.string() + ") must have at least one phase.",
+                         maliput::common::phase_book_error);
   const auto& r = phases.at(0);  // The reference phase.
   for (const auto& phase : phases) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    MALIPUT_VALIDATE(phase.rule_states().size() == r.rule_states().size(),
-                     "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" + r.id().string() +
-                         ") must have the same number of rule_states.");
+    MALIPUT_RULES_VALIDATE(phase.rule_states().size() == r.rule_states().size(),
+                           "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" +
+                               r.id().string() + ") must have the same number of rule_states.",
+                           maliput::common::phase_book_error);
     for (const auto& s : phase.rule_states()) {
-      MALIPUT_VALIDATE(r.rule_states().count(s.first) == 1, "PhaseRing(" + id.string() + "). Phase(" +
-                                                                phase.id().string() + ") has duplicated rule states.");
+      MALIPUT_RULES_VALIDATE(
+          r.rule_states().count(s.first) == 1,
+          "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") has duplicated rule states.",
+          maliput::common::phase_book_error);
     }
 #pragma GCC diagnostic pop
-    MALIPUT_VALIDATE(phase.discrete_value_rule_states().size() == r.discrete_value_rule_states().size(),
-                     "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" + r.id().string() +
-                         ") must have the same number of discrete_value_rule_states.");
+    MALIPUT_RULES_VALIDATE(phase.discrete_value_rule_states().size() == r.discrete_value_rule_states().size(),
+                           "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" +
+                               r.id().string() + ") must have the same number of discrete_value_rule_states.",
+                           maliput::common::phase_book_error);
     for (const auto& s : phase.discrete_value_rule_states()) {
-      MALIPUT_VALIDATE(r.discrete_value_rule_states().count(s.first) == 1,
-                       "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() +
-                           ") has duplicated discrete value rule states");
+      MALIPUT_RULES_VALIDATE(r.discrete_value_rule_states().count(s.first) == 1,
+                             "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() +
+                                 ") has duplicated discrete value rule states",
+                             maliput::common::phase_book_error);
     }
     // Require both set of bulb states to be defined or undefined together.
     if (r.bulb_states() != std::nullopt) {
-      MALIPUT_VALIDATE(phase.bulb_states()->size() == r.bulb_states()->size(),
-                       "Phase(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" + r.id().string() +
-                           ") must have the same number of bulb_states.");
+      MALIPUT_RULES_VALIDATE(phase.bulb_states()->size() == r.bulb_states()->size(),
+                             "Phase(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" +
+                                 r.id().string() + ") must have the same number of bulb_states.",
+                             maliput::common::phase_book_error);
       for (const auto& s : *phase.bulb_states()) {
-        MALIPUT_VALIDATE(r.bulb_states()->count(s.first) == 1,
-                         "PhaseRing(" + id.string() + ") has duplicated bulb states");
+        MALIPUT_RULES_VALIDATE(r.bulb_states()->count(s.first) == 1,
+                               "PhaseRing(" + id.string() + ") has duplicated bulb states",
+                               maliput::common::phase_book_error);
       }
     }
   }
@@ -82,12 +90,14 @@ void VerifyAllPhasesHaveSameCoverage(const PhaseRing::Id& id, const std::vector<
 /// phase in `phases` and nothing more.
 void VerifyNextPhases(const PhaseRing::Id& id, const std::vector<Phase>& phases,
                       const std::unordered_map<Phase::Id, std::vector<PhaseRing::NextPhase>>& next_phases) {
-  MALIPUT_VALIDATE(phases.size() == next_phases.size(),
-                   "PhaseRing(" + id.string() + ")'s phases and next_phases sizes must be equal.");
+  MALIPUT_RULES_VALIDATE(phases.size() == next_phases.size(),
+                         "PhaseRing(" + id.string() + ")'s phases and next_phases sizes must be equal.",
+                         maliput::common::phase_book_error);
   for (const auto& phase : phases) {
-    MALIPUT_VALIDATE(
+    MALIPUT_RULES_VALIDATE(
         next_phases.find(phase.id()) != next_phases.end(),
-        "In PhaseRing(" + id.string() + "), the Phase(" + phase.id().string() + ") is not in next_phases.");
+        "In PhaseRing(" + id.string() + "), the Phase(" + phase.id().string() + ") is not in next_phases.",
+        maliput::common::phase_book_error);
   }
 }
 
@@ -96,11 +106,12 @@ void VerifyNextPhases(const PhaseRing::Id& id, const std::vector<Phase>& phases,
 PhaseRing::PhaseRing(const Id& id, const std::vector<Phase>& phases,
                      const std::optional<const std::unordered_map<Phase::Id, std::vector<NextPhase>>>& next_phases)
     : id_(id) {
-  MALIPUT_VALIDATE(phases.size() >= 1, "PhaseRing(" + id_.string() + ") must have at least one phase.");
+  MALIPUT_RULES_VALIDATE(phases.size() >= 1, "PhaseRing(" + id_.string() + ") must have at least one phase.",
+                         maliput::common::phase_book_error);
   for (const Phase& phase : phases) {
     // Construct index of phases by ID, ensuring uniqueness of ID's.
     auto result = phases_.emplace(phase.id(), phase);
-    MALIPUT_THROW_UNLESS(result.second);
+    MALIPUT_THROW_RULES_UNLESS(result.second, maliput::common::phase_book_error);
   }
   if (next_phases != std::nullopt) {
     next_phases_ = *next_phases;

--- a/src/maliput/api/rules/phase_ring.cc
+++ b/src/maliput/api/rules/phase_ring.cc
@@ -44,43 +44,42 @@ namespace {
 /// This is because every phase must specify the complete state of all the rules
 /// and bulb states mentioned by the ring.
 void VerifyAllPhasesHaveSameCoverage(const PhaseRing::Id& id, const std::vector<Phase>& phases) {
-  MALIPUT_RULES_VALIDATE(phases.size() >= 1, "PhaseRing(" + id.string() + ") must have at least one phase.",
-                         maliput::common::phase_book_error);
+  MALIPUT_VALIDATE(phases.size() >= 1, "PhaseRing(" + id.string() + ") must have at least one phase.",
+                   maliput::common::phase_book_error);
   const auto& r = phases.at(0);  // The reference phase.
   for (const auto& phase : phases) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    MALIPUT_RULES_VALIDATE(phase.rule_states().size() == r.rule_states().size(),
-                           "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" +
-                               r.id().string() + ") must have the same number of rule_states.",
-                           maliput::common::phase_book_error);
+    MALIPUT_VALIDATE(phase.rule_states().size() == r.rule_states().size(),
+                     "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" + r.id().string() +
+                         ") must have the same number of rule_states.",
+                     maliput::common::phase_book_error);
     for (const auto& s : phase.rule_states()) {
-      MALIPUT_RULES_VALIDATE(
-          r.rule_states().count(s.first) == 1,
-          "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") has duplicated rule states.",
-          maliput::common::phase_book_error);
+      MALIPUT_VALIDATE(r.rule_states().count(s.first) == 1,
+                       "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") has duplicated rule states.",
+                       maliput::common::phase_book_error);
     }
 #pragma GCC diagnostic pop
-    MALIPUT_RULES_VALIDATE(phase.discrete_value_rule_states().size() == r.discrete_value_rule_states().size(),
-                           "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" +
-                               r.id().string() + ") must have the same number of discrete_value_rule_states.",
-                           maliput::common::phase_book_error);
+    MALIPUT_VALIDATE(phase.discrete_value_rule_states().size() == r.discrete_value_rule_states().size(),
+                     "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" + r.id().string() +
+                         ") must have the same number of discrete_value_rule_states.",
+                     maliput::common::phase_book_error);
     for (const auto& s : phase.discrete_value_rule_states()) {
-      MALIPUT_RULES_VALIDATE(r.discrete_value_rule_states().count(s.first) == 1,
-                             "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() +
-                                 ") has duplicated discrete value rule states",
-                             maliput::common::phase_book_error);
+      MALIPUT_VALIDATE(r.discrete_value_rule_states().count(s.first) == 1,
+                       "PhaseRing(" + id.string() + "). Phase(" + phase.id().string() +
+                           ") has duplicated discrete value rule states",
+                       maliput::common::phase_book_error);
     }
     // Require both set of bulb states to be defined or undefined together.
     if (r.bulb_states() != std::nullopt) {
-      MALIPUT_RULES_VALIDATE(phase.bulb_states()->size() == r.bulb_states()->size(),
-                             "Phase(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" +
-                                 r.id().string() + ") must have the same number of bulb_states.",
-                             maliput::common::phase_book_error);
+      MALIPUT_VALIDATE(phase.bulb_states()->size() == r.bulb_states()->size(),
+                       "Phase(" + id.string() + "). Phase(" + phase.id().string() + ") and Phase(" + r.id().string() +
+                           ") must have the same number of bulb_states.",
+                       maliput::common::phase_book_error);
       for (const auto& s : *phase.bulb_states()) {
-        MALIPUT_RULES_VALIDATE(r.bulb_states()->count(s.first) == 1,
-                               "PhaseRing(" + id.string() + ") has duplicated bulb states",
-                               maliput::common::phase_book_error);
+        MALIPUT_VALIDATE(r.bulb_states()->count(s.first) == 1,
+                         "PhaseRing(" + id.string() + ") has duplicated bulb states",
+                         maliput::common::phase_book_error);
       }
     }
   }
@@ -90,14 +89,13 @@ void VerifyAllPhasesHaveSameCoverage(const PhaseRing::Id& id, const std::vector<
 /// phase in `phases` and nothing more.
 void VerifyNextPhases(const PhaseRing::Id& id, const std::vector<Phase>& phases,
                       const std::unordered_map<Phase::Id, std::vector<PhaseRing::NextPhase>>& next_phases) {
-  MALIPUT_RULES_VALIDATE(phases.size() == next_phases.size(),
-                         "PhaseRing(" + id.string() + ")'s phases and next_phases sizes must be equal.",
-                         maliput::common::phase_book_error);
+  MALIPUT_VALIDATE(phases.size() == next_phases.size(),
+                   "PhaseRing(" + id.string() + ")'s phases and next_phases sizes must be equal.",
+                   maliput::common::phase_book_error);
   for (const auto& phase : phases) {
-    MALIPUT_RULES_VALIDATE(
-        next_phases.find(phase.id()) != next_phases.end(),
-        "In PhaseRing(" + id.string() + "), the Phase(" + phase.id().string() + ") is not in next_phases.",
-        maliput::common::phase_book_error);
+    MALIPUT_VALIDATE(next_phases.find(phase.id()) != next_phases.end(),
+                     "In PhaseRing(" + id.string() + "), the Phase(" + phase.id().string() + ") is not in next_phases.",
+                     maliput::common::phase_book_error);
   }
 }
 
@@ -106,12 +104,14 @@ void VerifyNextPhases(const PhaseRing::Id& id, const std::vector<Phase>& phases,
 PhaseRing::PhaseRing(const Id& id, const std::vector<Phase>& phases,
                      const std::optional<const std::unordered_map<Phase::Id, std::vector<NextPhase>>>& next_phases)
     : id_(id) {
-  MALIPUT_RULES_VALIDATE(phases.size() >= 1, "PhaseRing(" + id_.string() + ") must have at least one phase.",
-                         maliput::common::phase_book_error);
+  MALIPUT_VALIDATE(phases.size() >= 1, "PhaseRing(" + id_.string() + ") must have at least one phase.",
+                   maliput::common::phase_book_error);
   for (const Phase& phase : phases) {
     // Construct index of phases by ID, ensuring uniqueness of ID's.
     auto result = phases_.emplace(phase.id(), phase);
-    MALIPUT_THROW_RULES_UNLESS(result.second, maliput::common::phase_book_error);
+    MALIPUT_VALIDATE(result.second,
+                     "Phase with ID '" + phase.id().string() + "' is not unique when creating PhaseRing.",
+                     maliput::common::phase_book_error);
   }
   if (next_phases != std::nullopt) {
     next_phases_ = *next_phases;

--- a/src/maliput/api/rules/range_value_rule.cc
+++ b/src/maliput/api/rules/range_value_rule.cc
@@ -40,18 +40,18 @@ namespace rules {
 RangeValueRule::RangeValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                const std::vector<Range>& ranges)
     : Rule(id, type_id, zone), states_(ranges) {
-  MALIPUT_RULES_VALIDATE(!states_.empty(), "RangeValueRule(" + id.string() + ") has no RangeValueRule::Ranges.",
-                         maliput::common::rulebook_error);
+  MALIPUT_VALIDATE(!states_.empty(), "RangeValueRule(" + id.string() + ") has no RangeValueRule::Ranges.",
+                   maliput::common::rulebook_error);
   for (const Range& range : states_) {
     ValidateRelatedRules(range.related_rules);
     ValidateRelatedUniqueIds(range.related_unique_ids);
     ValidateSeverity(range.severity);
-    MALIPUT_RULES_VALIDATE(range.min <= range.max,
-                           "RangeValueRule(" + id.string() + ") has a RangeValueRule::Ranges whose min > max.",
-                           maliput::common::rulebook_error);
-    MALIPUT_RULES_VALIDATE(std::count(states_.begin(), states_.end(), range) == 1,
-                           "RangeValueRule(" + id.string() + ") has duplicated RangeValueRule::Ranges.",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(range.min <= range.max,
+                     "RangeValueRule(" + id.string() + ") has a RangeValueRule::Ranges whose min > max.",
+                     maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(std::count(states_.begin(), states_.end(), range) == 1,
+                     "RangeValueRule(" + id.string() + ") has duplicated RangeValueRule::Ranges.",
+                     maliput::common::rulebook_error);
   }
 }
 

--- a/src/maliput/api/rules/range_value_rule.cc
+++ b/src/maliput/api/rules/range_value_rule.cc
@@ -40,15 +40,18 @@ namespace rules {
 RangeValueRule::RangeValueRule(const Rule::Id& id, const Rule::TypeId& type_id, const LaneSRoute& zone,
                                const std::vector<Range>& ranges)
     : Rule(id, type_id, zone), states_(ranges) {
-  MALIPUT_VALIDATE(!states_.empty(), "RangeValueRule(" + id.string() + ") has no RangeValueRule::Ranges.");
+  MALIPUT_RULES_VALIDATE(!states_.empty(), "RangeValueRule(" + id.string() + ") has no RangeValueRule::Ranges.",
+                         maliput::common::rulebook_error);
   for (const Range& range : states_) {
     ValidateRelatedRules(range.related_rules);
     ValidateRelatedUniqueIds(range.related_unique_ids);
     ValidateSeverity(range.severity);
-    MALIPUT_VALIDATE(range.min <= range.max,
-                     "RangeValueRule(" + id.string() + ") has a RangeValueRule::Ranges whose min > max.");
-    MALIPUT_VALIDATE(std::count(states_.begin(), states_.end(), range) == 1,
-                     "RangeValueRule(" + id.string() + ") has duplicated RangeValueRule::Ranges.");
+    MALIPUT_RULES_VALIDATE(range.min <= range.max,
+                           "RangeValueRule(" + id.string() + ") has a RangeValueRule::Ranges whose min > max.",
+                           maliput::common::rulebook_error);
+    MALIPUT_RULES_VALIDATE(std::count(states_.begin(), states_.end(), range) == 1,
+                           "RangeValueRule(" + id.string() + ") has duplicated RangeValueRule::Ranges.",
+                           maliput::common::rulebook_error);
   }
 }
 

--- a/src/maliput/api/rules/rule.cc
+++ b/src/maliput/api/rules/rule.cc
@@ -68,11 +68,11 @@ bool Rule::State::operator==(const State& other) const {
 
 void Rule::ValidateRelatedRules(const Rule::RelatedRules& related_rules) const {
   for (const auto& group_id_to_related_rules : related_rules) {
-    MALIPUT_RULES_VALIDATE(!group_id_to_related_rules.first.empty(),
-                           "Rule(" + id_.string() + ") contains an empty key in related_rules",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(!group_id_to_related_rules.first.empty(),
+                     "Rule(" + id_.string() + ") contains an empty key in related_rules",
+                     maliput::common::rulebook_error);
     for (const Rule::Id& rule_id : group_id_to_related_rules.second) {
-      MALIPUT_RULES_VALIDATE(
+      MALIPUT_VALIDATE(
           std::count(group_id_to_related_rules.second.begin(), group_id_to_related_rules.second.end(), rule_id) == 1,
           "Rule(" + id_.string() + ") with related_rules that contains a duplicate Rule::Id(" + rule_id.string() +
               ") at key <" + group_id_to_related_rules.first + ">",
@@ -83,22 +83,22 @@ void Rule::ValidateRelatedRules(const Rule::RelatedRules& related_rules) const {
 
 void Rule::ValidateRelatedUniqueIds(const RelatedUniqueIds& related_unique_ids) const {
   for (const auto& group_id_to_related_unique_ids : related_unique_ids) {
-    MALIPUT_RULES_VALIDATE(!group_id_to_related_unique_ids.first.empty(),
-                           "Rule(" + id_.string() + ") contains an empty key in related_unique_ids",
-                           maliput::common::rulebook_error);
+    MALIPUT_VALIDATE(!group_id_to_related_unique_ids.first.empty(),
+                     "Rule(" + id_.string() + ") contains an empty key in related_unique_ids",
+                     maliput::common::rulebook_error);
     for (const UniqueId& unique_id : group_id_to_related_unique_ids.second) {
-      MALIPUT_RULES_VALIDATE(std::count(group_id_to_related_unique_ids.second.begin(),
-                                        group_id_to_related_unique_ids.second.end(), unique_id) == 1,
-                             "Rule(" + id_.string() + ") with related_unique_ids that contains a duplicate UniqueId(" +
-                                 unique_id.string() + ") at key <" + group_id_to_related_unique_ids.first + ">",
-                             maliput::common::rulebook_error);
+      MALIPUT_VALIDATE(std::count(group_id_to_related_unique_ids.second.begin(),
+                                  group_id_to_related_unique_ids.second.end(), unique_id) == 1,
+                       "Rule(" + id_.string() + ") with related_unique_ids that contains a duplicate UniqueId(" +
+                           unique_id.string() + ") at key <" + group_id_to_related_unique_ids.first + ">",
+                       maliput::common::rulebook_error);
     }
   }
 }
 
 void Rule::ValidateSeverity(int severity) const {
-  MALIPUT_RULES_VALIDATE(severity >= 0, "Rule(" + id_.string() + ") has a state whose severity is negative.",
-                         maliput::common::rulebook_error);
+  MALIPUT_VALIDATE(severity >= 0, "Rule(" + id_.string() + ") has a state whose severity is negative.",
+                   maliput::common::rulebook_error);
 }
 
 }  // namespace rules

--- a/src/maliput/api/rules/rule.cc
+++ b/src/maliput/api/rules/rule.cc
@@ -68,32 +68,37 @@ bool Rule::State::operator==(const State& other) const {
 
 void Rule::ValidateRelatedRules(const Rule::RelatedRules& related_rules) const {
   for (const auto& group_id_to_related_rules : related_rules) {
-    MALIPUT_VALIDATE(!group_id_to_related_rules.first.empty(),
-                     "Rule(" + id_.string() + ") contains an empty key in related_rules");
+    MALIPUT_RULES_VALIDATE(!group_id_to_related_rules.first.empty(),
+                           "Rule(" + id_.string() + ") contains an empty key in related_rules",
+                           maliput::common::rulebook_error);
     for (const Rule::Id& rule_id : group_id_to_related_rules.second) {
-      MALIPUT_VALIDATE(
+      MALIPUT_RULES_VALIDATE(
           std::count(group_id_to_related_rules.second.begin(), group_id_to_related_rules.second.end(), rule_id) == 1,
           "Rule(" + id_.string() + ") with related_rules that contains a duplicate Rule::Id(" + rule_id.string() +
-              ") at key <" + group_id_to_related_rules.first + ">");
+              ") at key <" + group_id_to_related_rules.first + ">",
+          maliput::common::rulebook_error);
     }
   }
 }
 
 void Rule::ValidateRelatedUniqueIds(const RelatedUniqueIds& related_unique_ids) const {
   for (const auto& group_id_to_related_unique_ids : related_unique_ids) {
-    MALIPUT_VALIDATE(!group_id_to_related_unique_ids.first.empty(),
-                     "Rule(" + id_.string() + ") contains an empty key in related_unique_ids");
+    MALIPUT_RULES_VALIDATE(!group_id_to_related_unique_ids.first.empty(),
+                           "Rule(" + id_.string() + ") contains an empty key in related_unique_ids",
+                           maliput::common::rulebook_error);
     for (const UniqueId& unique_id : group_id_to_related_unique_ids.second) {
-      MALIPUT_VALIDATE(std::count(group_id_to_related_unique_ids.second.begin(),
-                                  group_id_to_related_unique_ids.second.end(), unique_id) == 1,
-                       "Rule(" + id_.string() + ") with related_unique_ids that contains a duplicate UniqueId(" +
-                           unique_id.string() + ") at key <" + group_id_to_related_unique_ids.first + ">");
+      MALIPUT_RULES_VALIDATE(std::count(group_id_to_related_unique_ids.second.begin(),
+                                        group_id_to_related_unique_ids.second.end(), unique_id) == 1,
+                             "Rule(" + id_.string() + ") with related_unique_ids that contains a duplicate UniqueId(" +
+                                 unique_id.string() + ") at key <" + group_id_to_related_unique_ids.first + ">",
+                             maliput::common::rulebook_error);
     }
   }
 }
 
 void Rule::ValidateSeverity(int severity) const {
-  MALIPUT_VALIDATE(severity >= 0, "Rule(" + id_.string() + ") has a state whose severity is negative.");
+  MALIPUT_RULES_VALIDATE(severity >= 0, "Rule(" + id_.string() + ") has a state whose severity is negative.",
+                         maliput::common::rulebook_error);
 }
 
 }  // namespace rules

--- a/src/maliput/api/rules/rule_registry.cc
+++ b/src/maliput/api/rules/rule_registry.cc
@@ -63,36 +63,38 @@ bool HasValue(const RuleRegistry::QueryResult::Ranges& ranges, const RangeValueR
 
 void RuleRegistry::RegisterRangeValueRule(const Rule::TypeId& type_id,
                                           const RuleRegistry::QueryResult::Ranges& all_possible_ranges) {
-  MALIPUT_RULES_VALIDATE(GetPossibleStatesOfRuleType(type_id) == std::nullopt,
-                         "Rule::TypeId(" + type_id.string() + ") must have at least one state.",
-                         maliput::common::rule_registry_error);
-  MALIPUT_RULES_VALIDATE(!all_possible_ranges.empty(), "No ranges set for Rule::TypeId( " + type_id.string() + ").",
-                         maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(GetPossibleStatesOfRuleType(type_id) == std::nullopt,
+                   "Rule::TypeId(" + type_id.string() + ") must have at least one state.",
+                   maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(!all_possible_ranges.empty(), "No ranges set for Rule::TypeId( " + type_id.string() + ").",
+                   maliput::common::rule_registry_error);
   for (const RangeValueRule::Range& range : all_possible_ranges) {
-    MALIPUT_RULES_VALIDATE(std::count(all_possible_ranges.begin(), all_possible_ranges.end(), range) == 1,
-                           "The same range is repeated for Rule::TypeId(" + type_id.string() + ")",
-                           maliput::common::rule_registry_error);
+    MALIPUT_VALIDATE(std::count(all_possible_ranges.begin(), all_possible_ranges.end(), range) == 1,
+                     "The same range is repeated for Rule::TypeId(" + type_id.string() + ")",
+                     maliput::common::rule_registry_error);
   }
 
-  MALIPUT_THROW_RULES_UNLESS(range_rule_types_.emplace(type_id, all_possible_ranges).second,
-                             maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(range_rule_types_.emplace(type_id, all_possible_ranges).second,
+                   "RuleType with ID '" + type_id.string() + "' is not unique when registering RangeValueRule.",
+                   maliput::common::rule_registry_error);
 }
 
 void RuleRegistry::RegisterDiscreteValueRule(const Rule::TypeId& type_id,
                                              const RuleRegistry::QueryResult::DiscreteValues& all_possible_values) {
-  MALIPUT_RULES_VALIDATE(GetPossibleStatesOfRuleType(type_id) == std::nullopt,
-                         "Rule::TypeId(" + type_id.string() + ") must have at least one state.",
-                         maliput::common::rule_registry_error);
-  MALIPUT_RULES_VALIDATE(!all_possible_values.empty(), "No values set for Rule::TypeId( " + type_id.string() + ").",
-                         maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(GetPossibleStatesOfRuleType(type_id) == std::nullopt,
+                   "Rule::TypeId(" + type_id.string() + ") must have at least one state.",
+                   maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(!all_possible_values.empty(), "No values set for Rule::TypeId( " + type_id.string() + ").",
+                   maliput::common::rule_registry_error);
   for (const DiscreteValueRule::DiscreteValue& value_state : all_possible_values) {
-    MALIPUT_RULES_VALIDATE(std::count(all_possible_values.begin(), all_possible_values.end(), value_state) == 1,
-                           "The same value is repeated for Rule::TypeId(" + type_id.string() + ")",
-                           maliput::common::rule_registry_error);
+    MALIPUT_VALIDATE(std::count(all_possible_values.begin(), all_possible_values.end(), value_state) == 1,
+                     "The same value is repeated for Rule::TypeId(" + type_id.string() + ")",
+                     maliput::common::rule_registry_error);
   }
 
-  MALIPUT_THROW_RULES_UNLESS(discrete_rule_types_.emplace(type_id, all_possible_values).second,
-                             maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(discrete_rule_types_.emplace(type_id, all_possible_values).second,
+                   "RuleType with ID '" + type_id.string() + "' is not unique when registering DiscreteValueRule.",
+                   maliput::common::rule_registry_error);
 }
 
 const std::map<Rule::TypeId, RuleRegistry::QueryResult::Ranges>& RuleRegistry::RangeValueRuleTypes() const {
@@ -123,14 +125,14 @@ RangeValueRule RuleRegistry::BuildRangeValueRule(const Rule::Id& id, const Rule:
                                                  const LaneSRoute& zone,
                                                  const RuleRegistry::QueryResult::Ranges& ranges) const {
   const auto range_rule_type = range_rule_types_.find(type_id);
-  MALIPUT_RULES_VALIDATE(range_rule_type != range_rule_types_.end(),
-                         "No Rule::TypeId(" + type_id.string() + ") found in loaded range rule types.",
-                         maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(range_rule_type != range_rule_types_.end(),
+                   "No Rule::TypeId(" + type_id.string() + ") found in loaded range rule types.",
+                   maliput::common::rule_registry_error);
   for (const RangeValueRule::Range& range : ranges) {
-    MALIPUT_RULES_VALIDATE(HasValue(range_rule_type->second, range),
-                           "Rule::TypeId(" + type_id.string() + ") has no range value {" + std::to_string(range.min) +
-                               ", " + std::to_string(range.max) + "}.",
-                           maliput::common::rule_registry_error);
+    MALIPUT_VALIDATE(HasValue(range_rule_type->second, range),
+                     "Rule::TypeId(" + type_id.string() + ") has no range value {" + std::to_string(range.min) + ", " +
+                         std::to_string(range.max) + "}.",
+                     maliput::common::rule_registry_error);
   }
 
   return RangeValueRule(id, type_id, zone, ranges);
@@ -140,13 +142,13 @@ DiscreteValueRule RuleRegistry::BuildDiscreteValueRule(const Rule::Id& id, const
                                                        const LaneSRoute& zone,
                                                        const RuleRegistry::QueryResult::DiscreteValues& values) const {
   const auto discrete_rule_type = discrete_rule_types_.find(type_id);
-  MALIPUT_RULES_VALIDATE(discrete_rule_type != discrete_rule_types_.end(),
-                         "No Rule::TypeId(" + type_id.string() + ") found in loaded discrete value rule types.",
-                         maliput::common::rule_registry_error);
+  MALIPUT_VALIDATE(discrete_rule_type != discrete_rule_types_.end(),
+                   "No Rule::TypeId(" + type_id.string() + ") found in loaded discrete value rule types.",
+                   maliput::common::rule_registry_error);
   for (const DiscreteValueRule::DiscreteValue& value_state : values) {
-    MALIPUT_RULES_VALIDATE(HasValue(discrete_rule_type->second, value_state),
-                           "Rule::TypeId(" + type_id.string() + ") has no value state: " + value_state.value,
-                           maliput::common::rule_registry_error);
+    MALIPUT_VALIDATE(HasValue(discrete_rule_type->second, value_state),
+                     "Rule::TypeId(" + type_id.string() + ") has no value state: " + value_state.value,
+                     maliput::common::rule_registry_error);
   }
 
   return DiscreteValueRule(id, type_id, zone, values);

--- a/src/maliput/api/rules/traffic_lights.cc
+++ b/src/maliput/api/rules/traffic_lights.cc
@@ -72,10 +72,11 @@ Bulb::Bulb(const Bulb::Id& id, const InertialPosition& position_bulb_group, cons
       type_(type),
       arrow_orientation_rad_(arrow_orientation_rad),
       bounding_box_(std::move(bounding_box)) {
-  MALIPUT_THROW_RULES_UNLESS(type_ != BulbType::kArrow || arrow_orientation_rad_ != std::nullopt,
-                             maliput::common::traffic_light_book_error);
+  MALIPUT_VALIDATE(type_ != BulbType::kArrow || arrow_orientation_rad_ != std::nullopt,
+                   "Arrow-typed bulb's orientation is null.", maliput::common::traffic_light_book_error);
   if (type_ != BulbType::kArrow) {
-    MALIPUT_THROW_RULES_UNLESS(arrow_orientation_rad_ == std::nullopt, maliput::common::traffic_light_book_error);
+    MALIPUT_VALIDATE(arrow_orientation_rad_ == std::nullopt, "Non-arrow-typed bulb cannot have an orientation.",
+                     maliput::common::traffic_light_book_error);
   }
   if (states == std::nullopt || states->size() == 0) {
     states_ = {BulbState::kOff, BulbState::kOn};
@@ -98,8 +99,9 @@ bool Bulb::IsValidState(const BulbState& bulb_state) const {
 }
 
 UniqueBulbId Bulb::unique_id() const {
-  MALIPUT_THROW_RULES_UNLESS(bulb_group_ != nullptr, maliput::common::traffic_light_book_error);
-  MALIPUT_THROW_RULES_UNLESS(bulb_group_->traffic_light() != nullptr, maliput::common::traffic_light_book_error);
+  MALIPUT_VALIDATE(bulb_group_ != nullptr, "BulbGroup is null.", maliput::common::traffic_light_book_error);
+  MALIPUT_VALIDATE(bulb_group_->traffic_light() != nullptr, "BulbGroup's traffic light is null.",
+                   maliput::common::traffic_light_book_error);
   return UniqueBulbId(bulb_group_->traffic_light()->id(), bulb_group_->id(), id_);
 }
 
@@ -109,14 +111,16 @@ BulbGroup::BulbGroup(const BulbGroup::Id& id, const InertialPosition& position_t
       position_traffic_light_(position_traffic_light),
       orientation_traffic_light_(orientation_traffic_light),
       bulbs_(std::move(bulbs)) {
-  MALIPUT_THROW_RULES_UNLESS(bulbs_.size() > 0, maliput::common::traffic_light_book_error);
-  MALIPUT_THROW_RULES_UNLESS(
+  MALIPUT_VALIDATE(bulbs_.size() > 0, "BulbGroup should have at least 1 bulb.",
+                   maliput::common::traffic_light_book_error);
+  MALIPUT_VALIDATE(
       std::find_if(bulbs_.begin(), bulbs_.end(), [](const auto& bulb) { return bulb == nullptr; }) == bulbs_.end(),
-      maliput::common::traffic_light_book_error);
+      "Found nulled bulb when creating BulbGroup.", maliput::common::traffic_light_book_error);
   for (auto& bulb : bulbs_) {
-    MALIPUT_THROW_RULES_UNLESS(std::count_if(bulbs_.begin(), bulbs_.end(),
-                                             [bulb_id = bulb->id()](const auto& b) { return bulb_id == b->id(); }) == 1,
-                               maliput::common::traffic_light_book_error);
+    MALIPUT_VALIDATE(std::count_if(bulbs_.begin(), bulbs_.end(),
+                                   [bulb_id = bulb->id()](const auto& b) { return bulb_id == b->id(); }) == 1,
+                     "Bulb with ID '" + bulb->id().string() + "' is not unique when creating BulbGroup.",
+                     maliput::common::traffic_light_book_error);
     bulb->SetBulbGroup({}, this);
   }
 }
@@ -139,7 +143,7 @@ std::vector<const Bulb*> BulbGroup::bulbs() const {
 }
 
 UniqueBulbGroupId BulbGroup::unique_id() const {
-  MALIPUT_THROW_RULES_UNLESS(traffic_light_ != nullptr, maliput::common::traffic_light_book_error);
+  MALIPUT_VALIDATE(traffic_light_ != nullptr, "Traffic light is null.", maliput::common::traffic_light_book_error);
   return UniqueBulbGroupId(traffic_light_->id(), id_);
 }
 
@@ -150,14 +154,14 @@ TrafficLight::TrafficLight(const TrafficLight::Id& id, const InertialPosition& p
       position_road_network_(position_road_network),
       orientation_road_network_(orientation_road_network),
       bulb_groups_(std::move(bulb_groups)) {
-  MALIPUT_THROW_RULES_UNLESS(
-      std::find_if(bulb_groups_.begin(), bulb_groups_.end(),
-                   [](const auto& bulb_group) { return bulb_group == nullptr; }) == bulb_groups_.end(),
-      maliput::common::traffic_light_book_error);
+  MALIPUT_VALIDATE(std::find_if(bulb_groups_.begin(), bulb_groups_.end(),
+                                [](const auto& bulb_group) { return bulb_group == nullptr; }) == bulb_groups_.end(),
+                   "Found nulled bulb when creating TrafficLight.", maliput::common::traffic_light_book_error);
   for (auto& bulb_group : bulb_groups_) {
-    MALIPUT_THROW_RULES_UNLESS(
+    MALIPUT_VALIDATE(
         std::count_if(bulb_groups_.begin(), bulb_groups_.end(),
                       [bulb_group_id = bulb_group->id()](const auto& bg) { return bulb_group_id == bg->id(); }) == 1,
+        "BulbGroup with ID '" + bulb_group->id().string() + "' is not unique when creating TrafficLight.",
         maliput::common::traffic_light_book_error);
     bulb_group->SetTrafficLight({}, this);
   }

--- a/src/maliput/api/rules/traffic_lights.cc
+++ b/src/maliput/api/rules/traffic_lights.cc
@@ -72,9 +72,10 @@ Bulb::Bulb(const Bulb::Id& id, const InertialPosition& position_bulb_group, cons
       type_(type),
       arrow_orientation_rad_(arrow_orientation_rad),
       bounding_box_(std::move(bounding_box)) {
-  MALIPUT_THROW_UNLESS(type_ != BulbType::kArrow || arrow_orientation_rad_ != std::nullopt);
+  MALIPUT_THROW_RULES_UNLESS(type_ != BulbType::kArrow || arrow_orientation_rad_ != std::nullopt,
+                             maliput::common::traffic_light_book_error);
   if (type_ != BulbType::kArrow) {
-    MALIPUT_THROW_UNLESS(arrow_orientation_rad_ == std::nullopt);
+    MALIPUT_THROW_RULES_UNLESS(arrow_orientation_rad_ == std::nullopt, maliput::common::traffic_light_book_error);
   }
   if (states == std::nullopt || states->size() == 0) {
     states_ = {BulbState::kOff, BulbState::kOn};
@@ -97,8 +98,8 @@ bool Bulb::IsValidState(const BulbState& bulb_state) const {
 }
 
 UniqueBulbId Bulb::unique_id() const {
-  MALIPUT_THROW_UNLESS(bulb_group_ != nullptr);
-  MALIPUT_THROW_UNLESS(bulb_group_->traffic_light() != nullptr);
+  MALIPUT_THROW_RULES_UNLESS(bulb_group_ != nullptr, maliput::common::traffic_light_book_error);
+  MALIPUT_THROW_RULES_UNLESS(bulb_group_->traffic_light() != nullptr, maliput::common::traffic_light_book_error);
   return UniqueBulbId(bulb_group_->traffic_light()->id(), bulb_group_->id(), id_);
 }
 
@@ -108,12 +109,14 @@ BulbGroup::BulbGroup(const BulbGroup::Id& id, const InertialPosition& position_t
       position_traffic_light_(position_traffic_light),
       orientation_traffic_light_(orientation_traffic_light),
       bulbs_(std::move(bulbs)) {
-  MALIPUT_THROW_UNLESS(bulbs_.size() > 0);
-  MALIPUT_THROW_UNLESS(std::find_if(bulbs_.begin(), bulbs_.end(), [](const auto& bulb) { return bulb == nullptr; }) ==
-                       bulbs_.end());
+  MALIPUT_THROW_RULES_UNLESS(bulbs_.size() > 0, maliput::common::traffic_light_book_error);
+  MALIPUT_THROW_RULES_UNLESS(
+      std::find_if(bulbs_.begin(), bulbs_.end(), [](const auto& bulb) { return bulb == nullptr; }) == bulbs_.end(),
+      maliput::common::traffic_light_book_error);
   for (auto& bulb : bulbs_) {
-    MALIPUT_THROW_UNLESS(std::count_if(bulbs_.begin(), bulbs_.end(),
-                                       [bulb_id = bulb->id()](const auto& b) { return bulb_id == b->id(); }) == 1);
+    MALIPUT_THROW_RULES_UNLESS(std::count_if(bulbs_.begin(), bulbs_.end(),
+                                             [bulb_id = bulb->id()](const auto& b) { return bulb_id == b->id(); }) == 1,
+                               maliput::common::traffic_light_book_error);
     bulb->SetBulbGroup({}, this);
   }
 }
@@ -136,7 +139,7 @@ std::vector<const Bulb*> BulbGroup::bulbs() const {
 }
 
 UniqueBulbGroupId BulbGroup::unique_id() const {
-  MALIPUT_THROW_UNLESS(traffic_light_ != nullptr);
+  MALIPUT_THROW_RULES_UNLESS(traffic_light_ != nullptr, maliput::common::traffic_light_book_error);
   return UniqueBulbGroupId(traffic_light_->id(), id_);
 }
 
@@ -147,13 +150,15 @@ TrafficLight::TrafficLight(const TrafficLight::Id& id, const InertialPosition& p
       position_road_network_(position_road_network),
       orientation_road_network_(orientation_road_network),
       bulb_groups_(std::move(bulb_groups)) {
-  MALIPUT_THROW_UNLESS(std::find_if(bulb_groups_.begin(), bulb_groups_.end(), [](const auto& bulb_group) {
-                         return bulb_group == nullptr;
-                       }) == bulb_groups_.end());
+  MALIPUT_THROW_RULES_UNLESS(
+      std::find_if(bulb_groups_.begin(), bulb_groups_.end(),
+                   [](const auto& bulb_group) { return bulb_group == nullptr; }) == bulb_groups_.end(),
+      maliput::common::traffic_light_book_error);
   for (auto& bulb_group : bulb_groups_) {
-    MALIPUT_THROW_UNLESS(
+    MALIPUT_THROW_RULES_UNLESS(
         std::count_if(bulb_groups_.begin(), bulb_groups_.end(),
-                      [bulb_group_id = bulb_group->id()](const auto& bg) { return bulb_group_id == bg->id(); }) == 1);
+                      [bulb_group_id = bulb_group->id()](const auto& bg) { return bulb_group_id == bg->id(); }) == 1,
+        maliput::common::traffic_light_book_error);
     bulb_group->SetTrafficLight({}, this);
   }
 }

--- a/test/api/rule_registry_test.cc
+++ b/test/api/rule_registry_test.cc
@@ -79,15 +79,15 @@ GTEST_TEST(RegisterRangeValueRule, RegisterAndQueryTest) {
   EXPECT_NO_THROW(dut.RegisterRangeValueRule(kTypeA, {kRangeA, kRangeB}));
   EXPECT_NO_THROW(dut.RegisterRangeValueRule(kTypeB, {kRangeA}));
   // Throws because of duplicated type ID.
-  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeB, {kRangeA}), maliput::common::assertion_error);
+  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeB, {kRangeA}), maliput::common::rule_registry_error);
   EXPECT_THROW(dut.RegisterDiscreteValueRule(
                    kTypeB, {DiscreteValueRule::DiscreteValue{Rule::State::kStrict, api::test::CreateEmptyRelatedRules(),
                                                              api::test::CreateEmptyRelatedUniqueIds(), "SomeValue"}}),
-               maliput::common::assertion_error);
+               maliput::common::rule_registry_error);
   // Throws because of empty range vector.
-  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeC, {} /* ranges */), maliput::common::assertion_error);
+  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeC, {} /* ranges */), maliput::common::rule_registry_error);
   // Throws because of duplicated ranges.
-  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeC, {kRangeA, kRangeA}), maliput::common::assertion_error);
+  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeC, {kRangeA, kRangeA}), maliput::common::rule_registry_error);
 
   EXPECT_TRUE(dut.DiscreteValueRuleTypes().empty());
 
@@ -165,10 +165,10 @@ GTEST_TEST(RegisterDiscreteValueRule, RegisterAndQueryTest) {
   EXPECT_THROW(dut.RegisterDiscreteValueRule(
                    kTypeB, {DiscreteValueRule::DiscreteValue{Rule::State::kStrict, api::test::CreateEmptyRelatedRules(),
                                                              api::test::CreateEmptyRelatedUniqueIds(), "SomeValue"}}),
-               maliput::common::assertion_error);
-  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeB, {kRange}), maliput::common::assertion_error);
+               maliput::common::rule_registry_error);
+  EXPECT_THROW(dut.RegisterRangeValueRule(kTypeB, {kRange}), maliput::common::rule_registry_error);
   // Throws because of empty vector.
-  EXPECT_THROW(dut.RegisterDiscreteValueRule(Rule::TypeId("SomeRuleType"), {}), maliput::common::assertion_error);
+  EXPECT_THROW(dut.RegisterDiscreteValueRule(Rule::TypeId("SomeRuleType"), {}), maliput::common::rule_registry_error);
 
   EXPECT_TRUE(dut.RangeValueRuleTypes().empty());
 
@@ -276,10 +276,10 @@ GTEST_TEST(RegisterAndBuildTest, RegisterAndBuild) {
 
   // Unregistered type.
   EXPECT_THROW(dut.BuildRangeValueRule(Rule::Id("RuleId"), kUnregisteredRuleType, kZone, {kRangeA}),
-               maliput::common::assertion_error);
+               maliput::common::rule_registry_error);
   // Unregistered range.
   EXPECT_THROW(dut.BuildRangeValueRule(Rule::Id("RuleId"), kUnregisteredRuleType, kZone, {kUnregisteredRange}),
-               maliput::common::assertion_error);
+               maliput::common::rule_registry_error);
 
   // Builds and evaluates a discrete value based rule.
   const RuleRegistry::QueryResult::DiscreteValues kExpectedDiscreteValues{
@@ -296,11 +296,11 @@ GTEST_TEST(RegisterAndBuildTest, RegisterAndBuild) {
 
   // Unregistered type.
   EXPECT_THROW(dut.BuildDiscreteValueRule(Rule::Id("RuleId"), kUnregisteredRuleType, kZone, kExpectedDiscreteValues),
-               maliput::common::assertion_error);
+               maliput::common::rule_registry_error);
   // Unregistered discrete value for the type.
   EXPECT_THROW(
       dut.BuildDiscreteValueRule(kDiscreteValueRuleId, kDiscreteValueRuleType, kZone, {kUnregisteredDiscreteValue}),
-      maliput::common::assertion_error);
+      maliput::common::rule_registry_error);
 }
 
 }  // namespace test

--- a/test/api/rule_test.cc
+++ b/test/api/rule_test.cc
@@ -87,7 +87,7 @@ TEST_F(RuleTest, RangeValueRuleConstructor) {
       RangeValueRule::Range{Rule::State::kStrict,  kDuplicatedRelatedRules, api::test::CreateEmptyRelatedUniqueIds(),
                             "range_description_1", 123. /* min */,          456. /* max */};
   EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithDuplicatedRelatedRulesIds}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Duplicated UniqueIds in RelatedUniqueIds in RangeValueRule::Range.
   const Rule::RelatedUniqueIds kDuplicatedRelatedUniqueIds{
@@ -102,14 +102,14 @@ TEST_F(RuleTest, RangeValueRuleConstructor) {
                             123. /* min */,
                             456. /* max */};
   EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithDuplicatedRelatedUniqueIds}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Empty std::string for semantic group key in RelatedRules in RangeValueRule::Range.
   const Rule::RelatedRules kEmptyKeyRelatedRules{{"", {Rule::Id("RuleTypeIdB/RuleIdB")}}};
   const RangeValueRule::Range kRangeWithEmptyKeyRelatedRules =
       RangeValueRule::Range{Rule::State::kStrict,  kEmptyKeyRelatedRules, api::test::CreateEmptyRelatedUniqueIds(),
                             "range_description_1", 123. /* min */,        456. /* max */};
-  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithEmptyKeyRelatedRules}), maliput::common::assertion_error);
+  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithEmptyKeyRelatedRules}), maliput::common::rulebook_error);
 
   // Empty std::string for semantic group key in RelatedUniqueIds in RangeValueRule::Range.
   const Rule::RelatedUniqueIds kEmptyKeyRelatedUniqueIds{
@@ -122,7 +122,7 @@ TEST_F(RuleTest, RangeValueRuleConstructor) {
                             123. /* min */,
                             456. /* max */};
   EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kRangeWithEmptyKeyRelatedUniqueIds}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Negative severity.
   const int kSeverityInvalid{-1};
@@ -130,9 +130,9 @@ TEST_F(RuleTest, RangeValueRuleConstructor) {
                               {RangeValueRule::Range{kSeverityInvalid, api::test::CreateNonEmptyRelatedRules(),
                                                      api::test::CreateEmptyRelatedUniqueIds(), "range_description_1",
                                                      123. /* min */, 456. /* max */}}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
   // Empty ranges.
-  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {} /* ranges */), maliput::common::assertion_error);
+  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {} /* ranges */), maliput::common::rulebook_error);
   // Duplicated ranges.
   const std::vector<RangeValueRule::Range> kDuplicatedRanges{
       RangeValueRule::Range{Rule::State::kStrict, api::test::CreateEmptyRelatedRules(),
@@ -142,13 +142,13 @@ TEST_F(RuleTest, RangeValueRuleConstructor) {
                             api::test::CreateEmptyRelatedUniqueIds(), "range_description_1", 123. /* min */,
                             456. /* max */},
   };
-  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, kDuplicatedRanges), maliput::common::assertion_error);
+  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, kDuplicatedRanges), maliput::common::rulebook_error);
 
   // RangeValueRule::Range::min is greater than RangeValueRule::Range::max.
   const std::vector<RangeValueRule::Range> kShiftedRanges{RangeValueRule::Range{
       Rule::State::kStrict, api::test::CreateEmptyRelatedRules(), api::test::CreateEmptyRelatedUniqueIds(),
       "range_description_3", 456. /* min */, 123. /* max */}};
-  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kShiftedRanges}), maliput::common::assertion_error);
+  EXPECT_THROW(RangeValueRule(kId, kTypeId, kZone, {kShiftedRanges}), maliput::common::rulebook_error);
 }
 
 // Evaluates RangeValueRule accessors.
@@ -316,7 +316,7 @@ TEST_F(RuleTest, DiscreteValueRuleConstructor) {
                    kId, kTypeId, kZone,
                    {DiscreteValueRule::DiscreteValue{kSeverityInvalid, api::test::CreateEmptyRelatedRules(),
                                                      api::test::CreateEmptyRelatedUniqueIds(), "rule_state_value"}}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Duplicated Rule::Ids in RelatedRules in DiscreteValueRule::DiscreteValue.
   const Rule::RelatedRules kDuplicatedRelatedRules{
@@ -324,7 +324,7 @@ TEST_F(RuleTest, DiscreteValueRuleConstructor) {
   const DiscreteValueRule::DiscreteValue kDiscreteValueWithDuplicatedRules = DiscreteValueRule::DiscreteValue{
       Rule::State::kStrict, kDuplicatedRelatedRules, api::test::CreateEmptyRelatedUniqueIds(), "rule_state_value"};
   EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {kDiscreteValueWithDuplicatedRules}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Duplicated UniqueIds in RelatedUniqueIds in DiscreteValueRule::DiscreteValue.
   const Rule::RelatedUniqueIds kDuplicatedRelatedUniqueIds{
@@ -335,7 +335,7 @@ TEST_F(RuleTest, DiscreteValueRuleConstructor) {
       DiscreteValueRule::DiscreteValue{Rule::State::kStrict, api::test::CreateEmptyRelatedRules(),
                                        kDuplicatedRelatedUniqueIds, "rule_state_value"};
   EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {kDiscreteValueWithDuplicatedRelatedUniqueIds}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Duplicated discrete values.
   const std::vector<DiscreteValueRule::DiscreteValue> kDuplicatedDiscreteValues{
@@ -343,14 +343,14 @@ TEST_F(RuleTest, DiscreteValueRuleConstructor) {
                                        api::test::CreateEmptyRelatedUniqueIds(), "rule_state_value_1"},
       DiscreteValueRule::DiscreteValue{Rule::State::kStrict, api::test::CreateNonEmptyRelatedRules(),
                                        api::test::CreateEmptyRelatedUniqueIds(), "rule_state_value_1"}};
-  EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, kDuplicatedDiscreteValues), maliput::common::assertion_error);
+  EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, kDuplicatedDiscreteValues), maliput::common::rulebook_error);
 
   // Empty std::string for semantic group key in RelatedRules in DiscreteValueRule::DiscreteValue.
   const Rule::RelatedRules kEmptyKeyRelatedRules{{"", {Rule::Id("RuleTypeIdB/RuleIdB")}}};
   const DiscreteValueRule::DiscreteValue kDiscreteValueWithEmptyKeyRelatedRules = DiscreteValueRule::DiscreteValue{
       Rule::State::kStrict, kEmptyKeyRelatedRules, api::test::CreateEmptyRelatedUniqueIds(), "rule_state_value"};
   EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {kDiscreteValueWithEmptyKeyRelatedRules}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Empty std::string for semantic group key in RelatedUniqueIds in DiscreteValueRule::DiscreteValue.
   const Rule::RelatedUniqueIds kEmptyKeyRelatedUniqueIds{
@@ -358,10 +358,10 @@ TEST_F(RuleTest, DiscreteValueRuleConstructor) {
   const DiscreteValueRule::DiscreteValue kDiscreteValueWithEmptyKeyRelatedUniqueIds = DiscreteValueRule::DiscreteValue{
       Rule::State::kStrict, api::test::CreateEmptyRelatedRules(), kEmptyKeyRelatedUniqueIds, "rule_state_value"};
   EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {kDiscreteValueWithEmptyKeyRelatedUniqueIds}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 
   // Empty discrete values.
-  EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {} /* discrete_values */), maliput::common::assertion_error);
+  EXPECT_THROW(DiscreteValueRule(kId, kTypeId, kZone, {} /* discrete_values */), maliput::common::rulebook_error);
 }
 
 // Evaluates DiscreteValueRule accessors.

--- a/test/api/rules_right_of_way_test.cc
+++ b/test/api/rules_right_of_way_test.cc
@@ -110,7 +110,7 @@ GTEST_TEST(RightOfWayRuleTest, Construction) {
   EXPECT_THROW(RightOfWayRule(RightOfWayRule::Id("some_id"), api::test::CreateLaneSRoute(),
                               RightOfWayRule::ZoneType::kStopExcluded, {api::test::NoYieldState()},
                               RightOfWayRule::RelatedBulbGroups{{kTrafficLightId, {kBulbGroupId, kBulbGroupId}}}),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 }
 
 GTEST_TEST(RightOfWayRuleTest, Accessors) {

--- a/test/api/rules_road_rulebook_test.cc
+++ b/test/api/rules_road_rulebook_test.cc
@@ -157,7 +157,7 @@ GTEST_TEST(RoadRulebookTest, ExerciseInterface) {
   EXPECT_EQ(static_cast<int>(empty.range_value_rules.size()), 0);
 
   const double kNegativeTolerance = -1.;
-  EXPECT_THROW(dut.FindRules({}, kNegativeTolerance), maliput::common::assertion_error);
+  EXPECT_THROW(dut.FindRules({}, kNegativeTolerance), maliput::common::rulebook_error);
 
   nonempty = dut.Rules();
   EXPECT_EQ(static_cast<int>(nonempty.right_of_way.size()), 1);

--- a/test/api/rules_speed_limit_test.cc
+++ b/test/api/rules_speed_limit_test.cc
@@ -58,12 +58,12 @@ GTEST_TEST(SpeedLimitRuleTest, Construction) {
 
   // Min must not be greater than max.
   EXPECT_THROW(SpeedLimitRule(SpeedLimitRule::Id("some_id"), kZone, SpeedLimitRule::Severity::kStrict, 90., 77.),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
   // Negative limits are not allowed.
   EXPECT_THROW(SpeedLimitRule(SpeedLimitRule::Id("some_id"), kZone, SpeedLimitRule::Severity::kStrict, -8., 77.),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
   EXPECT_THROW(SpeedLimitRule(SpeedLimitRule::Id("some_id"), kZone, SpeedLimitRule::Severity::kStrict, -8., -6.),
-               maliput::common::assertion_error);
+               maliput::common::rulebook_error);
 }
 
 GTEST_TEST(SpeedLimitRuleTest, Accessors) {

--- a/test/api/traffic_lights_test.cc
+++ b/test/api/traffic_lights_test.cc
@@ -151,7 +151,7 @@ class BulbTest : public ::testing::Test {
 
 TEST_F(BulbTest, Accessors) {
   EXPECT_EQ(bulb_.id(), Bulb::Id("dut_id"));
-  EXPECT_THROW(bulb_.unique_id(), common::assertion_error);
+  EXPECT_THROW(bulb_.unique_id(), common::traffic_light_book_error);
   EXPECT_EQ(bulb_.position_bulb_group(), InertialPosition(1, 2, 3));
   EXPECT_EQ(bulb_.orientation_bulb_group().matrix(), Rotation::FromRpy(4, 5, 6).matrix());
   EXPECT_EQ(bulb_.color(), BulbColor::kRed);
@@ -215,7 +215,7 @@ TEST_F(BulbGroupConstructorTest, DuplicatedBulbIds) {
   bulbs.push_back(std::make_unique<Bulb>(kBulbId, kZeroPosition, kZeroRotation, BulbColor::kRed, BulbType::kRound));
   bulbs.push_back(
       std::make_unique<Bulb>(kBulbId, InertialPosition(0, 0, 0.3), kZeroRotation, BulbColor::kGreen, BulbType::kRound));
-  EXPECT_THROW(BulbGroup(kDutId, kDutPosition, kDutRotation, std::move(bulbs)), common::assertion_error);
+  EXPECT_THROW(BulbGroup(kDutId, kDutPosition, kDutRotation, std::move(bulbs)), common::traffic_light_book_error);
 }
 
 TEST_F(BulbGroupConstructorTest, NullBulb) {
@@ -223,7 +223,7 @@ TEST_F(BulbGroupConstructorTest, NullBulb) {
   bulbs.push_back(std::make_unique<Bulb>(kBulbId, kZeroPosition, kZeroRotation, BulbColor::kRed, BulbType::kRound));
   bulbs.push_back({});
 
-  EXPECT_THROW(BulbGroup(kDutId, kDutPosition, kDutRotation, std::move(bulbs)), common::assertion_error);
+  EXPECT_THROW(BulbGroup(kDutId, kDutPosition, kDutRotation, std::move(bulbs)), common::traffic_light_book_error);
 }
 
 class BulbGroupTest : public ::testing::Test {
@@ -262,7 +262,7 @@ TEST_F(BulbGroupTest, Accessors) {
   EXPECT_EQ(static_cast<int>(bulb_group_->bulbs().size()), 3);
   EXPECT_EQ(bulb_group_->GetBulb(Bulb::Id("unknown_bulb")), nullptr);
   EXPECT_EQ(bulb_group_->GetBulb(Bulb::Id("red_bulb")), red_bulb_ptr_);
-  EXPECT_THROW(bulb_group_->unique_id(), common::assertion_error);
+  EXPECT_THROW(bulb_group_->unique_id(), common::traffic_light_book_error);
 }
 
 class TrafficLightConstructorTest : public ::testing::Test {
@@ -279,7 +279,8 @@ TEST_F(TrafficLightConstructorTest, DuplicatedBulbGroupIds) {
   std::vector<std::unique_ptr<BulbGroup>> bulb_group;
   bulb_group.push_back(api::test::CreateBulbGroup(false /* add_missing_bulb_group */));
   bulb_group.push_back(api::test::CreateBulbGroup(false /* add_missing_bulb_group */));
-  EXPECT_THROW(TrafficLight(kDutId, kZeroPosition, kZeroRotation, std::move(bulb_group)), common::assertion_error);
+  EXPECT_THROW(TrafficLight(kDutId, kZeroPosition, kZeroRotation, std::move(bulb_group)),
+               common::traffic_light_book_error);
 }
 
 TEST_F(TrafficLightConstructorTest, NullBulbGroup) {
@@ -288,7 +289,8 @@ TEST_F(TrafficLightConstructorTest, NullBulbGroup) {
   bulbs.push_back(std::make_unique<Bulb>(kRedBulbId, kZeroPosition, kZeroRotation, BulbColor::kRed, BulbType::kRound));
   bulb_group.push_back(std::make_unique<BulbGroup>(kBulbGroupId, kZeroPosition, kZeroRotation, std::move(bulbs)));
   bulb_group.push_back({});
-  EXPECT_THROW(TrafficLight(kDutId, kZeroPosition, kZeroRotation, std::move(bulb_group)), common::assertion_error);
+  EXPECT_THROW(TrafficLight(kDutId, kZeroPosition, kZeroRotation, std::move(bulb_group)),
+               common::traffic_light_book_error);
 }
 
 class TrafficLightTest : public ::testing::Test {

--- a/test/common/maliput_throw_test.cc
+++ b/test/common/maliput_throw_test.cc
@@ -44,15 +44,34 @@ GTEST_TEST(MaliputThrowTest, ExpectThrowAndNoThrowTest) {
   EXPECT_NO_THROW({ MALIPUT_THROW_UNLESS(true); });
 }
 
+// Evaluates whether or not MALIPUT_THROW_UNLESS() throws with a custom exception.
+GTEST_TEST(MaliputThrowTest, CustomExceptionTest) {
+  EXPECT_THROW({ MALIPUT_THROW_UNLESS(false, road_geometry_construction_error); }, road_geometry_construction_error);
+  EXPECT_NO_THROW({ MALIPUT_THROW_UNLESS(true, road_geometry_construction_error); });
+}
+
 // Evaluates whether or not MALIPUT_THROW_UNLESS() throws.
 GTEST_TEST(MaliputThrowMessageTest, ExpectThrowWithMessageTest) {
   EXPECT_THROW({ MALIPUT_THROW_MESSAGE("Exception description"); }, assertion_error);
+}
+
+// Evaluates whether or not MALIPUT_THROW_MESSAGE() throws with a custom exception.
+GTEST_TEST(MaliputThrowMessageTest, CustomExceptionTest) {
+  EXPECT_THROW({ MALIPUT_THROW_MESSAGE("Exception description", road_geometry_construction_error); },
+               road_geometry_construction_error);
 }
 
 // Evaluates whether or not MALIPUT_VALIDATE() throws.
 GTEST_TEST(MaliputValidateTest, Test) {
   EXPECT_THROW({ MALIPUT_VALIDATE(false, "Exception description"); }, assertion_error);
   EXPECT_NO_THROW({ MALIPUT_VALIDATE(true, "Exception description"); });
+}
+
+// Evaluates whether or not MALIPUT_VALIDATE() throws with a custom exception.
+GTEST_TEST(MaliputValidateTest, CustomExceptionTest) {
+  EXPECT_THROW({ MALIPUT_VALIDATE(false, "Exception description", road_geometry_construction_error); },
+               road_geometry_construction_error);
+  EXPECT_NO_THROW({ MALIPUT_VALIDATE(true, "Exception description", road_geometry_construction_error); });
 }
 
 // Evaluates whether or not MALIPUT_IS_IN_RANGE() throws.


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput-rs/issues/183

## Summary
* Creates new runtime exception types for maliput errors related to the creation and usage of the rulebook, phases, rule registry, traffic lights and state provider.
* Replaces all throws of `assertion_error` in rule-related features within maliput with:
  * `rulebook_error`
  * `rule_registry_error`
  * `phase_book_error`
  * `traffic_lights_error`
  * `state_provider_error`
* Improves some of the thrown errors by adding a helpful message for the user to debug.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
