### PR TITLE
Update macOS version for build workflow

### DIFF
--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -35,8 +35,3 @@ jobs:
         shell: bash
         run: |
           bazel build //...
-
-      - name: Test
-        shell: bash
-        run: |
-          bazel test //... --test_output=all


### PR DESCRIPTION
# 🦟 Bug fix

Runner macos-13 is deprecated: https://github.com/maliput/maliput/actions/runs/20307834270

