### PR TITLE
Adding properties API to traffic signs

### DIFF
--- a/include/maliput/api/rules/traffic_sign.h
+++ b/include/maliput/api/rules/traffic_sign.h
@@ -152,10 +152,13 @@ class TrafficSign final {
   /// @param value An optional numeric value associated with the sign (e.g.,
   /// 60 km/h for a speed limit sign). Corresponds to the value/unit pair
   /// from the XODR signal definition.
+  ///
+  /// @param properties Optional backend-specific properties.
   TrafficSign(const Id& id, const TrafficSignType& type, const InertialPosition& position_road_network,
               const Rotation& orientation_road_network, const std::optional<std::string>& message,
               std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box,
-              const std::optional<TrafficSignValue>& value = std::nullopt);
+              const std::optional<TrafficSignValue>& value = std::nullopt,
+              std::unordered_map<std::string, std::string> properties = {});
 
   /// Returns this sign's unique identifier.
   const Id& id() const { return id_; }
@@ -191,6 +194,12 @@ class TrafficSign final {
   /// unit (e.g., {60.0, TrafficSignValueUnit::kKilometersPerHour}).
   const std::optional<TrafficSignValue>& GetValue() const { return value_; }
 
+  /// Returns backend-specific properties as key-value pairs.
+  ///
+  /// This provides access to additional properties that may be specific to
+  /// a particular backend implementation (e.g., OpenDRIVE-specific attributes).
+  const std::unordered_map<std::string, std::string>& properties() const { return properties_; }
+
  private:
   Id id_;
   TrafficSignType type_;
@@ -200,6 +209,7 @@ class TrafficSign final {
   std::vector<LaneId> related_lanes_;
   maliput::math::BoundingBox bounding_box_;
   std::optional<TrafficSignValue> value_;
+  std::unordered_map<std::string, std::string> properties_;
 };
 
 }  // namespace rules

--- a/src/maliput/api/rules/traffic_sign.cc
+++ b/src/maliput/api/rules/traffic_sign.cc
@@ -74,7 +74,8 @@ std::unordered_map<TrafficSignValueUnit, const char*, maliput::common::DefaultHa
 TrafficSign::TrafficSign(const Id& id, const TrafficSignType& type, const InertialPosition& position_road_network,
                          const Rotation& orientation_road_network, const std::optional<std::string>& message,
                          std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box,
-                         const std::optional<TrafficSignValue>& value)
+                         const std::optional<TrafficSignValue>& value,
+                         std::unordered_map<std::string, std::string> properties)
     : id_(id),
       type_(type),
       position_road_network_(position_road_network),
@@ -82,7 +83,8 @@ TrafficSign::TrafficSign(const Id& id, const TrafficSignType& type, const Inerti
       message_(message),
       related_lanes_(std::move(related_lanes)),
       bounding_box_(bounding_box),
-      value_(value) {}
+      value_(value),
+      properties_(std::move(properties)) {}
 
 }  // namespace rules
 }  // namespace api

--- a/test/api/traffic_sign_test.cc
+++ b/test/api/traffic_sign_test.cc
@@ -185,10 +185,10 @@ GTEST_TEST(TrafficSignTest, ConstructorWithProperties) {
                                                 maliput::math::Vector3(0.05, 0.762, 0.762),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
   const std::unordered_map<std::string, std::string> kProperties{{"material", "steel"},
-                                                                  {"source_id", "xodr_signal_42"}};
+                                                                 {"source_id", "xodr_signal_42"}};
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox,
-                        std::nullopt /* value */, kProperties);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox, std::nullopt /* value */,
+                        kProperties);
 
   EXPECT_EQ(dut.properties().size(), 2u);
   EXPECT_EQ(dut.properties().at("material"), "steel");

--- a/test/api/traffic_sign_test.cc
+++ b/test/api/traffic_sign_test.cc
@@ -32,6 +32,7 @@
 
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -157,6 +158,7 @@ GTEST_TEST(TrafficSignTest, ConstructorWithValue) {
   EXPECT_TRUE(dut.GetValue().has_value());
   EXPECT_DOUBLE_EQ(dut.GetValue()->value, 100.0);
   EXPECT_EQ(dut.GetValue()->unit, TrafficSignValueUnit::kKilometersPerHour);
+  EXPECT_TRUE(dut.properties().empty());
 }
 
 GTEST_TEST(TrafficSignTest, ConstructorWithoutValue) {
@@ -171,6 +173,26 @@ GTEST_TEST(TrafficSignTest, ConstructorWithoutValue) {
   const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox);
 
   EXPECT_FALSE(dut.GetValue().has_value());
+  EXPECT_TRUE(dut.properties().empty());
+}
+
+GTEST_TEST(TrafficSignTest, ConstructorWithProperties) {
+  const TrafficSign::Id kId("stop_sign_with_properties");
+  const TrafficSignType kType = TrafficSignType::kStop;
+  const InertialPosition kPosition(1., 2., 3.);
+  const Rotation kOrientation = Rotation::FromRpy(0., 0., 0.);
+  const maliput::math::BoundingBox kBoundingBox(maliput::math::Vector3(0., 0., 0.),
+                                                maliput::math::Vector3(0.05, 0.762, 0.762),
+                                                maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
+  const std::unordered_map<std::string, std::string> kProperties{{"material", "steel"},
+                                                                  {"source_id", "xodr_signal_42"}};
+
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox,
+                        std::nullopt /* value */, kProperties);
+
+  EXPECT_EQ(dut.properties().size(), 2u);
+  EXPECT_EQ(dut.properties().at("material"), "steel");
+  EXPECT_EQ(dut.properties().at("source_id"), "xodr_signal_42");
 }
 
 GTEST_TEST(TrafficSignValueUnitTest, MapperTest) {


### PR DESCRIPTION
# 🎉 New feature

Properties vector for traffic signs the same way it's implemented for objects

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
