### PR TITLE
Expanding radius based on KDTree sampling step for FindRoadPositions

### DIFF
--- a/src/maliput/geometry_base/kd_tree_strategy.cc
+++ b/src/maliput/geometry_base/kd_tree_strategy.cc
@@ -83,7 +83,10 @@ api::RoadPositionResult KDTreeStrategy::DoToRoadPosition(const api::InertialPosi
 
 std::vector<api::RoadPositionResult> KDTreeStrategy::DoFindRoadPositions(const api::InertialPosition& inertial_position,
                                                                          double radius) const {
-  const auto closest_lanes = this->ClosestLanes(inertial_position, radius);
+  // Expand candidate-lane lookup to compensate for sparse KD-tree sampling.
+  // Exact 3D radius semantics are preserved by filtering on lane_position.distance below.
+  const double candidate_half_edge_length = radius + 2. * sampling_step_;
+  const auto closest_lanes = this->ClosestLanes(inertial_position, candidate_half_edge_length);
   std::vector<api::RoadPositionResult> road_positions;
   for (const auto& lane : closest_lanes) {
     MALIPUT_THROW_UNLESS(lane != nullptr);


### PR DESCRIPTION
# 🦟 Bug fix

No issue attached

## Summary

Expands the KDTree search strategy for FindRoadPositions  based on the sampling step for the kd tree, similar to how FindSurfaceRoadPositionsAtXY does

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
