### PR TITLE
Obtain handles to already loaded plugins.

### DIFF
--- a/include/maliput/plugin/maliput_plugin.h
+++ b/include/maliput/plugin/maliput_plugin.h
@@ -71,7 +71,14 @@ class MaliputPlugin {
   /// Constructs a MaliputPlugin
   /// @param path_to_lib Path to the library.
   /// @throws maliput::common::assertion_error When `path_to_lib` is empty.
-  MaliputPlugin(const std::string& path_to_lib);
+  explicit MaliputPlugin(const std::string& path_to_lib);
+
+  /// Constructs a MaliputPlugin from an existing dlopen handle.
+  /// This is useful when the library is already loaded in memory (e.g., as an ELF NEEDED dependency)
+  /// and can be retrieved via dlopen() with RTLD_NOLOAD flag.
+  /// @param lib_handle An existing handle from dlopen() (ownership is transferred).
+  /// @throws maliput::common::assertion_error When `lib_handle` is nullptr.
+  explicit MaliputPlugin(void* lib_handle);
 
   MaliputPlugin() = delete;
 

--- a/src/maliput/plugin/maliput_plugin.cc
+++ b/src/maliput/plugin/maliput_plugin.cc
@@ -44,5 +44,12 @@ MaliputPlugin::MaliputPlugin(const std::string& path_to_lib) {
   type_ = ExecuteSymbol<MaliputPluginType>(kMaliputPluginTypeSym);
 }
 
+MaliputPlugin::MaliputPlugin(void* lib_handle) {
+  MALIPUT_THROW_UNLESS(lib_handle != nullptr);
+  lib_handle_.reset(lib_handle);
+  id_ = MaliputPlugin::Id(ExecuteSymbol<char*>(kMaliputPluginIdSym));
+  type_ = ExecuteSymbol<MaliputPluginType>(kMaliputPluginTypeSym);
+}
+
 }  // namespace plugin
 }  // namespace maliput

--- a/test/plugin/maliput_plugin_test.cc
+++ b/test/plugin/maliput_plugin_test.cc
@@ -34,6 +34,8 @@
 
 #include "maliput/plugin/maliput_plugin.h"
 
+#include <dlfcn.h>
+
 #include <string>
 
 #include <gtest/gtest.h>
@@ -67,6 +69,49 @@ GTEST_TEST(MaliputPlugin, FunctionsCall) {
 
   EXPECT_THROW(maliput_plugin.ExecuteSymbol<double>(kWrongSymbol), maliput::common::assertion_error);
   EXPECT_EQ(200, maliput_plugin.ExecuteSymbol<int>(kCustomSymbol, 10, 20));
+}
+
+// MaliputPlugin's constructor receives a nullptr handle.
+GTEST_TEST(MaliputPlugin, NullHandle) { EXPECT_THROW(MaliputPlugin{nullptr}, maliput::common::assertion_error); }
+
+// MaliputPlugin's constructor receives a valid dlopen handle.
+GTEST_TEST(MaliputPlugin, ConstructFromHandle) {
+  const std::string kLibraryPath{"/tmp/maliput/test/plugins/libmaliput_multiply_integers_test_plugin.so"};
+  const std::string kCustomSymbol{"MultiplyIntegers"};
+
+  // Manually load the library with dlopen.
+  void* handle = dlopen(kLibraryPath.c_str(), RTLD_LAZY | RTLD_LOCAL);
+  ASSERT_NE(nullptr, handle) << "Failed to load library: " << dlerror();
+
+  // Create plugin from handle (ownership is transferred to MaliputPlugin).
+  const MaliputPlugin maliput_plugin{handle};
+  EXPECT_EQ("multiply_integers_test_plugin", maliput_plugin.GetId());
+  EXPECT_EQ(MaliputPluginType::kRoadNetworkLoader, maliput_plugin.GetType());
+  EXPECT_EQ(200, maliput_plugin.ExecuteSymbol<int>(kCustomSymbol, 10, 20));
+}
+
+// Simulates RTLD_NOLOAD behavior: load a library first, then use RTLD_NOLOAD to get a handle.
+GTEST_TEST(MaliputPlugin, ConstructFromPreloadedHandle) {
+  const std::string kLibraryPath{"/tmp/maliput/test/plugins/libmaliput_multiply_integers_test_plugin.so"};
+  const std::string kCustomSymbol{"MultiplyIntegers"};
+
+  // First, load the library (simulating what happens when it's an ELF NEEDED dependency).
+  void* preload_handle = dlopen(kLibraryPath.c_str(), RTLD_LAZY | RTLD_LOCAL);
+  ASSERT_NE(nullptr, preload_handle) << "Failed to preload library: " << dlerror();
+
+  // Now use RTLD_NOLOAD to get a handle to the already-loaded library (by name only).
+  const std::string kLibraryName{"libmaliput_multiply_integers_test_plugin.so"};
+  void* noload_handle = dlopen(kLibraryName.c_str(), RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
+  ASSERT_NE(nullptr, noload_handle) << "RTLD_NOLOAD failed to find preloaded library";
+
+  // Create plugin from the RTLD_NOLOAD handle.
+  const MaliputPlugin maliput_plugin{noload_handle};
+  EXPECT_EQ("multiply_integers_test_plugin", maliput_plugin.GetId());
+  EXPECT_EQ(MaliputPluginType::kRoadNetworkLoader, maliput_plugin.GetType());
+  EXPECT_EQ(200, maliput_plugin.ExecuteSymbol<int>(kCustomSymbol, 10, 20));
+
+  // Clean up the preload handle (MaliputPlugin owns noload_handle).
+  dlclose(preload_handle);
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

## Summary

There might be the case in downstream projects that the plugin is already loaded in memory. Handle with this situations to avoid having to loaded it again.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
