### PR TITLE
New API for continuous objects that are not represented by an outline.

### DIFF
--- a/include/maliput/api/objects/road_object.h
+++ b/include/maliput/api/objects/road_object.h
@@ -205,6 +205,48 @@ class RoadObjectPosition {
   std::optional<LanePosition> lane_position_;
 };
 
+/// Holds the properties of a continuous road object at a specific sample point.
+class ContinuousObject {
+ public:
+  MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContinuousObject)
+
+  /// Constructs a ContinuousObject sample.
+  ContinuousObject(double s, double lateral_offset, double z_offset, double width, double height,
+                   const InertialPosition& point_sample)
+      : s_(s),
+        lateral_offset_(lateral_offset),
+        z_offset_(z_offset),
+        width_(width),
+        height_(height),
+        point_sample_(point_sample) {}
+
+  /// Returns the s-coordinate along the lane's reference curve where this sample is taken.
+  double s() const { return s_; }
+
+  /// Returns the lateral offset (r-coordinate) from the lane's reference curve at this sample point.
+  double lateral_offset() const { return lateral_offset_; }
+
+  /// Returns the vertical offset (z-coordinate) from the lane's reference curve at this sample point.
+  double z_offset() const { return z_offset_; }
+
+  /// Returns the width of the continuous object at this sample point.
+  double width() const { return width_; }
+
+  /// Returns the height of the continuous object at this sample point.
+  double height() const { return height_; }
+
+  /// Returns the inertial position of this sample point.
+  const InertialPosition& point_sample() const { return point_sample_; }
+
+ private:
+  double s_;
+  double lateral_offset_;
+  double z_offset_;
+  double width_;
+  double height_;
+  InertialPosition point_sample_;
+};
+
 /// Models a static road object or piece of road furniture.
 ///
 /// Road objects are physical items that influence a road by expanding, delimiting, or
@@ -300,6 +342,11 @@ class RoadObject {
   ///  - "source_id" -> "opendrive_object_42"
   const std::unordered_map<std::string, std::string>& properties() const { return properties_; }
 
+  /// Returns continuous properties of the object.
+  ///
+  /// If the vector is empty, it indicates that the object does not have continuous properties.
+  const std::vector<ContinuousObject>& continuous_properties() const { return continuous_properties_; }
+
  protected:
   /// Constructs a RoadObject.
   ///
@@ -320,7 +367,7 @@ class RoadObject {
              const maliput::math::BoundingBox& bounding_box, bool is_dynamic, std::vector<LaneId> related_lanes,
              std::optional<std::string> name, std::optional<std::string> subtype,
              std::vector<std::unique_ptr<Outline>> outlines, std::unordered_map<std::string, std::string> properties,
-             bool is_movable = false);
+             std::vector<ContinuousObject> continuous_properties = {}, bool is_movable = false);
 
  private:
   Id id_;
@@ -335,6 +382,7 @@ class RoadObject {
   std::vector<LaneId> related_lanes_;
   std::vector<std::unique_ptr<Outline>> outlines_;
   std::unordered_map<std::string, std::string> properties_;
+  std::vector<ContinuousObject> continuous_properties_;
 };
 
 }  // namespace objects

--- a/include/maliput/api/objects/road_object.h
+++ b/include/maliput/api/objects/road_object.h
@@ -205,29 +205,17 @@ class RoadObjectPosition {
   std::optional<LanePosition> lane_position_;
 };
 
-/// Holds the properties of a continuous road object at a specific sample point.
+/// Holds dimensions of a continuous road object at an inertial sample point.
+///
+/// Continuous-object samples are lane-agnostic: each sample stores width and
+/// height at an explicit inertial point.
 class ContinuousObject {
  public:
   MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContinuousObject)
 
   /// Constructs a ContinuousObject sample.
-  ContinuousObject(double s, double lateral_offset, double z_offset, double width, double height,
-                   const InertialPosition& point_sample)
-      : s_(s),
-        lateral_offset_(lateral_offset),
-        z_offset_(z_offset),
-        width_(width),
-        height_(height),
-        point_sample_(point_sample) {}
-
-  /// Returns the s-coordinate along the lane's reference curve where this sample is taken.
-  double s() const { return s_; }
-
-  /// Returns the lateral offset (r-coordinate) from the lane's reference curve at this sample point.
-  double lateral_offset() const { return lateral_offset_; }
-
-  /// Returns the vertical offset (z-coordinate) from the lane's reference curve at this sample point.
-  double z_offset() const { return z_offset_; }
+  ContinuousObject(double width, double height, const InertialPosition& point_sample)
+      : width_(width), height_(height), point_sample_(point_sample) {}
 
   /// Returns the width of the continuous object at this sample point.
   double width() const { return width_; }
@@ -239,9 +227,6 @@ class ContinuousObject {
   const InertialPosition& point_sample() const { return point_sample_; }
 
  private:
-  double s_;
-  double lateral_offset_;
-  double z_offset_;
   double width_;
   double height_;
   InertialPosition point_sample_;

--- a/src/maliput/api/objects/road_object.cc
+++ b/src/maliput/api/objects/road_object.cc
@@ -86,7 +86,8 @@ RoadObject::RoadObject(const Id& id, RoadObjectType type, const RoadObjectPositi
                        const Rotation& orientation, const maliput::math::BoundingBox& bounding_box, bool is_dynamic,
                        std::vector<LaneId> related_lanes, std::optional<std::string> name,
                        std::optional<std::string> subtype, std::vector<std::unique_ptr<Outline>> outlines,
-                       std::unordered_map<std::string, std::string> properties, bool is_movable)
+                       std::unordered_map<std::string, std::string> properties,
+                       std::vector<ContinuousObject> continuous_properties, bool is_movable)
     : id_(id),
       name_(std::move(name)),
       type_(type),
@@ -98,7 +99,8 @@ RoadObject::RoadObject(const Id& id, RoadObjectType type, const RoadObjectPositi
       is_movable_(is_movable),
       related_lanes_(std::move(related_lanes)),
       outlines_(std::move(outlines)),
-      properties_(std::move(properties)) {}
+      properties_(std::move(properties)),
+      continuous_properties_(std::move(continuous_properties)) {}
 
 const Outline* RoadObject::outline(int index) const {
   MALIPUT_VALIDATE(

--- a/test/api/road_object_test.cc
+++ b/test/api/road_object_test.cc
@@ -275,11 +275,8 @@ GTEST_TEST(RoadObjectPositionTest, CopyAssignment) {
 
 GTEST_TEST(ContinuousObjectTest, ConstructionAndAccessors) {
   const InertialPosition point_sample(10., 20., 30.);
-  const ContinuousObject dut(12.5, -1.25, 0.75, 3.5, 2.1, point_sample);
+  const ContinuousObject dut(3.5, 2.1, point_sample);
 
-  EXPECT_DOUBLE_EQ(dut.s(), 12.5);
-  EXPECT_DOUBLE_EQ(dut.lateral_offset(), -1.25);
-  EXPECT_DOUBLE_EQ(dut.z_offset(), 0.75);
   EXPECT_DOUBLE_EQ(dut.width(), 3.5);
   EXPECT_DOUBLE_EQ(dut.height(), 2.1);
   EXPECT_DOUBLE_EQ(dut.point_sample().x(), 10.);
@@ -288,13 +285,10 @@ GTEST_TEST(ContinuousObjectTest, ConstructionAndAccessors) {
 }
 
 GTEST_TEST(ContinuousObjectTest, CopyAssignment) {
-  const ContinuousObject original(5., 1.5, -0.2, 0.8, 1.7, InertialPosition(1., 2., 3.));
-  ContinuousObject copy(0., 0., 0., 0., 0., InertialPosition(0., 0., 0.));
+  const ContinuousObject original(0.8, 1.7, InertialPosition(1., 2., 3.));
+  ContinuousObject copy(0., 0., InertialPosition(0., 0., 0.));
   copy = original;
 
-  EXPECT_DOUBLE_EQ(copy.s(), 5.);
-  EXPECT_DOUBLE_EQ(copy.lateral_offset(), 1.5);
-  EXPECT_DOUBLE_EQ(copy.z_offset(), -0.2);
   EXPECT_DOUBLE_EQ(copy.width(), 0.8);
   EXPECT_DOUBLE_EQ(copy.height(), 1.7);
   EXPECT_DOUBLE_EQ(copy.point_sample().x(), 1.);

--- a/test/api/road_object_test.cc
+++ b/test/api/road_object_test.cc
@@ -56,9 +56,11 @@ class TestRoadObject final : public RoadObject {
                  const maliput::math::BoundingBox& bounding_box, bool is_dynamic, std::vector<LaneId> related_lanes,
                  std::optional<std::string> name, std::optional<std::string> subtype,
                  std::vector<std::unique_ptr<Outline>> outlines,
-                 std::unordered_map<std::string, std::string> properties, bool is_movable = false)
+                 std::unordered_map<std::string, std::string> properties,
+                 std::vector<ContinuousObject> continuous_properties, bool is_movable = false)
       : RoadObject(id, type, position, orientation, bounding_box, is_dynamic, std::move(related_lanes), std::move(name),
-                   std::move(subtype), std::move(outlines), std::move(properties), is_movable) {}
+                   std::move(subtype), std::move(outlines), std::move(properties), std::move(continuous_properties),
+                   is_movable) {}
 };
 
 // -- RoadObjectType tests --
@@ -269,6 +271,37 @@ GTEST_TEST(RoadObjectPositionTest, CopyAssignment) {
   EXPECT_EQ(copy.lane_id()->string(), "lane_1");
 }
 
+// -- ContinuousObject tests --
+
+GTEST_TEST(ContinuousObjectTest, ConstructionAndAccessors) {
+  const InertialPosition point_sample(10., 20., 30.);
+  const ContinuousObject dut(12.5, -1.25, 0.75, 3.5, 2.1, point_sample);
+
+  EXPECT_DOUBLE_EQ(dut.s(), 12.5);
+  EXPECT_DOUBLE_EQ(dut.lateral_offset(), -1.25);
+  EXPECT_DOUBLE_EQ(dut.z_offset(), 0.75);
+  EXPECT_DOUBLE_EQ(dut.width(), 3.5);
+  EXPECT_DOUBLE_EQ(dut.height(), 2.1);
+  EXPECT_DOUBLE_EQ(dut.point_sample().x(), 10.);
+  EXPECT_DOUBLE_EQ(dut.point_sample().y(), 20.);
+  EXPECT_DOUBLE_EQ(dut.point_sample().z(), 30.);
+}
+
+GTEST_TEST(ContinuousObjectTest, CopyAssignment) {
+  const ContinuousObject original(5., 1.5, -0.2, 0.8, 1.7, InertialPosition(1., 2., 3.));
+  ContinuousObject copy(0., 0., 0., 0., 0., InertialPosition(0., 0., 0.));
+  copy = original;
+
+  EXPECT_DOUBLE_EQ(copy.s(), 5.);
+  EXPECT_DOUBLE_EQ(copy.lateral_offset(), 1.5);
+  EXPECT_DOUBLE_EQ(copy.z_offset(), -0.2);
+  EXPECT_DOUBLE_EQ(copy.width(), 0.8);
+  EXPECT_DOUBLE_EQ(copy.height(), 1.7);
+  EXPECT_DOUBLE_EQ(copy.point_sample().x(), 1.);
+  EXPECT_DOUBLE_EQ(copy.point_sample().y(), 2.);
+  EXPECT_DOUBLE_EQ(copy.point_sample().z(), 3.);
+}
+
 // -- RoadObject tests --
 
 class RoadObjectTest : public ::testing::Test {
@@ -293,10 +326,11 @@ class RoadObjectTest : public ::testing::Test {
     outlines.push_back(std::make_unique<Outline>(Outline::Id("outline_a"), std::move(corners), true));
 
     std::unordered_map<std::string, std::string> properties{{"material", "steel"}, {"source_id", "obj_42"}};
+    std::vector<ContinuousObject> continuous_properties;
 
-    dut_ = std::unique_ptr<TestRoadObject>(
-        new TestRoadObject(id, type, position, orientation, bounding_box, is_dynamic, std::move(related_lanes),
-                           std::move(name), std::move(subtype), std::move(outlines), std::move(properties)));
+    dut_ = std::unique_ptr<TestRoadObject>(new TestRoadObject(
+        id, type, position, orientation, bounding_box, is_dynamic, std::move(related_lanes), std::move(name),
+        std::move(subtype), std::move(outlines), std::move(properties), std::move(continuous_properties)));
   }
 
   std::unique_ptr<TestRoadObject> dut_;
@@ -375,7 +409,8 @@ GTEST_TEST(RoadObjectMinimalTest, NoOptionalFields) {
                                                 math::RollPitchYaw(0., 0., 0.), 0.01);
 
   TestRoadObject dut(id, RoadObjectType::kUnknown, position, orientation, bounding_box, false, {} /* related_lanes */,
-                     std::nullopt /* name */, std::nullopt /* subtype */, {} /* outlines */, {} /* properties */);
+                     std::nullopt /* name */, std::nullopt /* subtype */, {} /* outlines */, {} /* properties */,
+                     {} /* continuous_properties */);
 
   EXPECT_EQ(dut.id().string(), "minimal_obj");
   EXPECT_FALSE(dut.name().has_value());
@@ -398,7 +433,7 @@ GTEST_TEST(RoadObjectDynamicTest, IsDynamic) {
 
   TestRoadObject dut(id, RoadObjectType::kObstacle, position, orientation, bounding_box, true /* is_dynamic */,
                      {} /* related_lanes */, "Gate" /* name */, std::nullopt /* subtype */, {} /* outlines */,
-                     {} /* properties */);
+                     {} /* properties */, {} /* continuous_properties */);
 
   EXPECT_TRUE(dut.is_dynamic());
   EXPECT_FALSE(dut.is_movable());
@@ -415,7 +450,7 @@ GTEST_TEST(RoadObjectMovableTest, IsMovable) {
 
   TestRoadObject dut(id, RoadObjectType::kObstacle, position, orientation, bounding_box, false /* is_dynamic */,
                      {} /* related_lanes */, "Movable Gate" /* name */, std::nullopt /* subtype */, {} /* outlines */,
-                     {} /* properties */, true /* is_movable */);
+                     {} /* properties */, {} /* continuous_properties */, true /* is_movable */);
 
   EXPECT_FALSE(dut.is_dynamic());
   EXPECT_TRUE(dut.is_movable());

--- a/test/base/road_object_book_test.cc
+++ b/test/base/road_object_book_test.cc
@@ -63,9 +63,11 @@ class TestRoadObject final : public RoadObject {
                  const math::BoundingBox& bounding_box, bool is_dynamic, std::vector<LaneId> related_lanes,
                  std::optional<std::string> name, std::optional<std::string> subtype,
                  std::vector<std::unique_ptr<Outline>> outlines,
-                 std::unordered_map<std::string, std::string> properties)
+                 std::unordered_map<std::string, std::string> properties,
+                 std::vector<api::objects::ContinuousObject> continuous_properties = {}, bool is_movable = false)
       : RoadObject(id, type, position, orientation, bounding_box, is_dynamic, std::move(related_lanes), std::move(name),
-                   std::move(subtype), std::move(outlines), std::move(properties)) {}
+                   std::move(subtype), std::move(outlines), std::move(properties), std::move(continuous_properties),
+                   is_movable) {}
 };
 
 // Helper to create a RoadObject with a given ID, type, position, and related lanes.
@@ -77,7 +79,7 @@ std::unique_ptr<TestRoadObject> MakeRoadObject(const std::string& id, RoadObject
                                        math::RollPitchYaw(0., 0., 0.), 0.01);
   return std::unique_ptr<TestRoadObject>(new TestRoadObject(RoadObject::Id(id), type, position, orientation,
                                                             bounding_box, false, std::move(related_lanes), std::nullopt,
-                                                            std::nullopt, {}, {}));
+                                                            std::nullopt, {}, {}, {}));
 }
 
 // -- Empty book tests --


### PR DESCRIPTION
# 🎉 New feature

## Summary
* `RoadObjects` may be described with a vector of `ContinuousObject` elements. These elements have a dimensional description of the object on a sampling basis, where the sample point is an `InertialPosition` that is also accessible from this new API.
* New API for `ContinuousObject`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
