### PR TITLE
Add new RoadObjectTypes for GuardRails and GuardWall.

### DIFF
--- a/docs/road_object.md
+++ b/docs/road_object.md
@@ -38,6 +38,8 @@ Type-safe enumeration of common object categories:
 |------------|-------------|
 | `kUnknown` | Unknown or unclassified object |
 | `kBarrier` | Continuous roadside barrier (guard rail, wall, fence) |
+| `kGuardWall` | Continuous roadside wall (concrete barrier, sound wall) |
+| `kGuardRail` | Continuous roadside guard rail (metal beam, cable) |
 | `kBuilding` | Building or permanent structure |
 | `kGantry` | Overhead structure for mounting signals |
 | `kObstacle` | Static obstacle that cannot be passed |
@@ -45,8 +47,6 @@ Type-safe enumeration of common object categories:
 | `kTrafficIsland` | Traffic island or median |
 | `kTree` | Individual tree |
 | `kVegetation` | Vegetation area (bush, forest, hedge) |
-
-The `subtype` string provides additional classification within a type (e.g., a `kBarrier` with subtype `"guardRail"` vs `"wall"`).
 
 ### BoundingBox (`maliput::math::BoundingBox`)
 

--- a/include/maliput/api/objects/road_object.h
+++ b/include/maliput/api/objects/road_object.h
@@ -54,6 +54,8 @@ namespace objects {
 enum class RoadObjectType {
   kUnknown = 0,    ///< Unknown or unclassified object.
   kBarrier,        ///< Continuous roadside barrier (guard rail, wall, fence, etc.).
+  kGuardWall,      ///< Continuous roadside wall (concrete barrier, sound wall, etc.).
+  kGuardRail,      ///< Continuous roadside guard rail (metal beam, cable, etc.).
   kBuilding,       ///< Building or permanent structure.
   kGantry,         ///< Overhead structure for mounting signals.
   kObstacle,       ///< Static obstacle that cannot be passed.

--- a/src/maliput/api/objects/road_object.cc
+++ b/src/maliput/api/objects/road_object.cc
@@ -40,6 +40,8 @@ std::unordered_map<RoadObjectType, const char*, maliput::common::DefaultHash> Ro
   return {
       {RoadObjectType::kUnknown, "Unknown"},
       {RoadObjectType::kBarrier, "Barrier"},
+      {RoadObjectType::kGuardWall, "GuardWall"},
+      {RoadObjectType::kGuardRail, "GuardRail"},
       {RoadObjectType::kBuilding, "Building"},
       {RoadObjectType::kGantry, "Gantry"},
       {RoadObjectType::kObstacle, "Obstacle"},

--- a/test/api/road_object_test.cc
+++ b/test/api/road_object_test.cc
@@ -67,8 +67,9 @@ GTEST_TEST(RoadObjectTypeTest, InstantiateAndAssign) {
   RoadObjectType dut{};
   EXPECT_EQ(dut, RoadObjectType::kUnknown);
   for (RoadObjectType type :
-       {RoadObjectType::kBarrier, RoadObjectType::kBuilding, RoadObjectType::kGantry, RoadObjectType::kObstacle,
-        RoadObjectType::kPole, RoadObjectType::kTrafficIsland, RoadObjectType::kTree, RoadObjectType::kVegetation}) {
+       {RoadObjectType::kBarrier, RoadObjectType::kGuardWall, RoadObjectType::kGuardRail, RoadObjectType::kBuilding,
+        RoadObjectType::kGantry, RoadObjectType::kObstacle, RoadObjectType::kPole, RoadObjectType::kTrafficIsland,
+        RoadObjectType::kTree, RoadObjectType::kVegetation}) {
     dut = type;
     EXPECT_EQ(dut, type);
   }
@@ -77,9 +78,9 @@ GTEST_TEST(RoadObjectTypeTest, InstantiateAndAssign) {
 GTEST_TEST(RoadObjectTypeTest, MapperTest) {
   const auto dut = RoadObjectTypeMapper();
   const std::vector<RoadObjectType> expected_types{
-      RoadObjectType::kUnknown,       RoadObjectType::kBarrier,  RoadObjectType::kBuilding,
-      RoadObjectType::kGantry,        RoadObjectType::kObstacle, RoadObjectType::kPole,
-      RoadObjectType::kTrafficIsland, RoadObjectType::kTree,     RoadObjectType::kVegetation,
+      RoadObjectType::kUnknown,       RoadObjectType::kBarrier, RoadObjectType::kGuardWall,  RoadObjectType::kGuardRail,
+      RoadObjectType::kBuilding,      RoadObjectType::kGantry,  RoadObjectType::kObstacle,   RoadObjectType::kPole,
+      RoadObjectType::kTrafficIsland, RoadObjectType::kTree,    RoadObjectType::kVegetation,
   };
   EXPECT_EQ(dut.size(), expected_types.size());
   for (RoadObjectType type : expected_types) {


### PR DESCRIPTION
# 🎉 New feature

Closes #754 

## Summary
New `RoadObjectType`s `kGuardWall` and `kGuardRail`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
