### PR TITLE
Add API for traffic sign values and unit.

### DIFF
--- a/docs/traffic_sign.md
+++ b/docs/traffic_sign.md
@@ -37,6 +37,7 @@ A traffic sign can declare which lanes it is physically relevant to via `related
 | `message` | `optional<string>` | Optional text on the sign (e.g., `"60"` on a speed limit sign) |
 | `related_lanes` | `vector<LaneId>` | Lanes this sign is physically relevant to |
 | `bounding_box` | `maliput::math::BoundingBox` | Bounding box in the sign's local frame |
+| `value` | `optional<TrafficSignValue>` | Optional numeric value with unit (e.g., 60 km/h for speed limit) |
 
 ### Sign Types
 

--- a/include/maliput/api/rules/traffic_sign.h
+++ b/include/maliput/api/rules/traffic_sign.h
@@ -67,6 +67,40 @@ enum class TrafficSignType {
 /// Maps TrafficSignType enums to string representations.
 std::unordered_map<TrafficSignType, const char*, maliput::common::DefaultHash> TrafficSignTypeMapper();
 
+/// Defines the unit for a traffic sign's numeric value.
+/// These correspond to the units used in the XODR signal definition.
+enum class TrafficSignValueUnit {
+  kMetersPerSecond = 0,  ///< m/s
+  kKilometersPerHour,    ///< km/h
+  kMilesPerHour,         ///< mph
+  kMeters,               ///< m
+  kKilometers,           ///< km
+  kFeet,                 ///< ft
+  kMiles,                ///< mile
+  kPercent,              ///< %
+  kKilograms,            ///< kg
+  kMetricTons,           ///< t (metric tons)
+};
+
+/// Maps TrafficSignValueUnit enums to string representations.
+std::unordered_map<TrafficSignValueUnit, const char*, maliput::common::DefaultHash> TrafficSignValueUnitMapper();
+
+/// Holds a numeric value and its associated unit for a traffic sign.
+///
+/// For example, a speed limit sign might have value=60 with
+/// unit=TrafficSignValueUnit::kKilometersPerHour.
+struct TrafficSignValue {
+  /// Equality operator.
+  bool operator==(const TrafficSignValue& other) const { return value == other.value && unit == other.unit; }
+  /// Inequality operator.
+  bool operator!=(const TrafficSignValue& other) const { return !(*this == other); }
+
+  /// The numeric value of the sign.
+  double value{};
+  /// The unit of the value.
+  TrafficSignValueUnit unit{TrafficSignValueUnit::kMetersPerSecond};
+};
+
 /// Models a physical traffic sign — a static, passive signaling device
 /// placed along or above the road to convey regulatory, warning, or
 /// informational messages to road users.
@@ -111,9 +145,14 @@ class TrafficSign final {
   ///
   /// @param bounding_box The bounding box of the sign. The position and
   /// orientation are in the sign's local frame.
+  ///
+  /// @param value An optional numeric value associated with the sign (e.g.,
+  /// 60 km/h for a speed limit sign). Corresponds to the value/unit pair
+  /// from the XODR signal definition.
   TrafficSign(const Id& id, const TrafficSignType& type, const InertialPosition& position_road_network,
               const Rotation& orientation_road_network, const std::optional<std::string>& message,
-              std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box);
+              std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box,
+              const std::optional<TrafficSignValue>& value = std::nullopt);
 
   /// Returns this sign's unique identifier.
   const Id& id() const { return id_; }
@@ -143,6 +182,12 @@ class TrafficSign final {
   /// Returns the bounding box of this sign.
   const maliput::math::BoundingBox& bounding_box() const { return bounding_box_; }
 
+  /// Returns the numeric value associated with this sign, if any.
+  ///
+  /// For example, a speed limit sign would return the speed value and its
+  /// unit (e.g., {60.0, TrafficSignValueUnit::kKilometersPerHour}).
+  const std::optional<TrafficSignValue>& GetValue() const { return value_; }
+
  private:
   Id id_;
   TrafficSignType type_;
@@ -151,6 +196,7 @@ class TrafficSign final {
   std::optional<std::string> message_;
   std::vector<LaneId> related_lanes_;
   maliput::math::BoundingBox bounding_box_;
+  std::optional<TrafficSignValue> value_;
 };
 
 }  // namespace rules

--- a/src/maliput/api/rules/traffic_sign.cc
+++ b/src/maliput/api/rules/traffic_sign.cc
@@ -53,16 +53,33 @@ std::unordered_map<TrafficSignType, const char*, maliput::common::DefaultHash> T
   return result;
 }
 
+std::unordered_map<TrafficSignValueUnit, const char*, maliput::common::DefaultHash> TrafficSignValueUnitMapper() {
+  std::unordered_map<TrafficSignValueUnit, const char*, maliput::common::DefaultHash> result;
+  result.emplace(TrafficSignValueUnit::kMetersPerSecond, "m/s");
+  result.emplace(TrafficSignValueUnit::kKilometersPerHour, "km/h");
+  result.emplace(TrafficSignValueUnit::kMilesPerHour, "mph");
+  result.emplace(TrafficSignValueUnit::kMeters, "m");
+  result.emplace(TrafficSignValueUnit::kKilometers, "km");
+  result.emplace(TrafficSignValueUnit::kFeet, "ft");
+  result.emplace(TrafficSignValueUnit::kMiles, "mile");
+  result.emplace(TrafficSignValueUnit::kPercent, "%");
+  result.emplace(TrafficSignValueUnit::kKilograms, "kg");
+  result.emplace(TrafficSignValueUnit::kMetricTons, "t");
+  return result;
+}
+
 TrafficSign::TrafficSign(const Id& id, const TrafficSignType& type, const InertialPosition& position_road_network,
                          const Rotation& orientation_road_network, const std::optional<std::string>& message,
-                         std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box)
+                         std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box,
+                         const std::optional<TrafficSignValue>& value)
     : id_(id),
       type_(type),
       position_road_network_(position_road_network),
       orientation_road_network_(orientation_road_network),
       message_(message),
       related_lanes_(std::move(related_lanes)),
-      bounding_box_(bounding_box) {}
+      bounding_box_(bounding_box),
+      value_(value) {}
 
 }  // namespace rules
 }  // namespace api

--- a/test/api/traffic_sign_test.cc
+++ b/test/api/traffic_sign_test.cc
@@ -138,6 +138,54 @@ GTEST_TEST(TrafficSignTest, ConstructorWithCustomBoundingBox) {
   EXPECT_DOUBLE_EQ(bb.box_size().z(), 1.2);
 }
 
+GTEST_TEST(TrafficSignTest, ConstructorWithValue) {
+  const TrafficSign::Id kId("speed_limit_100");
+  const TrafficSignType kType = TrafficSignType::kSpeedLimit;
+  const InertialPosition kPosition(10., 20., 3.);
+  const Rotation kOrientation = Rotation::FromRpy(0., 0., 0.);
+  const maliput::math::BoundingBox kBoundingBox(maliput::math::Vector3(0., 0., 0.),
+                                                maliput::math::Vector3(0.05, 0.762, 0.762),
+                                                maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
+  const TrafficSignValue kValue{100.0, TrafficSignValueUnit::kKilometersPerHour};
+
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox, kValue);
+
+  EXPECT_EQ(dut.id(), kId);
+  EXPECT_EQ(dut.type(), kType);
+  EXPECT_TRUE(dut.GetValue().has_value());
+  EXPECT_DOUBLE_EQ(dut.GetValue()->value, 100.0);
+  EXPECT_EQ(dut.GetValue()->unit, TrafficSignValueUnit::kKilometersPerHour);
+}
+
+GTEST_TEST(TrafficSignTest, ConstructorWithoutValue) {
+  const TrafficSign::Id kId("stop_sign");
+  const TrafficSignType kType = TrafficSignType::kStop;
+  const InertialPosition kPosition(1., 2., 3.);
+  const Rotation kOrientation = Rotation::FromRpy(0., 0., 0.);
+  const maliput::math::BoundingBox kBoundingBox(maliput::math::Vector3(0., 0., 0.),
+                                                maliput::math::Vector3(0.05, 0.762, 0.762),
+                                                maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
+
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox);
+
+  EXPECT_FALSE(dut.GetValue().has_value());
+}
+
+GTEST_TEST(TrafficSignValueUnitTest, MapperTest) {
+  const auto dut = TrafficSignValueUnitMapper();
+  const std::vector<TrafficSignValueUnit> expected_units{
+      TrafficSignValueUnit::kMetersPerSecond, TrafficSignValueUnit::kKilometersPerHour,
+      TrafficSignValueUnit::kMilesPerHour,    TrafficSignValueUnit::kMeters,
+      TrafficSignValueUnit::kKilometers,      TrafficSignValueUnit::kFeet,
+      TrafficSignValueUnit::kMiles,           TrafficSignValueUnit::kPercent,
+      TrafficSignValueUnit::kKilograms,       TrafficSignValueUnit::kMetricTons,
+  };
+  EXPECT_EQ(dut.size(), expected_units.size());
+  for (TrafficSignValueUnit unit : expected_units) {
+    EXPECT_EQ(static_cast<int>(dut.count(unit)), 1);
+  }
+}
+
 }  // namespace
 }  // namespace rules
 }  // namespace api


### PR DESCRIPTION
# 🎉 New feature

## Summary
* New API for `TrafficSign` Value and Unit.
* Create mapper to assign units from the backend values.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
