### PR TITLE
Add TrafficSign dependent API.

### DIFF
--- a/include/maliput/api/rules/traffic_sign.h
+++ b/include/maliput/api/rules/traffic_sign.h
@@ -446,7 +446,8 @@ class TrafficSign final {
   /// @param is_movable Whether the sign's position can change.
   TrafficSign(const Id& id, const TrafficSignType& type, const InertialPosition& position_road_network,
               const Rotation& orientation_road_network, const std::optional<std::string>& message,
-              std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box,
+              std::vector<LaneId> related_lanes, std::vector<Id> dependent_signs,
+              const maliput::math::BoundingBox& bounding_box,
               const std::optional<TrafficSignValue>& value = std::nullopt,
               std::unordered_map<std::string, std::string> properties = {}, bool is_dynamic = false,
               bool is_movable = false);
@@ -476,6 +477,9 @@ class TrafficSign final {
   /// while this field captures the physical placement relationship.
   const std::vector<LaneId>& related_lanes() const { return related_lanes_; }
 
+  /// Returns the signs that depend on this sign.
+  const std::vector<Id>& dependent_signs() const { return dependent_signs_; }
+
   /// Returns the bounding box of this sign.
   const maliput::math::BoundingBox& bounding_box() const { return bounding_box_; }
 
@@ -504,6 +508,7 @@ class TrafficSign final {
   Rotation orientation_road_network_;
   std::optional<std::string> message_;
   std::vector<LaneId> related_lanes_;
+  std::vector<Id> dependent_signs_;
   maliput::math::BoundingBox bounding_box_;
   std::optional<TrafficSignValue> value_;
   std::unordered_map<std::string, std::string> properties_;

--- a/src/maliput/api/rules/traffic_sign.cc
+++ b/src/maliput/api/rules/traffic_sign.cc
@@ -369,8 +369,8 @@ std::unordered_map<TrafficSignValueUnit, const char*, maliput::common::DefaultHa
 
 TrafficSign::TrafficSign(const Id& id, const TrafficSignType& type, const InertialPosition& position_road_network,
                          const Rotation& orientation_road_network, const std::optional<std::string>& message,
-                         std::vector<LaneId> related_lanes, const maliput::math::BoundingBox& bounding_box,
-                         const std::optional<TrafficSignValue>& value,
+                         std::vector<LaneId> related_lanes, std::vector<Id> dependent_signs,
+                         const maliput::math::BoundingBox& bounding_box, const std::optional<TrafficSignValue>& value,
                          std::unordered_map<std::string, std::string> properties, bool is_dynamic, bool is_movable)
     : id_(id),
       type_(type),
@@ -378,6 +378,7 @@ TrafficSign::TrafficSign(const Id& id, const TrafficSignType& type, const Inerti
       orientation_road_network_(orientation_road_network),
       message_(message),
       related_lanes_(std::move(related_lanes)),
+      dependent_signs_(std::move(dependent_signs)),
       bounding_box_(bounding_box),
       value_(value),
       properties_(std::move(properties)),

--- a/test/api/traffic_sign_test.cc
+++ b/test/api/traffic_sign_test.cc
@@ -85,11 +85,12 @@ GTEST_TEST(TrafficSignTest, Constructor) {
   const Rotation kOrientation = Rotation::FromRpy(0., 0., 1.57);
   const std::optional<std::string> kMessage = std::nullopt;
   const std::vector<LaneId> kRelatedLanes{LaneId("lane_1"), LaneId("lane_2")};
+  const std::vector<TrafficSign::Id> kDependentSigns{TrafficSign::Id("sign_1"), TrafficSign::Id("sign_2")};
   const maliput::math::BoundingBox kBoundingBox(maliput::math::Vector3(0., 0., 0.),
                                                 maliput::math::Vector3(0.05, 0.762, 0.762),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, kMessage, kRelatedLanes, kBoundingBox);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, kMessage, kRelatedLanes, kDependentSigns, kBoundingBox);
 
   EXPECT_EQ(dut.id(), kId);
   EXPECT_EQ(dut.type(), kType);
@@ -100,6 +101,9 @@ GTEST_TEST(TrafficSignTest, Constructor) {
   EXPECT_EQ(dut.related_lanes().size(), 2u);
   EXPECT_EQ(dut.related_lanes()[0], LaneId("lane_1"));
   EXPECT_EQ(dut.related_lanes()[1], LaneId("lane_2"));
+  EXPECT_EQ(dut.dependent_signs().size(), 2u);
+  EXPECT_EQ(dut.dependent_signs()[0], TrafficSign::Id("sign_1"));
+  EXPECT_EQ(dut.dependent_signs()[1], TrafficSign::Id("sign_2"));
   EXPECT_DOUBLE_EQ(dut.bounding_box().box_size().x(), 0.05);
   EXPECT_DOUBLE_EQ(dut.bounding_box().box_size().y(), 0.762);
   EXPECT_DOUBLE_EQ(dut.bounding_box().box_size().z(), 0.762);
@@ -117,7 +121,7 @@ GTEST_TEST(TrafficSignTest, ConstructorWithMessage) {
                                                 maliput::math::Vector3(0.05, 0.762, 0.762),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, kMessage, {}, kBoundingBox);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, kMessage, {}, {}, kBoundingBox);
 
   EXPECT_EQ(dut.id(), kId);
   EXPECT_EQ(dut.type(), kType);
@@ -137,7 +141,7 @@ GTEST_TEST(TrafficSignTest, ConstructorWithCustomBoundingBox) {
                                                 maliput::math::Vector3(0.1, 1.2, 1.2),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, {}, kBoundingBox);
 
   const auto& bb = dut.bounding_box();
   EXPECT_DOUBLE_EQ(bb.box_size().x(), 0.1);
@@ -154,7 +158,8 @@ GTEST_TEST(TrafficSignTest, ConstructorWithDynamicFlag) {
                                                 maliput::math::Vector3(0.05, 0.762, 0.762),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox, std::nullopt, {}, true);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, {}, kBoundingBox, std::nullopt, {},
+                        true);
 
   EXPECT_TRUE(dut.is_dynamic());
   EXPECT_FALSE(dut.is_movable());
@@ -169,8 +174,8 @@ GTEST_TEST(TrafficSignTest, ConstructorWithMovableFlag) {
                                                 maliput::math::Vector3(0.05, 0.762, 0.762),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox, std::nullopt, {}, false,
-                        true);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, {}, kBoundingBox, std::nullopt, {},
+                        false, true);
 
   EXPECT_FALSE(dut.is_dynamic());
   EXPECT_TRUE(dut.is_movable());
@@ -186,7 +191,7 @@ GTEST_TEST(TrafficSignTest, ConstructorWithValue) {
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
   const TrafficSignValue kValue{100.0, TrafficSignValueUnit::kKilometersPerHour};
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox, kValue);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, {}, kBoundingBox, kValue);
 
   EXPECT_EQ(dut.id(), kId);
   EXPECT_EQ(dut.type(), kType);
@@ -205,7 +210,7 @@ GTEST_TEST(TrafficSignTest, ConstructorWithoutValue) {
                                                 maliput::math::Vector3(0.05, 0.762, 0.762),
                                                 maliput::math::RollPitchYaw(0., 0., 0.), 1e-3);
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, {}, kBoundingBox);
 
   EXPECT_FALSE(dut.GetValue().has_value());
   EXPECT_TRUE(dut.properties().empty());
@@ -222,8 +227,8 @@ GTEST_TEST(TrafficSignTest, ConstructorWithProperties) {
   const std::unordered_map<std::string, std::string> kProperties{{"material", "steel"},
                                                                  {"source_id", "xodr_signal_42"}};
 
-  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, kBoundingBox, std::nullopt /* value */,
-                        kProperties);
+  const TrafficSign dut(kId, kType, kPosition, kOrientation, std::nullopt, {}, {}, kBoundingBox,
+                        std::nullopt /* value */, kProperties);
 
   EXPECT_EQ(dut.properties().size(), 2u);
   EXPECT_EQ(dut.properties().at("material"), "steel");

--- a/test/base/traffic_sign_book_test.cc
+++ b/test/base/traffic_sign_book_test.cc
@@ -55,9 +55,10 @@ maliput::math::BoundingBox MakeBoundingBox() {
 GTEST_TEST(TrafficSignBookTest, BasicTest) {
   const TrafficSign::Id id("my_stop_sign");
   const std::vector<LaneId> related_lanes{LaneId("lane_1"), LaneId("lane_2")};
-  auto sign = std::make_unique<const TrafficSign>(id, TrafficSignType::kStop, api::InertialPosition(1., 2., 3.),
-                                                  api::Rotation::FromRpy(0., 0., 0.),
-                                                  std::optional<std::string>{"STOP"}, related_lanes, MakeBoundingBox());
+  const std::vector<TrafficSign::Id> dependent_signs{TrafficSign::Id("sign_1"), TrafficSign::Id("sign_2")};
+  auto sign = std::make_unique<const TrafficSign>(
+      id, TrafficSignType::kStop, api::InertialPosition(1., 2., 3.), api::Rotation::FromRpy(0., 0., 0.),
+      std::optional<std::string>{"STOP"}, related_lanes, dependent_signs, MakeBoundingBox());
   const TrafficSign* sign_ptr = sign.get();
 
   TrafficSignBook dut;
@@ -77,12 +78,12 @@ GTEST_TEST(TrafficSignBookTest, BasicTest) {
 
 GTEST_TEST(TrafficSignBookTest, DuplicateIdThrows) {
   const TrafficSign::Id id("dup_sign");
-  auto sign_a = std::make_unique<const TrafficSign>(id, TrafficSignType::kYield, api::InertialPosition(0., 0., 0.),
-                                                    api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
-                                                    std::vector<LaneId>{}, MakeBoundingBox());
-  auto sign_b = std::make_unique<const TrafficSign>(id, TrafficSignType::kYield, api::InertialPosition(1., 1., 1.),
-                                                    api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
-                                                    std::vector<LaneId>{}, MakeBoundingBox());
+  auto sign_a = std::make_unique<const TrafficSign>(
+      id, TrafficSignType::kYield, api::InertialPosition(0., 0., 0.), api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
+      std::vector<LaneId>{}, std::vector<TrafficSign::Id>{}, MakeBoundingBox());
+  auto sign_b = std::make_unique<const TrafficSign>(
+      id, TrafficSignType::kYield, api::InertialPosition(1., 1., 1.), api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
+      std::vector<LaneId>{}, std::vector<TrafficSign::Id>{}, MakeBoundingBox());
 
   TrafficSignBook dut;
   dut.AddTrafficSign(std::move(sign_a));
@@ -96,12 +97,12 @@ GTEST_TEST(TrafficSignBookTest, FindByLane) {
   const LaneId lane_2("lane_2");
   const LaneId lane_unknown("lane_unknown");
 
-  auto sign_a = std::make_unique<const TrafficSign>(id_a, TrafficSignType::kStop, api::InertialPosition(0., 0., 0.),
-                                                    api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
-                                                    std::vector<LaneId>{lane_1, lane_2}, MakeBoundingBox());
-  auto sign_b = std::make_unique<const TrafficSign>(id_b, TrafficSignType::kYield, api::InertialPosition(1., 1., 1.),
-                                                    api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
-                                                    std::vector<LaneId>{lane_2}, MakeBoundingBox());
+  auto sign_a = std::make_unique<const TrafficSign>(
+      id_a, TrafficSignType::kStop, api::InertialPosition(0., 0., 0.), api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
+      std::vector<LaneId>{lane_1, lane_2}, std::vector<TrafficSign::Id>{}, MakeBoundingBox());
+  auto sign_b = std::make_unique<const TrafficSign>(
+      id_b, TrafficSignType::kYield, api::InertialPosition(1., 1., 1.), api::Rotation::FromRpy(0., 0., 0.),
+      std::nullopt, std::vector<LaneId>{lane_2}, std::vector<TrafficSign::Id>{}, MakeBoundingBox());
 
   TrafficSignBook dut;
   dut.AddTrafficSign(std::move(sign_a));
@@ -126,15 +127,15 @@ GTEST_TEST(TrafficSignBookTest, FindByType) {
   const TrafficSign::Id id_yield("yield_sign");
   const TrafficSign::Id id_speed("speed_sign");
 
-  auto stop = std::make_unique<const TrafficSign>(id_stop, TrafficSignType::kStop, api::InertialPosition(0., 0., 0.),
-                                                  api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
-                                                  std::vector<LaneId>{}, MakeBoundingBox());
-  auto yield = std::make_unique<const TrafficSign>(id_yield, TrafficSignType::kYield, api::InertialPosition(1., 1., 1.),
-                                                   api::Rotation::FromRpy(0., 0., 0.), std::nullopt,
-                                                   std::vector<LaneId>{}, MakeBoundingBox());
+  auto stop = std::make_unique<const TrafficSign>(
+      id_stop, TrafficSignType::kStop, api::InertialPosition(0., 0., 0.), api::Rotation::FromRpy(0., 0., 0.),
+      std::nullopt, std::vector<LaneId>{}, std::vector<TrafficSign::Id>{}, MakeBoundingBox());
+  auto yield = std::make_unique<const TrafficSign>(
+      id_yield, TrafficSignType::kYield, api::InertialPosition(1., 1., 1.), api::Rotation::FromRpy(0., 0., 0.),
+      std::nullopt, std::vector<LaneId>{}, std::vector<TrafficSign::Id>{}, MakeBoundingBox());
   auto speed = std::make_unique<const TrafficSign>(
       id_speed, TrafficSignType::kSpeedLimit, api::InertialPosition(2., 2., 2.), api::Rotation::FromRpy(0., 0., 0.),
-      std::optional<std::string>{"60"}, std::vector<LaneId>{}, MakeBoundingBox());
+      std::optional<std::string>{"60"}, std::vector<LaneId>{}, std::vector<TrafficSign::Id>{}, MakeBoundingBox());
 
   TrafficSignBook dut;
   dut.AddTrafficSign(std::move(stop));


### PR DESCRIPTION
# 🎉 New feature

Closes #736 

## Summary
* New `TrafficSign::dependent_signs` API that returns all `TrafficSign::ID`s that depend on the calling `TrafficSign`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
